### PR TITLE
feat: チームみらい政治資金ダッシュボード（/mirai, /mirai/party-fee）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ next-env.d.ts
 !/public/data/houjin-lookup.json
 # Allow entity normalization dict (curated mapping, needed to regenerate structured JSON)
 !/public/data/entity-normalization.json
+# Allow mirai political funds summary (generated from public data)
+!/public/data/mirai-summary.json
 
 # raw CSV data (939MB) and build artifacts (houjin.db etc.)
 /data/

--- a/app/mirai/page.tsx
+++ b/app/mirai/page.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ResponsiveBar } from '@nivo/bar';
+import type { MiraiSummaryData } from '@/types/mirai';
+
+const INCOME_COLOR = '#3b82f6';
+const EXPENSE_COLOR = '#ef4444';
+
+function formatYen(n: number): string {
+  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(2)}億円`;
+  if (n >= 10_000) return `${(n / 10_000).toFixed(0)}万円`;
+  return `${n.toLocaleString()}円`;
+}
+
+function SummaryCard({ label, amount, count, color }: {
+  label: string; amount: number; count: number; color: string;
+}) {
+  return (
+    <div style={{
+      background: '#fff', border: `2px solid ${color}`, borderRadius: 12,
+      padding: '20px 28px', minWidth: 200, flex: 1,
+    }}>
+      <div style={{ fontSize: 13, color: '#666', marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 26, fontWeight: 700, color }}>{formatYen(amount)}</div>
+      <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>{count.toLocaleString()}件</div>
+    </div>
+  );
+}
+
+function HBar({ label, value, max, color, sub }: {
+  label: string; value: number; max: number; color: string; sub?: string;
+}) {
+  const pct = max > 0 ? (value / max) * 100 : 0;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 3 }}>
+        <span>{label}</span>
+        <span style={{ color: '#555' }}>{formatYen(value)}{sub ? `（${sub}）` : ''}</span>
+      </div>
+      <div style={{ background: '#e5e7eb', borderRadius: 4, height: 10 }}>
+        <div style={{ width: `${pct}%`, background: color, borderRadius: 4, height: 10, transition: 'width 0.5s' }} />
+      </div>
+    </div>
+  );
+}
+
+export default function MiraiPage() {
+  const [data, setData] = useState<MiraiSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/data/mirai-summary.json')
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .then((d: MiraiSummaryData) => { setData(d); setLoading(false); })
+      .catch(e => { setError(e.message); setLoading(false); });
+  }, []);
+
+  if (loading) return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh', color: '#999' }}>
+      読み込み中…
+    </div>
+  );
+  if (error || !data) return (
+    <div style={{ padding: 40, color: '#ef4444' }}>エラー: {error ?? 'データが読み込めませんでした'}</div>
+  );
+
+  const { summary, monthly, incomeByCategory, expenseByCategory, partyFeeDistribution, donationDistribution } = data;
+  const balance = summary.totalIncome - summary.totalExpense;
+
+  // 月別グラフ用データ
+  const monthlyChartData = monthly.map(m => ({
+    month: m.month.replace('2025-', ''),
+    収入: m.income,
+    支出: m.expense,
+  }));
+
+  // 党費分布グラフ用データ
+  const feeChartData = partyFeeDistribution.map(f => ({
+    金額: f.amount >= 10000 ? `${(f.amount / 10000).toFixed(1)}万円` : `${f.amount.toLocaleString()}円`,
+    件数: f.count,
+    割合: f.percentage,
+  }));
+
+  // 収入カテゴリ最大値
+  const incomeMax = Math.max(...incomeByCategory.map(c => c.amount));
+  const expenseMax = Math.max(...expenseByCategory.map(c => c.amount));
+
+  const tooltipStyle = {
+    background: 'rgba(0,0,0,0.75)', color: '#fff', padding: '6px 10px',
+    borderRadius: 6, fontSize: 12,
+  };
+
+  return (
+    <div style={{ maxWidth: 900, margin: '0 auto', padding: '32px 20px', fontFamily: 'sans-serif', color: '#111' }}>
+      {/* ヘッダー */}
+      <div style={{ marginBottom: 8 }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>
+          チームみらい 政治資金ダッシュボード
+        </h1>
+        <div style={{ fontSize: 13, color: '#666', marginTop: 6 }}>
+          出典:{' '}
+          <a
+            href="https://marumie.team-mir.ai/o/team-mirai"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: '#3b82f6' }}
+          >
+            marumie.team-mir.ai
+          </a>
+          {' '}／ 対象期間: {summary.dateRange.from} 〜 {summary.dateRange.to}
+          {' '}／ 集計日: {data.generatedAt.slice(0, 10)}
+        </div>
+      </div>
+
+      {/* サマリーカード */}
+      <div style={{ display: 'flex', gap: 16, marginTop: 24, flexWrap: 'wrap' }}>
+        <SummaryCard label="総収入" amount={summary.totalIncome} count={monthly.reduce((s, m) => s + m.incomeCount, 0)} color={INCOME_COLOR} />
+        <SummaryCard label="総支出" amount={summary.totalExpense} count={monthly.reduce((s, m) => s + m.expenseCount, 0)} color={EXPENSE_COLOR} />
+        <SummaryCard
+          label="差引残高"
+          amount={Math.abs(balance)}
+          count={summary.totalTransactions}
+          color={balance >= 0 ? '#10b981' : '#f59e0b'}
+        />
+      </div>
+
+      {/* 月別収支推移 */}
+      <section style={{ marginTop: 40 }}>
+        <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 16 }}>月別収支推移</h2>
+        <div style={{ height: 280 }}>
+          <ResponsiveBar
+            data={monthlyChartData}
+            keys={['収入', '支出']}
+            indexBy="month"
+            groupMode="grouped"
+            margin={{ top: 10, right: 20, bottom: 40, left: 80 }}
+            padding={0.25}
+            colors={[INCOME_COLOR, EXPENSE_COLOR]}
+            axisBottom={{ tickSize: 0, tickPadding: 8, legend: '月', legendOffset: 32, legendPosition: 'middle' }}
+            axisLeft={{
+              tickSize: 0,
+              format: (v: number) => v >= 1e8 ? `${(v / 1e8).toFixed(0)}億` : v >= 1e4 ? `${(v / 1e4).toFixed(0)}万` : String(v),
+              legend: '金額（円）', legendOffset: -70, legendPosition: 'middle',
+            }}
+            enableLabel={false}
+            tooltip={({ id, value, indexValue }) => (
+              <div style={tooltipStyle}>{indexValue}月 {id}: {formatYen(value as number)}</div>
+            )}
+            legends={[{
+              dataFrom: 'keys', anchor: 'top-right', direction: 'row', itemWidth: 60,
+              itemHeight: 20, translateY: -10, symbolSize: 12,
+            }]}
+          />
+        </div>
+      </section>
+
+      {/* 収入内訳 */}
+      <section style={{ marginTop: 40 }}>
+        <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 16 }}>収入内訳</h2>
+        {incomeByCategory.map(c => (
+          <HBar
+            key={`${c.category}-${c.subCategory}`}
+            label={c.subCategory === c.category ? c.category : `${c.category} / ${c.subCategory}`}
+            value={c.amount}
+            max={incomeMax}
+            color={INCOME_COLOR}
+            sub={`${c.count.toLocaleString()}件`}
+          />
+        ))}
+      </section>
+
+      {/* 党費金額分布 */}
+      <section style={{ marginTop: 40 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
+          <h2 style={{ fontSize: 17, fontWeight: 700, margin: 0 }}>党費の金額分布</h2>
+          <Link href="/mirai/party-fee" style={{ fontSize: 13, color: '#2aa693', textDecoration: 'none', fontWeight: 600 }}>
+            詳細ビュー →
+          </Link>
+        </div>
+        <p style={{ fontSize: 13, color: '#666', marginBottom: 16 }}>
+          全{partyFeeDistribution.reduce((s, f) => s + f.count, 0).toLocaleString()}件。
+          最頻値は <strong>{partyFeeDistribution[0]?.amount.toLocaleString()}円</strong>（{partyFeeDistribution[0]?.percentage}%）。
+        </p>
+        <div style={{ height: 220 }}>
+          <ResponsiveBar
+            data={feeChartData}
+            keys={['件数']}
+            indexBy="金額"
+            margin={{ top: 10, right: 20, bottom: 50, left: 70 }}
+            padding={0.3}
+            colors={['#8b5cf6']}
+            axisBottom={{ tickSize: 0, tickPadding: 8, legend: '党費金額', legendOffset: 36, legendPosition: 'middle' }}
+            axisLeft={{ tickSize: 0, legend: '件数', legendOffset: -55, legendPosition: 'middle' }}
+            label={(d) => `${d.value?.toLocaleString()}`}
+            labelSkipHeight={16}
+            tooltip={({ indexValue, value, data: d }) => (
+              <div style={tooltipStyle}>{indexValue}: {(value as number).toLocaleString()}件（{d['割合']}%）</div>
+            )}
+          />
+        </div>
+      </section>
+
+      {/* 個人寄附分布 */}
+      <section style={{ marginTop: 40 }}>
+        <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 16 }}>個人寄附の金額帯分布</h2>
+        {donationDistribution.map(d => (
+          <HBar
+            key={d.label}
+            label={d.label}
+            value={d.totalAmount}
+            max={Math.max(...donationDistribution.map(x => x.totalAmount))}
+            color={INCOME_COLOR}
+            sub={`${d.count.toLocaleString()}件`}
+          />
+        ))}
+      </section>
+
+      {/* 支出内訳 */}
+      <section style={{ marginTop: 40, marginBottom: 60 }}>
+        <h2 style={{ fontSize: 17, fontWeight: 700, marginBottom: 16 }}>支出内訳</h2>
+        {expenseByCategory.map(c => (
+          <HBar
+            key={c.category}
+            label={c.category}
+            value={c.amount}
+            max={expenseMax}
+            color={EXPENSE_COLOR}
+            sub={`${c.count.toLocaleString()}件`}
+          />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/app/mirai/party-fee/page.tsx
+++ b/app/mirai/party-fee/page.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ResponsiveBar } from '@nivo/bar';
+import type { MiraiSummaryData } from '@/types/mirai';
+
+// --- チームみらい ブランドカラー ---
+const TEAL_400 = '#30bca7';
+const TEAL_500 = '#2aa693';
+const TEAL_600 = '#238778';
+const BG_GRADIENT = 'linear-gradient(135deg, rgba(226,246,243,1) 0%, rgba(238,246,226,1) 100%)';
+const TEXT_PRIMARY = '#171717';
+const TEXT_MUTED = '#6b7280';
+
+// 党費ティアごとの色
+const TIER_COLORS: Record<number, { bg: string; border: string; label: string }> = {
+  1500:  { bg: TEAL_400,  border: TEAL_600, label: '月1,500円' },
+  5000:  { bg: '#10b981', border: '#059669', label: '月5,000円' },
+  10000: { bg: '#3b82f6', border: '#2563eb', label: '月10,000円' },
+};
+const OTHER_COLOR = { bg: '#94a3b8', border: '#64748b', label: 'その他' };
+
+function tierColor(amount: number) {
+  return TIER_COLORS[amount] ?? OTHER_COLOR;
+}
+
+function formatYen(n: number): string {
+  if (n >= 100_000_000) return `${(n / 100_000_000).toFixed(2)}億円`;
+  if (n >= 10_000)      return `${(n / 10_000).toFixed(0)}万円`;
+  return `${n.toLocaleString()}円`;
+}
+
+// --- ドーナツ風SVGアーク ---
+function DonutArc({ percentage, color, radius = 70, stroke = 18 }: {
+  percentage: number; color: string; radius?: number; stroke?: number;
+}) {
+  const cx = radius + stroke;
+  const cy = radius + stroke;
+  const size = (radius + stroke) * 2;
+  const circ = 2 * Math.PI * radius;
+  const dash = (percentage / 100) * circ;
+  return (
+    <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
+      <circle cx={cx} cy={cy} r={radius} fill="none" stroke="#e5e7eb" strokeWidth={stroke} />
+      <circle
+        cx={cx} cy={cy} r={radius} fill="none"
+        stroke={color} strokeWidth={stroke}
+        strokeDasharray={`${dash} ${circ}`}
+        strokeLinecap="round"
+        style={{ transition: 'stroke-dasharray 0.8s ease' }}
+      />
+    </svg>
+  );
+}
+
+// --- ティアカード ---
+function TierCard({ amount, count, percentage, total }: {
+  amount: number; count: number; percentage: number; total: number;
+}) {
+  const { bg, border, label } = tierColor(amount);
+  return (
+    <div style={{
+      background: '#fff', border: `2px solid ${border}`, borderRadius: 16,
+      padding: '24px 20px', flex: 1, minWidth: 180, textAlign: 'center',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+    }}>
+      <div style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+        <DonutArc percentage={percentage} color={bg} />
+        <div style={{
+          position: 'absolute', fontWeight: 700, fontSize: 20, color: TEXT_PRIMARY,
+        }}>
+          {percentage}%
+        </div>
+      </div>
+      <div style={{ marginTop: 12, fontSize: 22, fontWeight: 800, color: bg }}>{label}</div>
+      <div style={{ fontSize: 15, color: TEXT_PRIMARY, marginTop: 4, fontWeight: 600 }}>
+        {count.toLocaleString()}人
+      </div>
+      <div style={{ fontSize: 12, color: TEXT_MUTED, marginTop: 2 }}>
+        合計 {formatYen(amount * count)}
+      </div>
+      <div style={{ marginTop: 12, background: '#f3f4f6', borderRadius: 6, height: 6 }}>
+        <div style={{
+          width: `${(count / total) * 100}%`, background: bg,
+          borderRadius: 6, height: 6, transition: 'width 0.8s ease',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+export default function PartyFeePage() {
+  const [data, setData] = useState<MiraiSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/data/mirai-summary.json')
+      .then(r => r.json())
+      .then((d: MiraiSummaryData) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) return (
+    <div style={{ minHeight: '100vh', background: BG_GRADIENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ color: TEAL_500, fontSize: 16 }}>読み込み中…</div>
+    </div>
+  );
+  if (!data) return <div style={{ padding: 40, color: '#ef4444' }}>データが読み込めませんでした</div>;
+
+  const { partyFeeDistribution, partyFeeMonthly, summary } = data;
+
+  const totalFeeCount = partyFeeDistribution.reduce((s, f) => s + f.count, 0);
+  const totalFeeAmount = partyFeeDistribution.reduce((s, f) => s + f.amount * f.count, 0);
+  const topTier = partyFeeDistribution[0];
+
+  // 主要3ティア + その他
+  const mainTiers = [1500, 5000, 10000];
+  const mainDist = mainTiers.map(a => partyFeeDistribution.find(f => f.amount === a) ?? { amount: a, count: 0, percentage: 0 });
+  const otherCount = partyFeeDistribution.filter(f => !mainTiers.includes(f.amount)).reduce((s, f) => s + f.count, 0);
+  const otherPct = Math.round((otherCount / totalFeeCount) * 1000) / 10;
+
+  // 月別積み上げバーチャート用データ
+  const monthlyChartData = partyFeeMonthly.map(m => {
+    const entry: Record<string, string | number> = { month: m.month.replace('2025-', '') };
+    for (const tier of m.byTier) {
+      const key = mainTiers.includes(tier.amount)
+        ? `${tier.amount.toLocaleString()}円`
+        : 'その他';
+      entry[key] = ((entry[key] as number) ?? 0) + tier.count;
+    }
+    return entry;
+  });
+
+  const barKeys = ['1,500円', '5,000円', '10,000円', 'その他'].filter(k =>
+    monthlyChartData.some(d => (d[k] as number) > 0)
+  );
+  const barColors = [TEAL_400, '#10b981', '#3b82f6', '#94a3b8'];
+
+  const tooltipStyle = {
+    background: 'rgba(23,23,23,0.85)', color: '#fff',
+    padding: '6px 12px', borderRadius: 8, fontSize: 12,
+  };
+
+  return (
+    <div style={{ minHeight: '100vh', background: BG_GRADIENT, fontFamily: 'sans-serif', color: TEXT_PRIMARY }}>
+      <div style={{ maxWidth: 860, margin: '0 auto', padding: '40px 20px 80px' }}>
+
+        {/* ナビゲーション */}
+        <div style={{ marginBottom: 24, fontSize: 13, color: TEXT_MUTED }}>
+          <Link href="/mirai" style={{ color: TEAL_500, textDecoration: 'none' }}>
+            ← 政治資金ダッシュボード
+          </Link>
+        </div>
+
+        {/* ヘッダー */}
+        <div style={{ marginBottom: 40 }}>
+          <div style={{
+            display: 'inline-block', background: TEAL_500, color: '#fff',
+            borderRadius: 6, padding: '4px 12px', fontSize: 12, fontWeight: 600, marginBottom: 10,
+          }}>
+            チームみらい 党費分析
+          </div>
+          <h1 style={{ fontSize: 30, fontWeight: 800, margin: '0 0 8px', lineHeight: 1.2 }}>
+            党費の金額分布
+          </h1>
+          <p style={{ fontSize: 14, color: TEXT_MUTED, margin: 0 }}>
+            対象期間: {summary.dateRange.from} 〜 {summary.dateRange.to}　／
+            出典:{' '}
+            <a href="https://marumie.team-mir.ai/o/team-mirai" target="_blank" rel="noopener noreferrer"
+              style={{ color: TEAL_500 }}>
+              marumie.team-mir.ai
+            </a>
+          </p>
+        </div>
+
+        {/* ヒーロー数値 */}
+        <div style={{
+          display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 40,
+        }}>
+          {[
+            { label: '党費納付件数', value: `${totalFeeCount.toLocaleString()}件`, sub: '集計期間合計' },
+            { label: '党費総額', value: formatYen(totalFeeAmount), sub: '集計期間合計' },
+            { label: '最頻値（最多の金額）', value: `${topTier?.amount.toLocaleString()}円`, sub: `全体の ${topTier?.percentage}%` },
+          ].map(({ label, value, sub }) => (
+            <div key={label} style={{
+              background: '#fff', borderRadius: 14, padding: '20px 24px',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.06)', borderTop: `4px solid ${TEAL_500}`,
+            }}>
+              <div style={{ fontSize: 12, color: TEXT_MUTED, marginBottom: 4 }}>{label}</div>
+              <div style={{ fontSize: 24, fontWeight: 800, color: TEAL_600 }}>{value}</div>
+              <div style={{ fontSize: 11, color: TEXT_MUTED, marginTop: 2 }}>{sub}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* ティアカード */}
+        <section style={{ marginBottom: 48 }}>
+          <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 20, color: TEXT_PRIMARY }}>
+            金額ティア別の内訳
+          </h2>
+          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+            {mainDist.map(f => (
+              <TierCard
+                key={f.amount}
+                amount={f.amount}
+                count={f.count}
+                percentage={f.percentage}
+                total={totalFeeCount}
+              />
+            ))}
+            {otherCount > 0 && (
+              <div style={{
+                background: '#fff', border: `2px solid ${OTHER_COLOR.border}`, borderRadius: 16,
+                padding: '24px 20px', flex: 1, minWidth: 180, textAlign: 'center',
+                boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+              }}>
+                <div style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <DonutArc percentage={otherPct} color={OTHER_COLOR.bg} />
+                  <div style={{ position: 'absolute', fontWeight: 700, fontSize: 20, color: TEXT_PRIMARY }}>
+                    {otherPct}%
+                  </div>
+                </div>
+                <div style={{ marginTop: 12, fontSize: 22, fontWeight: 800, color: OTHER_COLOR.bg }}>{OTHER_COLOR.label}</div>
+                <div style={{ fontSize: 15, color: TEXT_PRIMARY, marginTop: 4, fontWeight: 600 }}>{otherCount.toLocaleString()}件</div>
+                <div style={{ fontSize: 11, color: TEXT_MUTED, marginTop: 4 }}>
+                  {partyFeeDistribution.filter(f => !mainTiers.includes(f.amount))
+                    .map(f => `${f.amount.toLocaleString()}円×${f.count}件`).join('、')}
+                </div>
+                <div style={{ marginTop: 12, background: '#f3f4f6', borderRadius: 6, height: 6 }}>
+                  <div style={{
+                    width: `${(otherCount / totalFeeCount) * 100}%`, background: OTHER_COLOR.bg,
+                    borderRadius: 6, height: 6,
+                  }} />
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* 月別党費件数推移 */}
+        <section style={{ marginBottom: 48 }}>
+          <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 8, color: TEXT_PRIMARY }}>
+            月別 党費納付件数の推移
+          </h2>
+          <p style={{ fontSize: 13, color: TEXT_MUTED, marginBottom: 20 }}>
+            ティア（金額）別に積み上げ表示しています。
+          </p>
+          <div style={{
+            background: '#fff', borderRadius: 16, padding: '28px 20px 16px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.06)', height: 320,
+          }}>
+            <ResponsiveBar
+              data={monthlyChartData}
+              keys={barKeys}
+              indexBy="month"
+              groupMode="stacked"
+              margin={{ top: 10, right: 120, bottom: 45, left: 60 }}
+              padding={0.35}
+              colors={barKeys.map((_, i) => barColors[i])}
+              axisBottom={{
+                tickSize: 0, tickPadding: 8,
+                legend: '月', legendOffset: 36, legendPosition: 'middle',
+              }}
+              axisLeft={{
+                tickSize: 0,
+                legend: '件数', legendOffset: -48, legendPosition: 'middle',
+              }}
+              enableLabel={false}
+              tooltip={({ id, value, indexValue }) => (
+                <div style={tooltipStyle}>
+                  {indexValue}月　{id}：{(value as number).toLocaleString()}件
+                </div>
+              )}
+              legends={[{
+                dataFrom: 'keys', anchor: 'right', direction: 'column',
+                itemWidth: 100, itemHeight: 22, translateX: 110, translateY: 0,
+                symbolSize: 12, symbolShape: 'circle',
+              }]}
+            />
+          </div>
+        </section>
+
+        {/* 全金額一覧 */}
+        <section>
+          <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 16, color: TEXT_PRIMARY }}>
+            全金額の詳細（件数順）
+          </h2>
+          <div style={{
+            background: '#fff', borderRadius: 16, overflow: 'hidden',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+          }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+              <thead>
+                <tr style={{ background: TEAL_500, color: '#fff' }}>
+                  {['金額', '件数', '割合', '小計'].map(h => (
+                    <th key={h} style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {partyFeeDistribution.map((f, i) => {
+                  const { bg } = tierColor(f.amount);
+                  return (
+                    <tr key={f.amount} style={{ background: i % 2 === 0 ? '#f9fafb' : '#fff' }}>
+                      <td style={{ padding: '11px 20px', textAlign: 'right', fontWeight: 700, color: bg }}>
+                        {f.amount.toLocaleString()}円
+                      </td>
+                      <td style={{ padding: '11px 20px', textAlign: 'right' }}>
+                        {f.count.toLocaleString()}件
+                      </td>
+                      <td style={{ padding: '11px 20px', textAlign: 'right' }}>
+                        <span style={{
+                          display: 'inline-block', background: `${bg}22`,
+                          color: bg, borderRadius: 12, padding: '2px 10px', fontWeight: 600,
+                        }}>
+                          {f.percentage}%
+                        </span>
+                      </td>
+                      <td style={{ padding: '11px 20px', textAlign: 'right', color: TEXT_MUTED }}>
+                        {formatYen(f.amount * f.count)}
+                      </td>
+                    </tr>
+                  );
+                })}
+                <tr style={{ background: TEAL_500 + '18', fontWeight: 700 }}>
+                  <td style={{ padding: '12px 20px', textAlign: 'right', color: TEAL_600 }}>合計</td>
+                  <td style={{ padding: '12px 20px', textAlign: 'right', color: TEAL_600 }}>{totalFeeCount.toLocaleString()}件</td>
+                  <td style={{ padding: '12px 20px', textAlign: 'right', color: TEAL_600 }}>100%</td>
+                  <td style={{ padding: '12px 20px', textAlign: 'right', color: TEAL_600 }}>{formatYen(totalFeeAmount)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </div>
+  );
+}

--- a/docs/tasks/20260222_1128_みらい政治資金ページ実装計画.md
+++ b/docs/tasks/20260222_1128_みらい政治資金ページ実装計画.md
@@ -1,0 +1,197 @@
+# みらいまる見え政治資金 可視化ページ実装計画
+
+## 目的
+
+チームみらいの公開政治資金データ（marumie.team-mir.ai）を素早く把握したいユーザーが、
+CSV を手動で集計せずに収支の全体像・党費分布などをブラウザで見られるようにするため。
+
+---
+
+## データの概要
+
+- **ソース**: `https://marumie.team-mir.ai/o/team-mirai` からDL した CSV
+- **ファイル**: `data/download/transactions_team-mirai_2026-02-22.csv`（2.7MB・gitignore対象）
+- **件数**: 27,532件（収入 13,383件 / 支出 14,149件）
+- **期間**: 2025-05-07 〜 2025-12-06
+- **総収入**: 約2.72億円 / **総支出**: 約1.65億円
+
+### カラム構成
+
+| カラム | 説明 | 値例 |
+|--------|------|------|
+| 日付 | `YYYY-MM-DD` | 2025-07-15 |
+| 政治団体名 | 固定値 | 政党・チームみらい |
+| タイプ | `収入` or `支出` | 収入 |
+| 金額 | 整数（円） | 1500 |
+| カテゴリ | 大分類 | 個人の負担する党費又は会費 |
+| 詳細区分 | 小分類 | 党費 |
+| ラベル | 任意の補足 | VERCEL |
+
+### 主要カテゴリ（収入）
+
+| カテゴリ | 詳細区分 | 件数 |
+|---------|---------|------|
+| 個人の負担する党費又は会費 | 党費 | 3,723件 |
+| 個人からの寄附 | 個人からの寄附 | 9,627件 |
+| その他の収入 | 立法事務費・返金等 | 16件 |
+
+### 党費金額分布（判明済み）
+
+| 金額 | 件数 | 割合 |
+|------|------|------|
+| 1,500円 | 2,710件 | 72.8% |
+| 5,000円 | 698件 | 18.7% |
+| 10,000円 | 298件 | 8.0% |
+| その他（端数・高額） | 17件 | 0.5% |
+
+---
+
+## アーキテクチャ
+
+既存の `mof-budget-overview` ページ（静的JSONをフェッチするパターン）に準拠する。
+
+### 追加ファイル一覧
+
+| ファイル | レイヤー | 役割 |
+|---------|---------|------|
+| `scripts/generate-mirai-summary.ts` | Data Pipeline | CSV → 集計JSON生成 |
+| `public/data/mirai-summary.json` | Static Asset | 集計済みデータ（commit対象） |
+| `types/mirai.ts` | Types | 集計JSONの型定義 |
+| `app/mirai/page.tsx` | Page | UIメインページ |
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `package.json` | `generate-mirai` スクリプト追加 |
+| `.gitignore` | `!/public/data/mirai-summary.json` 追記 |
+
+### URL
+
+`/mirai`
+
+---
+
+## データパイプライン
+
+### スクリプト: `scripts/generate-mirai-summary.ts`
+
+**入力**: `data/download/transactions_team-mirai_*.csv`（最新ファイルを自動検出）
+**出力**: `public/data/mirai-summary.json`
+
+生成するJSON構造:
+
+```ts
+{
+  generatedAt: string,          // ISO日時
+  sourceFile: string,           // 元CSVファイル名
+  summary: {
+    totalIncome: number,        // 総収入（円）
+    totalExpense: number,       // 総支出（円）
+    totalTransactions: number,  // 総件数
+    dateRange: { from: string, to: string }  // "YYYY-MM"
+  },
+  monthly: Array<{
+    month: string,              // "YYYY-MM"
+    income: number,
+    expense: number,
+    incomeCount: number,
+    expenseCount: number,
+  }>,
+  incomeByCategory: Array<{
+    category: string,
+    subCategory: string,
+    amount: number,
+    count: number,
+  }>,
+  expenseByCategory: Array<{
+    category: string,
+    amount: number,
+    count: number,
+  }>,
+  partyFeeDistribution: Array<{
+    amount: number,
+    count: number,
+    percentage: number,
+  }>,
+  donationDistribution: Array<{   // 個人寄附の分布（金額帯別）
+    label: string,                // "〜999円", "1,000〜4,999円" など
+    count: number,
+    totalAmount: number,
+  }>,
+}
+```
+
+**npm スクリプト**:
+```
+"generate-mirai": "npx ts-node --project tsconfig.json scripts/generate-mirai-summary.ts"
+```
+
+---
+
+## ページ仕様: `app/mirai/page.tsx`
+
+`'use client'` コンポーネント。マウント時に `/public/data/mirai-summary.json` を fetch。
+
+### セクション構成
+
+#### 1. ヘッダー
+- タイトル: 「チームみらい 政治資金ダッシュボード」
+- データソースリンク（marumie.team-mir.ai へのリンク）
+- 集計期間表示（dateRange）
+
+#### 2. サマリーカード（3枚）
+- 総収入: 約X.X億円（N件）
+- 総支出: 約X.X億円（N件）
+- 差引残高: 約X.X億円
+
+#### 3. 月別収支推移
+- 横軸: 月（2025-05 〜 2025-12）
+- 縦軸: 金額（円）
+- 収入バー（青系）と支出バー（赤系）の並列表示
+- **実装**: `@nivo/bar`（`@0.99.0` を新規インストール）を使用
+
+#### 4. 収入内訳
+- 党費 / 個人寄附 / その他を金額・件数で表示
+- シンプルな横棒グラフ（CSS `width` ベース）
+
+#### 5. 党費金額分布
+- 棒グラフ: 1,500円・5,000円・10,000円・その他の件数と割合
+- 「72.8% が月1,500円」などの強調テキスト付き
+
+#### 6. 個人寄附分布
+- 金額帯別（〜999円 / 1,000〜4,999円 / 5,000〜9,999円 / 10,000円〜）の件数・金額
+
+### スタイリング
+
+既存ページ（`globals.css`）のスタイルを踏襲。新規CSSクラスは `app/mirai/` 内にスコープする（CSS Modules または `<style>` タグ）。
+
+---
+
+## レイヤー設計チェック
+
+| チェック項目 | 結果 |
+|------------|------|
+| `scripts/` にUIロジックなし | OK（CSVパース・JSON出力のみ） |
+| `app/lib/` にHTTP・Reactなし | OK（lib層への追加なし） |
+| `client/components/` に直接APIコールなし | OK（コンポーネント追加なし） |
+| `app/mirai/page.tsx` から fetch のみ | OK（`public/data/` の静的JSONを参照） |
+
+---
+
+## 実装順序
+
+1. `types/mirai.ts` — 型定義
+2. `scripts/generate-mirai-summary.ts` — CSVパーサー・集計スクリプト
+3. `npm run generate-mirai` 実行 → `public/data/mirai-summary.json` 生成確認
+4. `.gitignore` 更新 + `package.json` スクリプト追加
+5. `@nivo/bar@0.99.0` インストール
+6. `app/mirai/page.tsx` — ページ実装
+
+---
+
+## 注意事項
+
+- `data/download/` は gitignore 対象のため、`mirai-summary.json` の生成はローカルで手動実行（`npm run generate-mirai`）し、生成物を commit する
+- CSV ファイルのエンコーディングは `UTF-8 BOM付き`（`utf-8-sig` 相当）
+- 金額は **整数（円単位）**（本プロジェクトの他データと同じ単位）

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@nivo/bar": "^0.99.0",
         "@nivo/sankey": "^0.99.0",
         "next": "15.1.11",
         "react": "^18.3.1",
@@ -1316,6 +1317,123 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nivo/annotations": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
+      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/annotations/node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@nivo/axes": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
+      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes/node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@nivo/bar": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.99.0.tgz",
+      "integrity": "sha512-9yfMn7H6UF/TqtCwVZ/vihVAXUff9wWvSaeF2Z1DCfgr5S07qs31Qb2p0LZA+YgCWpaU7zqkeb3VZ4WCpZbrDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/canvas": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/bar/node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@nivo/canvas": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/canvas/-/canvas-0.99.0.tgz",
+      "integrity": "sha512-UxA8zb+NPwqmNm81hoyUZSMAikgjU1ukLf4KybVNyV8ejcJM+BUFXsb8DxTcLdt4nmCFHqM56GaJQv2hnAHmzg==",
+      "license": "MIT"
+    },
     "node_modules/@nivo/colors": {
       "version": "0.99.0",
       "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
@@ -1446,6 +1564,41 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@nivo/scales": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
+      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/scales/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@nivo/text": {
       "version": "0.99.0",
@@ -1680,6 +1833,21 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
@@ -1738,6 +1906,12 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "validate-tags": "tsx scripts/validate-tags.ts",
     "build-houjin-db": "python3 scripts/build-houjin-sqlite.py",
     "build-houjin-lookup": "python3 scripts/build-houjin-lookup.py",
+    "generate-mirai": "tsx scripts/generate-mirai-summary.ts",
     "setup": "npm install && npm run normalize && npm run generate-structured && npm run generate-project-details"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@nivo/bar": "^0.99.0",
     "@nivo/sankey": "^0.99.0",
     "next": "15.1.11",
     "react": "^18.3.1",

--- a/public/data/mirai-summary.json
+++ b/public/data/mirai-summary.json
@@ -1,0 +1,399 @@
+{
+  "generatedAt": "2026-02-22T02:44:43.682Z",
+  "sourceFile": "transactions_team-mirai_2026-02-22.csv",
+  "summary": {
+    "totalIncome": 272472775,
+    "totalExpense": 164922622,
+    "totalTransactions": 27532,
+    "dateRange": {
+      "from": "2025-05",
+      "to": "2025-12"
+    }
+  },
+  "monthly": [
+    {
+      "month": "2025-05",
+      "income": 148000,
+      "expense": 144618,
+      "incomeCount": 17,
+      "expenseCount": 61
+    },
+    {
+      "month": "2025-06",
+      "income": 58941010,
+      "expense": 63240464,
+      "incomeCount": 562,
+      "expenseCount": 653
+    },
+    {
+      "month": "2025-07",
+      "income": 107858779,
+      "expense": 54267184,
+      "incomeCount": 7311,
+      "expenseCount": 7617
+    },
+    {
+      "month": "2025-08",
+      "income": 9453745,
+      "expense": 14480683,
+      "incomeCount": 262,
+      "expenseCount": 349
+    },
+    {
+      "month": "2025-09",
+      "income": 16007412,
+      "expense": 9518136,
+      "incomeCount": 1239,
+      "expenseCount": 1320
+    },
+    {
+      "month": "2025-10",
+      "income": 46009547,
+      "expense": 11897645,
+      "incomeCount": 2142,
+      "expenseCount": 2231
+    },
+    {
+      "month": "2025-11",
+      "income": 33404282,
+      "expense": 11334009,
+      "incomeCount": 1849,
+      "expenseCount": 1912
+    },
+    {
+      "month": "2025-12",
+      "income": 650000,
+      "expense": 39883,
+      "incomeCount": 1,
+      "expenseCount": 6
+    }
+  ],
+  "incomeByCategory": [
+    {
+      "category": "個人からの寄附",
+      "subCategory": "個人からの寄附",
+      "amount": 163824526,
+      "count": 9627
+    },
+    {
+      "category": "政治団体からの寄附",
+      "subCategory": "候補者後援会からの寄附",
+      "amount": 24697690,
+      "count": 10
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "政党交付金",
+      "amount": 24095500,
+      "count": 1
+    },
+    {
+      "category": "政治団体からの寄附",
+      "subCategory": "安野貴博の政治団体からの寄附",
+      "amount": 21000000,
+      "count": 2
+    },
+    {
+      "category": "借入金",
+      "subCategory": "安野貴博からの借入",
+      "amount": 20000000,
+      "count": 1
+    },
+    {
+      "category": "個人の負担する党費又は会費",
+      "subCategory": "党費",
+      "amount": 10809112,
+      "count": 3723
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "立法事務費",
+      "amount": 3250000,
+      "count": 5
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "手続き不備の供託金返還",
+      "amount": 3000000,
+      "count": 1
+    },
+    {
+      "category": "機関紙誌の発行その他の事業による収入",
+      "subCategory": "BBQ交流会",
+      "amount": 1731240,
+      "count": 3
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "デビットカードキャッシュバック",
+      "amount": 31568,
+      "count": 3
+    },
+    {
+      "category": "機関紙誌の発行その他の事業による収入",
+      "subCategory": "サポーター交流会",
+      "amount": 26521,
+      "count": 1
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "返金",
+      "amount": 4068,
+      "count": 5
+    },
+    {
+      "category": "その他の収入",
+      "subCategory": "受取利息",
+      "amount": 2550,
+      "count": 1
+    }
+  ],
+  "expenseByCategory": [
+    {
+      "category": "選挙関係費",
+      "amount": 75865010,
+      "count": 157
+    },
+    {
+      "category": "宣伝事業費",
+      "amount": 43461295,
+      "count": 276
+    },
+    {
+      "category": "人件費",
+      "amount": 31934239,
+      "count": 4
+    },
+    {
+      "category": "組織活動費",
+      "amount": 10060497,
+      "count": 241
+    },
+    {
+      "category": "その他の経費",
+      "amount": 3510511,
+      "count": 13462
+    },
+    {
+      "category": "備品・消耗品費",
+      "amount": 43640,
+      "count": 6
+    },
+    {
+      "category": "事務所費",
+      "amount": 27630,
+      "count": 2
+    },
+    {
+      "category": "調査研究費",
+      "amount": 19800,
+      "count": 1
+    }
+  ],
+  "partyFeeDistribution": [
+    {
+      "amount": 1500,
+      "count": 2710,
+      "percentage": 72.8
+    },
+    {
+      "amount": 5000,
+      "count": 698,
+      "percentage": 18.7
+    },
+    {
+      "amount": 10000,
+      "count": 298,
+      "percentage": 8
+    },
+    {
+      "amount": 11922,
+      "count": 3,
+      "percentage": 0.1
+    },
+    {
+      "amount": 11111,
+      "count": 3,
+      "percentage": 0.1
+    },
+    {
+      "amount": 10001,
+      "count": 3,
+      "percentage": 0.1
+    },
+    {
+      "amount": 30000,
+      "count": 3,
+      "percentage": 0.1
+    },
+    {
+      "amount": 20000,
+      "count": 3,
+      "percentage": 0.1
+    },
+    {
+      "amount": 15000,
+      "count": 1,
+      "percentage": 0
+    },
+    {
+      "amount": 10010,
+      "count": 1,
+      "percentage": 0
+    }
+  ],
+  "donationDistribution": [
+    {
+      "label": "〜999円",
+      "count": 20,
+      "totalAmount": 9980
+    },
+    {
+      "label": "1,000〜4,999円",
+      "count": 5776,
+      "totalAmount": 12542546
+    },
+    {
+      "label": "5,000〜9,999円",
+      "count": 1256,
+      "totalAmount": 6491000
+    },
+    {
+      "label": "10,000〜29,999円",
+      "count": 1985,
+      "totalAmount": 21602000
+    },
+    {
+      "label": "30,000円〜",
+      "count": 590,
+      "totalAmount": 123179000
+    }
+  ],
+  "partyFeeMonthly": [
+    {
+      "month": "2025-09",
+      "count": 811,
+      "totalAmount": 2551044,
+      "byTier": [
+        {
+          "amount": 1500,
+          "count": 562
+        },
+        {
+          "amount": 5000,
+          "count": 163
+        },
+        {
+          "amount": 10000,
+          "count": 80
+        },
+        {
+          "amount": 10001,
+          "count": 1
+        },
+        {
+          "amount": 10010,
+          "count": 1
+        },
+        {
+          "amount": 11111,
+          "count": 1
+        },
+        {
+          "amount": 11922,
+          "count": 1
+        },
+        {
+          "amount": 20000,
+          "count": 1
+        },
+        {
+          "amount": 30000,
+          "count": 1
+        }
+      ]
+    },
+    {
+      "month": "2025-10",
+      "count": 1413,
+      "totalAmount": 4033534,
+      "byTier": [
+        {
+          "amount": 1500,
+          "count": 1037
+        },
+        {
+          "amount": 5000,
+          "count": 263
+        },
+        {
+          "amount": 10000,
+          "count": 108
+        },
+        {
+          "amount": 10001,
+          "count": 1
+        },
+        {
+          "amount": 11111,
+          "count": 1
+        },
+        {
+          "amount": 11922,
+          "count": 1
+        },
+        {
+          "amount": 20000,
+          "count": 1
+        },
+        {
+          "amount": 30000,
+          "count": 1
+        }
+      ]
+    },
+    {
+      "month": "2025-11",
+      "count": 1499,
+      "totalAmount": 4224534,
+      "byTier": [
+        {
+          "amount": 1500,
+          "count": 1111
+        },
+        {
+          "amount": 5000,
+          "count": 272
+        },
+        {
+          "amount": 10000,
+          "count": 110
+        },
+        {
+          "amount": 10001,
+          "count": 1
+        },
+        {
+          "amount": 11111,
+          "count": 1
+        },
+        {
+          "amount": 11922,
+          "count": 1
+        },
+        {
+          "amount": 15000,
+          "count": 1
+        },
+        {
+          "amount": 20000,
+          "count": 1
+        },
+        {
+          "amount": 30000,
+          "count": 1
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/generate-mirai-summary.ts
+++ b/scripts/generate-mirai-summary.ts
@@ -1,0 +1,228 @@
+/**
+ * チームみらい政治資金CSV → 集計JSON生成スクリプト
+ *
+ * 入力: data/download/transactions_team-mirai_*.csv（最新ファイルを自動検出）
+ * 出力: public/data/mirai-summary.json
+ *
+ * 実行: npm run generate-mirai
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import type { MiraiSummaryData } from '../types/mirai';
+
+const ROOT = path.resolve(__dirname, '..');
+const DOWNLOAD_DIR = path.join(ROOT, 'data', 'download');
+const OUTPUT_PATH = path.join(ROOT, 'public', 'data', 'mirai-summary.json');
+
+interface Row {
+  date: string;
+  orgName: string;
+  type: '収入' | '支出';
+  amount: number;
+  category: string;
+  subCategory: string;
+  label: string;
+}
+
+async function parseCSV(filePath: string): Promise<Row[]> {
+  const rows: Row[] = [];
+  const fileStream = fs.createReadStream(filePath);
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  let isFirst = true;
+  for await (const rawLine of rl) {
+    // BOM 除去
+    const line = rawLine.replace(/^\uFEFF/, '');
+    if (isFirst) { isFirst = false; continue; } // ヘッダースキップ
+    if (!line.trim()) continue;
+
+    // CSV パース（引用符対応）
+    const cols = splitCSVLine(line);
+    if (cols.length < 6) continue;
+
+    const amount = parseInt(cols[3].replace(/,/g, ''), 10);
+    if (isNaN(amount)) continue;
+
+    rows.push({
+      date: cols[0],
+      orgName: cols[1],
+      type: cols[2] as '収入' | '支出',
+      amount,
+      category: cols[4],
+      subCategory: cols[5],
+      label: cols[6] ?? '',
+    });
+  }
+
+  return rows;
+}
+
+function splitCSVLine(line: string): string[] {
+  const cols: string[] = [];
+  let cur = '';
+  let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuote && line[i + 1] === '"') { cur += '"'; i++; }
+      else { inQuote = !inQuote; }
+    } else if (ch === ',' && !inQuote) {
+      cols.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  cols.push(cur);
+  return cols;
+}
+
+function findLatestCSV(): string {
+  const files = fs.readdirSync(DOWNLOAD_DIR)
+    .filter(f => f.startsWith('transactions_team-mirai_') && f.endsWith('.csv'))
+    .sort()
+    .reverse();
+  if (files.length === 0) {
+    throw new Error(`CSVファイルが見つかりません: ${DOWNLOAD_DIR}/transactions_team-mirai_*.csv`);
+  }
+  return path.join(DOWNLOAD_DIR, files[0]);
+}
+
+async function main() {
+  const csvPath = findLatestCSV();
+  console.log(`読み込み中: ${path.relative(ROOT, csvPath)}`);
+
+  const rows = await parseCSV(csvPath);
+  console.log(`  ${rows.length.toLocaleString()} 件読み込み完了`);
+
+  // --- summary ---
+  const incomeRows = rows.filter(r => r.type === '収入');
+  const expenseRows = rows.filter(r => r.type === '支出');
+  const totalIncome = incomeRows.reduce((s, r) => s + r.amount, 0);
+  const totalExpense = expenseRows.reduce((s, r) => s + r.amount, 0);
+
+  const dates = rows.map(r => r.date).sort();
+  const months = [...new Set(rows.map(r => r.date.slice(0, 7)))].sort();
+
+  // --- monthly ---
+  const monthlyMap = new Map<string, { income: number; expense: number; incomeCount: number; expenseCount: number }>();
+  for (const m of months) {
+    monthlyMap.set(m, { income: 0, expense: 0, incomeCount: 0, expenseCount: 0 });
+  }
+  for (const r of rows) {
+    const m = r.date.slice(0, 7);
+    const entry = monthlyMap.get(m)!;
+    if (r.type === '収入') { entry.income += r.amount; entry.incomeCount++; }
+    else { entry.expense += r.amount; entry.expenseCount++; }
+  }
+  const monthly = months.map(m => ({ month: m, ...monthlyMap.get(m)! }));
+
+  // --- incomeByCategory ---
+  const incomeCatMap = new Map<string, { amount: number; count: number }>();
+  for (const r of incomeRows) {
+    const key = `${r.category}__${r.subCategory}`;
+    const entry = incomeCatMap.get(key) ?? { amount: 0, count: 0 };
+    entry.amount += r.amount;
+    entry.count++;
+    incomeCatMap.set(key, entry);
+  }
+  const incomeByCategory = [...incomeCatMap.entries()]
+    .map(([key, v]) => {
+      const [category, subCategory] = key.split('__');
+      return { category, subCategory, ...v };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  // --- expenseByCategory ---
+  const expenseCatMap = new Map<string, { amount: number; count: number }>();
+  for (const r of expenseRows) {
+    const entry = expenseCatMap.get(r.category) ?? { amount: 0, count: 0 };
+    entry.amount += r.amount;
+    entry.count++;
+    expenseCatMap.set(r.category, entry);
+  }
+  const expenseByCategory = [...expenseCatMap.entries()]
+    .map(([category, v]) => ({ category, ...v }))
+    .sort((a, b) => b.amount - a.amount);
+
+  // --- partyFeeDistribution ---
+  const partyFeeRows = rows.filter(r => r.subCategory === '党費');
+  const feeCountMap = new Map<number, number>();
+  for (const r of partyFeeRows) {
+    feeCountMap.set(r.amount, (feeCountMap.get(r.amount) ?? 0) + 1);
+  }
+  const totalFeeCount = partyFeeRows.length;
+  const partyFeeDistribution = [...feeCountMap.entries()]
+    .sort((a, b) => b[1] - a[1]) // 件数降順
+    .map(([amount, count]) => ({
+      amount,
+      count,
+      percentage: Math.round((count / totalFeeCount) * 1000) / 10,
+    }));
+
+  // --- donationDistribution ---
+  const donationRows = rows.filter(r => r.subCategory === '個人からの寄附');
+  const bands = [
+    { label: '〜999円', min: 0, max: 999 },
+    { label: '1,000〜4,999円', min: 1000, max: 4999 },
+    { label: '5,000〜9,999円', min: 5000, max: 9999 },
+    { label: '10,000〜29,999円', min: 10000, max: 29999 },
+    { label: '30,000円〜', min: 30000, max: Infinity },
+  ];
+  const donationDistribution = bands.map(({ label, min, max }) => {
+    const filtered = donationRows.filter(r => r.amount >= min && r.amount <= max);
+    return {
+      label,
+      count: filtered.length,
+      totalAmount: filtered.reduce((s, r) => s + r.amount, 0),
+    };
+  });
+
+  // --- partyFeeMonthly ---
+  const partyFeeMonthly = months.map(m => {
+    const mRows = partyFeeRows.filter(r => r.date.slice(0, 7) === m);
+    const tierMap = new Map<number, number>();
+    for (const r of mRows) {
+      tierMap.set(r.amount, (tierMap.get(r.amount) ?? 0) + 1);
+    }
+    return {
+      month: m,
+      count: mRows.length,
+      totalAmount: mRows.reduce((s, r) => s + r.amount, 0),
+      byTier: [...tierMap.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([amount, count]) => ({ amount, count })),
+    };
+  }).filter(m => m.count > 0);
+
+  // --- assemble ---
+  const result: MiraiSummaryData = {
+    generatedAt: new Date().toISOString(),
+    sourceFile: path.basename(csvPath),
+    summary: {
+      totalIncome,
+      totalExpense,
+      totalTransactions: rows.length,
+      dateRange: {
+        from: months[0],
+        to: months[months.length - 1],
+      },
+    },
+    monthly,
+    incomeByCategory,
+    expenseByCategory,
+    partyFeeDistribution,
+    donationDistribution,
+    partyFeeMonthly,
+  };
+
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(result, null, 2), 'utf-8');
+  console.log(`出力完了: ${path.relative(ROOT, OUTPUT_PATH)}`);
+  console.log(`  総収入: ${totalIncome.toLocaleString()}円`);
+  console.log(`  総支出: ${totalExpense.toLocaleString()}円`);
+  console.log(`  差引: ${(totalIncome - totalExpense).toLocaleString()}円`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/types/mirai.ts
+++ b/types/mirai.ts
@@ -1,0 +1,44 @@
+export interface MiraiSummaryData {
+  generatedAt: string;
+  sourceFile: string;
+  summary: {
+    totalIncome: number;
+    totalExpense: number;
+    totalTransactions: number;
+    dateRange: { from: string; to: string };
+  };
+  monthly: Array<{
+    month: string;
+    income: number;
+    expense: number;
+    incomeCount: number;
+    expenseCount: number;
+  }>;
+  incomeByCategory: Array<{
+    category: string;
+    subCategory: string;
+    amount: number;
+    count: number;
+  }>;
+  expenseByCategory: Array<{
+    category: string;
+    amount: number;
+    count: number;
+  }>;
+  partyFeeDistribution: Array<{
+    amount: number;
+    count: number;
+    percentage: number;
+  }>;
+  donationDistribution: Array<{
+    label: string;
+    count: number;
+    totalAmount: number;
+  }>;
+  partyFeeMonthly: Array<{
+    month: string;
+    count: number;
+    totalAmount: number;
+    byTier: Array<{ amount: number; count: number }>;
+  }>;
+}


### PR DESCRIPTION
## 目的

チームみらいの公開政治資金データ（marumie.team-mir.ai）を、CSV を手動集計せずにブラウザで素早く把握できるようにするため。

## 変更内容

### 新規ページ
- **`/mirai`** — 収支全体ダッシュボード（月別収支推移・収入/支出内訳・党費サマリー）
- **`/mirai/party-fee`** — 党費金額分布に特化した専用ビュー

### 新規ファイル
| ファイル | 役割 |
|---------|------|
| `app/mirai/page.tsx` | 収支全体ダッシュボード |
| `app/mirai/party-fee/page.tsx` | 党費分布専用ビュー（チームみらいブランドカラー） |
| `scripts/generate-mirai-summary.ts` | CSV → 集計JSON生成スクリプト |
| `public/data/mirai-summary.json` | 生成済み集計データ |
| `types/mirai.ts` | 集計データの型定義 |

### 設定変更
- `package.json`: `generate-mirai` スクリプト追加、`@nivo/bar@0.99.0` 依存追加
- `.gitignore`: `mirai-summary.json` の追跡許可

## ハイライト

- 党費の最頻値 **1,500円（72.8%）**・5,000円（18.7%）・10,000円（8.0%）の3ティアをドーナツ円グラフで可視化
- ティア別月次積み上げ棒グラフで党員数の推移が一目瞭然
- 配色はチームみらい webapp（`#2aa693` ティール系）に準拠

## テスト方法

```bash
# 1. CSVをダウンロード（手動）
#    https://marumie.team-mir.ai/o/team-mirai → data/download/ に保存

# 2. 集計JSON生成（CSV不要の場合はスキップ、public/data/mirai-summary.json は同梱済み）
npm run generate-mirai

# 3. 開発サーバー起動
npm run dev
# → http://localhost:3002/mirai
# → http://localhost:3002/mirai/party-fee
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Mirai political funding dashboard displaying total income, expenses, monthly trends, category breakdowns, party fee distribution, and donation analysis with interactive charts and visualizations.
  * Added dedicated party fees analysis page featuring tier distribution cards, monthly stacked charts, and comprehensive fee tier breakdown table with percentage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->