### PR TITLE
fix: ダイアログのUX改善（テキスト選択後の誤クリック防止・外側クリックで閉じる）

### DIFF
--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -1388,8 +1388,8 @@ function SankeyContent() {
 
       {/* 設定ダイアログ */}
       {dialogStates.settings && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto relative">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setDialogStates(prev => ({ ...prev, settings: false }))}>
+          <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto relative" onClick={e => e.stopPropagation()}>
             <button
               onClick={() => setDialogStates(prev => ({ ...prev, settings: false }))}
               className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-2xl leading-none"

--- a/client/components/ProjectListModal.tsx
+++ b/client/components/ProjectListModal.tsx
@@ -384,6 +384,7 @@ export default function ProjectListModal({ isOpen, onClose, onSelectProject, onS
 
   // セルクリックハンドラー
   const handleMinistryClick = (ministryName: string) => {
+    if (window.getSelection()?.toString()) return;
     if (onSelectMinistry) {
       onSelectMinistry(ministryName);
       onClose();
@@ -391,11 +392,13 @@ export default function ProjectListModal({ isOpen, onClose, onSelectProject, onS
   };
 
   const handleProjectClick = (projectName: string) => {
+    if (window.getSelection()?.toString()) return;
     onSelectProject(projectName);
     onClose();
   };
 
   const handleRecipientClick = (recipientName: string) => {
+    if (window.getSelection()?.toString()) return;
     if (onSelectRecipient) {
       onSelectRecipient(recipientName);
       onClose();
@@ -405,8 +408,8 @@ export default function ProjectListModal({ isOpen, onClose, onSelectProject, onS
   // if (!isOpen) return null; // Stateを維持するためにアンマウントしない
 
   return (
-    <div className={`fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200 ${isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}>
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] h-[90vh] flex flex-col">
+    <div className={`fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200 ${isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`} onClick={onClose}>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
         {/* ヘッダー */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex justify-between items-start mb-2">

--- a/client/components/SpendingListModal.tsx
+++ b/client/components/SpendingListModal.tsx
@@ -456,6 +456,7 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
   };
 
   const handleMinistryClick = (item: SpendingDetail) => {
+    if (window.getSelection()?.toString()) return;
     if (groupBySpending && item.ministryBreakdown && item.ministryBreakdown.length > 1) {
       // 複数府省庁がある場合はモーダルを表示
       setMinistryBreakdownModal({
@@ -472,6 +473,7 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
   };
 
   const handleMinistryBreakdownSelect = (ministry: string) => {
+    if (window.getSelection()?.toString()) return;
     setMinistryBreakdownModal({ isOpen: false, spendingName: '', ministries: [] });
     if (onSelectMinistry) {
       onSelectMinistry(ministry);
@@ -480,8 +482,8 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
   };
 
   return (
-    <div className={`fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200 ${isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}>
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] h-[90vh] flex flex-col">
+    <div className={`fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200 ${isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`} onClick={onClose}>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
         {/* ヘッダー */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex justify-between items-start mb-2">
@@ -808,6 +810,7 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
                     <td
                       className="px-4 py-2 text-gray-900 dark:text-white cursor-pointer hover:underline"
                       onClick={() => {
+                        if (window.getSelection()?.toString()) return;
                         onSelectRecipient(item.spendingName);
                         onClose();
                       }}
@@ -822,6 +825,7 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
                     <td
                       className={`px-4 py-2 text-gray-900 dark:text-white ${!groupBySpending && item.projectName ? 'cursor-pointer hover:underline' : ''}`}
                       onClick={() => {
+                        if (window.getSelection()?.toString()) return;
                         if (!groupBySpending && item.projectName && onSelectProject) {
                           onSelectProject(item.projectName);
                           onClose();
@@ -935,8 +939,8 @@ export default function SpendingListModal({ isOpen, onClose, onSelectRecipient, 
 
       {/* 府省庁別内訳モーダル */}
       {ministryBreakdownModal.isOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60]">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[600px] max-h-[80vh] flex flex-col">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60]" onClick={() => setMinistryBreakdownModal({ isOpen: false, spendingName: '', ministries: [] })}>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[600px] max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
             {/* ヘッダー */}
             <div className="p-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex justify-between items-start mb-2">

--- a/client/components/SubcontractDetailDialog.tsx
+++ b/client/components/SubcontractDetailDialog.tsx
@@ -25,8 +25,8 @@ export default function SubcontractDetailDialog({ isOpen, onClose, detail, forma
   if (!isOpen || !detail) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] max-w-4xl max-h-[80vh] overflow-y-auto p-6 relative">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200" onClick={onClose}>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] max-w-4xl max-h-[80vh] overflow-y-auto p-6 relative" onClick={e => e.stopPropagation()}>
         <button
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-2xl leading-none"

--- a/client/components/SummaryDialog.tsx
+++ b/client/components/SummaryDialog.tsx
@@ -13,8 +13,8 @@ export default function SummaryDialog({ isOpen, onClose, metadata, formatCurrenc
     if (!isOpen) return null;
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200">
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] max-w-lg p-6 relative">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity duration-200" onClick={onClose}>
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-[90vw] max-w-lg p-6 relative" onClick={e => e.stopPropagation()}>
                 <button
                     onClick={onClose}
                     className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-2xl leading-none"


### PR DESCRIPTION
## 目的

一覧表の文字列を選択・コピーする操作をしたユーザーが、意図せずページ遷移してしまう問題と、ダイアログを素早く閉じられない問題を解消するため。

## 変更内容

### 1. テキスト選択後の誤クリック防止

テキストを選択してコピー後、マウスボタンを離す際に `click` イベントが発火し、ページ遷移が起きていた。全クリックハンドラに `window.getSelection()?.toString()` チェックを追加し、文字列選択中はナビゲーションを抑止する。

| ファイル | 対象セル |
|---|---|
| `ProjectListModal.tsx` | 府省庁・事業名・支出先 |
| `SpendingListModal.tsx` | 支出先・事業名・府省庁 |

### 2. ダイアログ外側クリックで閉じる

全ダイアログのオーバーレイ div に `onClick={onClose}` を追加し、内側ダイアログ div に `stopPropagation` を追加。

| ダイアログ | ファイル |
|---|---|
| 事業一覧 | `ProjectListModal.tsx` |
| 支出先一覧（府省庁内訳サブモーダルも対応） | `SpendingListModal.tsx` |
| 再委託先詳細 | `SubcontractDetailDialog.tsx` |
| 概要 | `SummaryDialog.tsx` |
| TopN表示設定 | `page.tsx` |

## テスト方法

```bash
npm run dev  # localhost:3002/sankey
```

1. 事業一覧・支出先一覧を開き、セルのテキストを選択してコピー → ページ遷移しないことを確認
2. 各ダイアログでオーバーレイ（暗い部分）をクリック → ダイアログが閉じることを確認
3. ダイアログ内部をクリック → 閉じないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Modals and dialogs now support closing by clicking the backdrop area outside the content.
* Interactions inside modal content no longer accidentally trigger closes.
* Text selection guards prevent unintended navigation or actions when users are selecting text in interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->