### PR TITLE
fix: 支出一覧で同一法人の複数ブロック再委託額が重複表示される問題を修正

### DIFF
--- a/client/components/SpendingListModal.tsx
+++ b/client/components/SpendingListModal.tsx
@@ -219,8 +219,10 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
         if (projectSpendings.length === 0) return;
 
         for (const projectSpending of projectSpendings) {
+          // ブロック番号（sourceBlockNumber）で絞り込み、このブロック分の再委託額のみを計算する
+          // （projectId のみで絞ると同一会社の複数ブロック全体の合計が全行に重複するため）
           const outflowAmount = spending.outflows
-            ?.filter(f => f.projectId === project.projectId)
+            ?.filter(f => f.projectId === project.projectId && f.sourceBlockNumber === projectSpending.blockNumber)
             .reduce((sum, f) => sum + f.amount, 0) ?? 0;
 
           result.push({


### PR DESCRIPTION
## 目的

支出先一覧を確認するユーザーが、同一法人の複数ブロック登録がある事業で
誤った（N倍に膨張した）再委託額を見てしまう問題を解消するため。

## 根本原因

`SpendingListModal` の ungrouped 表示で、`outflows` を `projectId` のみでフィルタしていた。
同一会社が同一事業の複数ブロックに登録されている場合、全ブロックの再委託合計額が
各ブロック行に重複して表示されていた。

```
例: 地域一体となった観光地・観光産業の再生・高付加価値化事業（博報堂）
5-2 CSV 構造:
  国土交通省 → Block A（博報堂 663億）→ Block B（補助金）+ Block C（再委託）
  国土交通省 → Block E（博報堂 113億）→ Block F（補助金）+ Block G（再委託）
```

## 変更内容

`SpendingListModal.tsx` の outflow フィルタに `f.sourceBlockNumber === projectSpending.blockNumber` を追加。
各ブロック行に対応するブロック発の再委託額のみを表示するよう修正。

| | 修正前 | 修正後 |
|---|---|---|
| Block A（663億） | 760億※（A+E合計が重複） | ~648億（Block B+C分） |
| Block E（113億） | 760億※（A+E合計が重複） | ~112億（Block F+G分） |

grouped 表示では各行の再委託額を合算するため、合計 760億も正しく算出される。

## テスト方法

```bash
npm run dev  # localhost:3002/sankey
```

1. 支出先一覧を開く
2. 「地域一体となった観光地・観光産業の再生・高付加価値化事業」で絞り込む
3. 「事業名でまとめない」表示に切り替え → 博報堂の2行（Block A / Block E）の再委託額が異なる値になることを確認

## 関連

- Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where outflow amounts were being duplicated when displayed across multiple spending blocks. The system now correctly aggregates spending data to show accurate, non-duplicated outflow information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->