### PR TITLE
docs: 府省庁ビュー支出先表示問題の調査報告を追加

### DIFF
--- a/docs/20251201_1941_事業ビュー支出先表示問題調査.md
+++ b/docs/20251201_1941_事業ビュー支出先表示問題調査.md
@@ -1,0 +1,218 @@
+# 府省庁ビュー 支出先表示問題 調査報告
+
+## 1. 問題の概要
+
+**報告内容**:
+- 府省庁ビュー（内閣府）で、「新型コロナウイルス感染症対応地方創生臨時交付金」という事業ノードが表示されないため、総務省への1.82兆円のリンクが可視化されない
+- 総務省は支出先Top1として表示されるが、リンク元が「事業(TopN以外)」という集約ノードになっている
+
+**問題の本質**:
+- **事業TopN選択**: 予算額順で選択 → 「新型コロナ...」は予算額が低いためTopNに選ばれない
+- **支出先TopN選択**: 全事業からの支出額順で選択 → 総務省は支出額Top1で選ばれる
+- **結果**: 支出額が大きい事業が事業TopNに含まれず、「事業(TopN以外)」から大きな金額が流れることになり、情報の可視性が低下する
+
+## 2. 調査結果
+
+### 2.1 府省庁ビュー（内閣府）の支出先選択
+
+**ログ出力** (app/lib/sankey-generator.ts:539-548):
+```
+[Ministry View - Spending Selection Debug]
+  targetMinistry: 内閣府
+  spendingLimit: 10
+  Total unique spendings from ministry: 1898
+  Top 20 spendings:
+    1. 総務省 (ID: 570): 2,835,373,941,309円  ← 2.83兆円で1位
+    2. 東京都 (ID: 576): 249,934,742,322円
+    3. 大阪府 (ID: 573): 230,721,948,824円
+    ...
+```
+
+**結果**: ✅ 府省庁ビューでは総務省が正しく選択されている（内閣府全体からの支出額でTopN選択）
+
+---
+
+### 2.2 府省庁ビュー（内閣府）の事業TopN選択
+
+**事業選択の基準**: 予算額順（`totalBudget` でソート）
+
+**問題**:
+- 「新型コロナウイルス感染症対応地方創生臨時交付金」は支出額1.82兆円で非常に大きいが、予算額が低いため事業TopNに選ばれない
+- そのため、事業ノードとして表示されず、「事業(TopN以外)」という集約ノードにまとめられる
+
+**結果**: ❌ 支出額Top1の支出先（総務省）へのリンク元が不明瞭になる
+
+---
+
+## 3. 問題の構造
+
+### 3.1 現在の府省庁ビュー仕様
+
+**事業TopN選択ロジック** ([app/lib/sankey-generator.ts:522-525](app/lib/sankey-generator.ts#L522-L525)):
+```typescript
+// Ministry View: Select top projects for the single ministry
+const sortedProjects = ministryProjects.sort(
+  (a, b) => b.totalBudget - a.totalBudget  // ← 予算額順
+);
+const topProjects = sortedProjects.slice(projectOffset, projectOffset + projectLimit);
+```
+
+**支出先TopN選択ロジック** ([app/lib/sankey-generator.ts:530-548](app/lib/sankey-generator.ts#L530-L548)):
+```typescript
+// Ministry View: Select top spendings for the single ministry
+const spendingAmounts = new Map<number, number>();
+for (const project of ministryProjects) {  // ← 府省庁の全事業を対象
+  for (const spendingId of project.spendingIds) {
+    const spending = data.spendings.find(s => s.spendingId === spendingId);
+    if (spending && spending.spendingName !== 'その他') {
+      const projectSpending = spending.projects.find(p => p.projectId === project.projectId);
+      if (projectSpending) {
+        const currentAmount = spendingAmounts.get(spendingId) || 0;
+        spendingAmounts.set(spendingId, currentAmount + projectSpending.amount);
+      }
+    }
+  }
+}
+// 支出額でソート
+const sortedSpendings = Array.from(spendingAmounts.entries())
+  .sort((a, b) => b[1] - a[1]);  // ← 支出額順
+```
+
+### 3.2 問題の発生メカニズム
+
+**内閣府の例**:
+
+| 事業名 | 予算額 | 総務省への支出額 | 事業TopN選択 | 支出先TopN寄与 |
+|--------|--------|-----------------|-------------|---------------|
+| 新型コロナウイルス... | **低い** | **1.82兆円** | ❌ 選ばれない | ✅ Top1の要因 |
+| その他の事業A | 高い | 0.3兆円 | ✅ 選ばれる | 一部寄与 |
+| その他の事業B | 高い | 0.2兆円 | ✅ 選ばれる | 一部寄与 |
+| ... | ... | ... | ... | ... |
+
+**結果**:
+1. 総務省は支出先Top1として選択される（全事業から2.83兆円）
+2. しかし、最大の寄与事業（新型コロナ... 1.82兆円）は事業TopNに含まれない
+3. 総務省へのリンクは「事業(TopN以外)」から引かれる
+4. **可視性の問題**: どの事業から大きな金額が流れているか分からない
+
+### 3.3 データ整合性の確認
+
+**府省庁ビュー（内閣府 → 総務省）**: 2,835,373,941,309円（2.83兆円）
+**内訳**:
+- 新型コロナウイルス... → 総務省: 1,822,367,180,746円（1.82兆円）← **64%を占める**
+- その他の事業 → 総務省: 1,013,006,760,563円（1.01兆円）← 残り36%
+
+→ **データ自体は正しく処理されている。問題は可視化の仕様にある。**
+
+---
+
+## 4. 解決策
+
+### 案1: 支出先TopNへの寄与度順で事業を選択（推奨）
+
+**目的**: 支出先TopNへのリンク元を明確化する
+
+**実装方針**:
+
+府省庁ビューの事業選択を、予算額順ではなく**支出先TopNへの寄与度順**に変更する。
+
+**アルゴリズム**:
+1. まず支出先TopNを選択（現状通り：全事業からの支出額順）
+2. 各事業について「支出先TopNへの総支出額」をスコアとして計算
+3. スコアでソートして事業TopNを選択
+
+**コード修正案** ([app/lib/sankey-generator.ts:522-525](app/lib/sankey-generator.ts#L522-L525)):
+```typescript
+// Ministry View: Select top projects by contribution to top spendings
+
+// Step 1: 支出先TopNを先に選択（既存のロジック）
+const topSpendingIds = new Set(
+  Array.from(spendingAmounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, spendingLimit)
+    .map(([id]) => id)
+);
+
+// Step 2: 各事業の支出先TopNへの寄与度を計算
+const projectScores = ministryProjects.map(project => {
+  let contributionToTopSpendings = 0;
+
+  for (const spendingId of project.spendingIds) {
+    if (topSpendingIds.has(spendingId)) {
+      const spending = data.spendings.find(s => s.spendingId === spendingId);
+      if (spending) {
+        const projectSpending = spending.projects.find(p => p.projectId === project.projectId);
+        if (projectSpending) {
+          contributionToTopSpendings += projectSpending.amount;
+        }
+      }
+    }
+  }
+
+  return {
+    project,
+    score: contributionToTopSpendings
+  };
+});
+
+// Step 3: スコア順でソートして事業TopNを選択
+const sortedProjects = projectScores.sort((a, b) => b.score - a.score);
+const topProjects = sortedProjects
+  .slice(projectOffset, projectOffset + projectLimit)
+  .map(item => item.project);
+```
+
+**メリット**:
+- 支出先TopNへの主要な寄与事業が必ず表示される
+- 「新型コロナ...」のような支出額が大きい事業が可視化される
+- 「事業(TopN以外)」ノードの金額が相対的に小さくなる
+
+**デメリット**:
+- 予算額が大きくても支出先TopNに寄与しない事業は選ばれなくなる
+- 事業選択の基準が「予算額」から「支出影響度」に変わる
+
+**影響範囲**:
+- 府省庁ビューのみ（全体ビューと事業ビューは影響なし）
+
+---
+
+### 案2: 事業選択基準をユーザーが選択可能にする
+
+**実装**:
+- UIに選択肢を追加: 「予算額順」 vs 「支出影響度順」
+- デフォルトは「支出影響度順」
+
+**メリット**:
+- ユーザーが用途に応じて切り替えられる
+
+**デメリット**:
+- UIが複雑になる
+- 開発コストが高い
+
+---
+
+### 案3: 現状維持（仕様として受け入れる）
+
+**判断基準**:
+- 「事業TopNと支出先TopNを両立するためには今の仕様でしょうがない部分もある」
+- 事業ビューを使えば個別事業の支出先は確認できる
+
+**デメリット**:
+- 府省庁ビューで支出先の主要な寄与事業が分からない
+
+---
+
+## 5. 推奨アクション
+
+1. **案1の実装を推奨**:
+   - 情報の可視性が大幅に向上
+   - コード修正は局所的（府省庁ビューの事業選択ロジックのみ）
+   - ユーザー体験の改善効果が大きい
+
+2. **検証手順**:
+   - 案1を実装
+   - 内閣府ビューで確認（新型コロナ...事業が表示されるか）
+   - 他の府省庁でも意図通り動作するか確認
+
+3. **将来的には案2も検討**:
+   - ユーザーフィードバックを得てから判断


### PR DESCRIPTION
## 概要
府省庁ビューにおいて、支出先TopNへの主要な寄与事業が事業TopNに含まれない問題の調査報告書を追加しました。

## 追加ファイル
- `docs/20251201_1941_事業ビュー支出先表示問題調査.md`

## 内容
1. **問題の概要と本質**
   - 予算額順の事業選択により、支出額が大きい事業が選ばれない問題

2. **調査結果**
   - 支出先選択ロジックの確認
   - 事業選択ロジックの確認

3. **問題の構造**
   - 現在の仕様（コード箇所へのリンク付き）
   - 問題の発生メカニズム（内閣府の具体例を表で示す）
   - データ整合性の確認

4. **解決策3案**
   - 案1: 支出先TopNへの寄与度順で事業を選択（推奨・実装済み）
   - 案2: 事業選択基準をユーザーが選択可能にする
   - 案3: 現状維持

5. **推奨アクション**
   - 案1の実装を推奨（PR #16で実装済み）

## 関連PR
- #16: 案1を実装済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added investigation documentation addressing Ministry-view spending destination visibility, including analysis of current data flows and recommended improvement approaches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->