### PR TITLE
fix: 事業(予算)→事業(支出)リンクの色をグレー系に変更

### DIFF
--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -693,6 +693,22 @@ function SankeyContent() {
                 linkHoverOthersOpacity={0.1}
                 linkContract={3}
                 enableLinkGradient={false}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                linkColor={(link: any) => {
+                  // link.source と link.target はオブジェクト形式
+                  const sourceNode = sankey.nodes.find(n => n.id === link.source.id);
+                  const targetNode = sankey.nodes.find(n => n.id === link.target.id);
+
+                  // 事業(予算) → 事業(支出) のリンクはグレー
+                  if (sourceNode?.type === 'project-budget' && targetNode?.type === 'project-spending') {
+                    return '#9ca3af'; // グレー系
+                  }
+
+                  // その他のリンクはソースノードの色を取得して返す
+                  // IMPORTANT: 'source' という文字列ではなく、実際の色コードを返す
+                  const sourceColor = link.source.color || '#10b981';
+                  return sourceColor;
+                }}
                 labelPosition="outside"
                 labelOrientation="horizontal"
                 labelPadding={16}


### PR DESCRIPTION
## 概要
事業(予算)→事業(支出)リンクの色をグレー系(#9ca3af)に変更しました。

## 問題
前回のPR #19 では、`linkColor`関数で`return 'source'`としていたため、Nivoが「ソースノードの色を使う」と解釈し、グレーが反映されませんでした。

## 解決策
`linkColor`関数で**実際の色コード**を返すように修正：

```typescript
linkColor={(link: any) => {
  const sourceNode = sankey.nodes.find(n => n.id === link.source.id);
  const targetNode = sankey.nodes.find(n => n.id === link.target.id);

  // 事業(予算) → 事業(支出) のリンクはグレー
  if (sourceNode?.type === 'project-budget' && targetNode?.type === 'project-spending') {
    return '#9ca3af'; // グレー系
  }

  // その他のリンクはソースノードの色を取得して返す
  // IMPORTANT: 'source' という文字列ではなく、実際の色コードを返す
  const sourceColor = link.source.color || '#10b981';
  return sourceColor;
}}
```

## 変更内容
- `return 'source'` → `return link.source.color || '#10b981'` に変更
- これにより、Nivoが文字列ではなく実際の色コードを認識

## テスト
- [x] 事業(予算)→事業(支出)のリンクがグレーで表示される
- [x] その他のリンクは従来通りソースノードの色で表示される

## 関連Issue
- Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Sankey chart link coloring—budget-to-spending connections now display in gray, while other links inherit source node colors for improved visual distinction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->