### PR TITLE
fix: 事業ビューで府省庁ノードクリック時に府省庁ビューへ遷移しない問題を修正

### DIFF
--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -193,8 +193,8 @@ function SankeyContent() {
       return;
     }
 
-    // Handle "Total Budget" (予算総計)
-    if (actualNode.id === 'total-budget') {
+    // Handle "Total Budget" (予算総計) - but NOT in Project View where it represents a ministry
+    if (actualNode.id === 'total-budget' && viewMode !== 'project') {
       if (viewMode === 'global') {
         // 全体ビュー: 事業一覧を開く（府省庁:すべて、支出先まとめ:維持）
         setProjectListFilters({
@@ -214,10 +214,12 @@ function SankeyContent() {
     }
 
     // Handle Ministry nodes
-    if (actualNode.type === 'ministry-budget' &&
-      actualNode.id !== 'total-budget' &&
-      actualNode.id !== 'ministry-budget-other') {
+    // In Project View, the 'total-budget' node displays the ministry name and should be clickable
+    const isMinistryNode = actualNode.type === 'ministry-budget' &&
+      actualNode.id !== 'ministry-budget-other' &&
+      (actualNode.id !== 'total-budget' || viewMode === 'project');
 
+    if (isMinistryNode) {
       if (viewMode === 'ministry') {
         // 府省庁ビュー: 事業一覧を開く（府省庁:選択中、支出先まとめ:維持）
         setProjectListFilters({


### PR DESCRIPTION
## 概要
事業ビューで府省庁ノード（Column 0）をクリックしても府省庁ビューへ遷移しない問題を修正しました。

## 問題の詳細
事業ビューでは、サンキー図の Column 0 に府省庁名が表示されますが、このノードをクリックしても何も起きず、府省庁ビューへ戻ることができませんでした。

### 再現手順
1. 全体ビューから任意の府省庁をクリック → 府省庁ビューへ遷移
2. 府省庁ビューから任意の事業をクリック → 事業ビューへ遷移
3. 事業ビューの Column 0 に表示される府省庁ノードをクリック
4. **期待**: 府省庁ビューへ戻る
5. **実際**: 何も起きない（修正前）

## 原因
`app/sankey/page.tsx` の `handleNodeClick` 関数において、以下の問題がありました：

1. 事業ビューでは Column 0 のノード ID が `'total-budget'` で府省庁名を表示
2. しかし、`total-budget` ノードの処理（line 197）が先に実行され、`return` されてしまう
3. その結果、府省庁ノードとしての処理（line 222-249）に到達しない

## 修正内容

### 変更ファイル
- `app/sankey/page.tsx`

### 修正箇所
**Before:**
```typescript
if (actualNode.id === 'total-budget') {
  // 全体ビュー、府省庁ビューの処理
  return;
}
```

**After:**
```typescript
if (actualNode.id === 'total-budget' && viewMode !== 'project') {
  // 全体ビュー、府省庁ビューの処理のみ
  return;
}
```

事業ビュー（`viewMode === 'project'`）の場合は、この処理をスキップして次の府省庁ノード処理へ進むようにしました。

## テスト方法
1. 開発サーバーを起動: `npm run dev`
2. http://localhost:3000/sankey にアクセス
3. 府省庁 → 事業の順にクリックして事業ビューへ移動
4. Column 0 の府省庁ノードをクリック
5. 府省庁ビューへ正しく遷移することを確認
6. URL が `/sankey?ministry=府省庁名` になることを確認

## 影響範囲
- ✅ 事業ビューのナビゲーション動作のみ
- ✅ 全体ビュー、府省庁ビュー、支出ビューには影響なし
- ✅ データ生成ロジックには変更なし

## 関連Issue
Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Total Budget node click behavior to respond appropriately based on the current view mode.
  * Improved click handling and detection for budget-related navigation elements to provide more consistent interaction across different contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->