### PR TITLE
docs: /docsディレクトリのファイル命名規則を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ npm run compress-data            # Gzip structured JSON for Git (5.9MB)
 - **Core Logic**: [app/lib/sankey-generator.ts](app/lib/sankey-generator.ts) - Sankey generation algorithm (936 lines)
 - **Data Scripts**: [scripts/](scripts/) - CSV normalization and JSON generation pipeline
 
+### Documentation Standards
+- **Naming Convention**: `/docs` directory uses `YYYYMMDD_HHMM_タイトル.md` format
+  - Example: `20251130_2220_支出ビュー仕様.md`
+  - Ensures chronological ordering and easy identification
+
 ---
 
 # RS2024 Sankey Diagram System - Architecture & Technical Overview


### PR DESCRIPTION
## 概要
CLAUDE.mdに/docsディレクトリのファイル命名規則を明記

## 変更内容
- Documentation Standardsセクションを追加
- `YYYYMMDD_HHMM_タイトル.md` 形式を標準化
- 例を記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)