### PR TITLE
feat: /globe Phase 2 — Globe API + 府省庁Fibonacci格子配置

### DIFF
--- a/app/api/map/globe/route.ts
+++ b/app/api/map/globe/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import type { RS2024StructuredData } from '@/types/structured';
+
+export interface GlobeMinistry {
+  name: string;
+  totalSpending: number;
+  areaFraction: number;
+  centroid: [number, number]; // [lat, lon] in degrees
+  projectCount: number;
+  color: string; // HSL color string
+}
+
+export interface GlobeResponse {
+  totalSpending: number;
+  ministries: GlobeMinistry[];
+}
+
+let cachedResponse: GlobeResponse | null = null;
+
+/**
+ * Fibonacci格子で球面上にN点を準均等配置する
+ * Returns [lat, lon] in degrees for each point
+ */
+function fibonacciSphere(n: number): [number, number][] {
+  const goldenRatio = (1 + Math.sqrt(5)) / 2;
+  const points: [number, number][] = [];
+
+  for (let i = 0; i < n; i++) {
+    // Polar angle (0 to π)
+    const theta = Math.acos(1 - 2 * (i + 0.5) / n);
+    // Azimuthal angle (golden angle increment)
+    const phi = 2 * Math.PI * i / goldenRatio;
+
+    // Convert to lat/lon in degrees
+    const lat = 90 - (theta * 180) / Math.PI; // -90 to 90
+    const lon = ((phi * 180) / Math.PI) % 360 - 180; // -180 to 180
+
+    points.push([lat, lon]);
+  }
+
+  return points;
+}
+
+function loadGlobeData(): GlobeResponse {
+  if (cachedResponse) return cachedResponse;
+
+  const structuredPath = path.join(process.cwd(), 'public/data/rs2024-structured.json');
+  const raw: RS2024StructuredData = JSON.parse(fs.readFileSync(structuredPath, 'utf8'));
+
+  const stats = raw.statistics.byMinistry;
+  const ministryNames = Object.keys(stats);
+
+  // Calculate total spending across all ministries
+  let totalSpending = 0;
+  for (const name of ministryNames) {
+    totalSpending += stats[name].totalSpending;
+  }
+
+  // Sort by spending (descending) for consistent ordering
+  const sorted = ministryNames
+    .map(name => ({ name, ...stats[name] }))
+    .sort((a, b) => b.totalSpending - a.totalSpending);
+
+  // Generate Fibonacci sphere points
+  const points = fibonacciSphere(sorted.length);
+
+  // Assign colors (HSL hue distributed across 360°)
+  const ministries: GlobeMinistry[] = sorted.map((m, i) => ({
+    name: m.name,
+    totalSpending: m.totalSpending,
+    areaFraction: totalSpending > 0 ? m.totalSpending / totalSpending : 0,
+    centroid: points[i],
+    projectCount: m.projectCount,
+    color: `hsl(${Math.round((i * 360) / sorted.length)}, 70%, 50%)`,
+  }));
+
+  cachedResponse = { totalSpending, ministries };
+  return cachedResponse;
+}
+
+export async function GET() {
+  const data = loadGlobeData();
+  return NextResponse.json(data);
+}

--- a/app/globe/page.tsx
+++ b/app/globe/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import type { GlobeResponse } from '@/app/api/map/globe/route';
 
 const GlobeView = dynamic(
   () => import('@/client/components/GlobeView'),
@@ -8,9 +10,18 @@ const GlobeView = dynamic(
 );
 
 export default function GlobePage() {
+  const [data, setData] = useState<GlobeResponse | null>(null);
+
+  useEffect(() => {
+    fetch('/api/map/globe')
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
   return (
     <main style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-      <GlobeView />
+      <GlobeView data={data} />
     </main>
   );
 }

--- a/client/components/GlobeView.tsx
+++ b/client/components/GlobeView.tsx
@@ -3,9 +3,64 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import type { GlobeResponse } from '@/app/api/map/globe/route';
 
-export default function GlobeView() {
+const SPHERE_RADIUS = 1;
+const MARKER_RADIUS = 1.01; // Slightly above sphere surface
+
+/**
+ * Convert lat/lon (degrees) to 3D position on sphere
+ */
+function latLonToVec3(lat: number, lon: number, radius: number): THREE.Vector3 {
+  const phi = (90 - lat) * (Math.PI / 180);
+  const theta = (lon + 180) * (Math.PI / 180);
+  return new THREE.Vector3(
+    -radius * Math.sin(phi) * Math.cos(theta),
+    radius * Math.cos(phi),
+    radius * Math.sin(phi) * Math.sin(theta)
+  );
+}
+
+/**
+ * Format yen amount for display
+ */
+function formatYen(amount: number): string {
+  if (amount >= 1_000_000_000_000) return `${(amount / 1_000_000_000_000).toFixed(2)}兆円`;
+  if (amount >= 100_000_000) return `${(amount / 100_000_000).toFixed(0)}億円`;
+  if (amount >= 10_000) return `${(amount / 10_000).toFixed(0)}万円`;
+  return `${amount}円`;
+}
+
+/**
+ * Create a text sprite (billboard label) for a ministry marker
+ */
+function createTextSprite(text: string, color: string): THREE.Sprite {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+  canvas.width = 512;
+  canvas.height = 128;
+
+  ctx.fillStyle = color;
+  ctx.font = 'bold 28px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 256, 64);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(0.5, 0.125, 1);
+  return sprite;
+}
+
+interface GlobeViewProps {
+  data?: GlobeResponse | null;
+}
+
+export default function GlobeView({ data }: GlobeViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -31,35 +86,80 @@ export default function GlobeView() {
     container.appendChild(renderer.domElement);
 
     // Lighting
-    const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
     scene.add(ambientLight);
-    const dirLight1 = new THREE.DirectionalLight(0xffffff, 1.0);
+    const dirLight1 = new THREE.DirectionalLight(0xffffff, 0.8);
     dirLight1.position.set(5, 3, 5);
     scene.add(dirLight1);
-    const dirLight2 = new THREE.DirectionalLight(0xffffff, 0.2);
+    const dirLight2 = new THREE.DirectionalLight(0xffffff, 0.3);
     dirLight2.position.set(-3, -2, -3);
     scene.add(dirLight2);
 
     // Globe sphere
-    const sphereGeom = new THREE.SphereGeometry(1, 64, 64);
+    const sphereGeom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 64);
     const sphereMat = new THREE.MeshStandardMaterial({
-      color: '#1a3a5c',
-      roughness: 0.8,
-      metalness: 0.1,
+      color: '#0a1628',
+      roughness: 0.9,
+      metalness: 0.05,
     });
     const sphere = new THREE.Mesh(sphereGeom, sphereMat);
     scene.add(sphere);
 
-    // Wireframe grid (latitude/longitude lines)
-    const wireGeom = new THREE.SphereGeometry(1.002, 36, 18);
+    // Wireframe grid
+    const wireGeom = new THREE.SphereGeometry(SPHERE_RADIUS + 0.001, 36, 18);
     const wireframe = new THREE.WireframeGeometry(wireGeom);
     const wireMat = new THREE.LineBasicMaterial({
-      color: '#4a8ab5',
-      opacity: 0.3,
+      color: '#1a3050',
+      opacity: 0.2,
       transparent: true,
     });
     const wireLines = new THREE.LineSegments(wireframe, wireMat);
     scene.add(wireLines);
+
+    // Group for markers (rotates with globe)
+    const markersGroup = new THREE.Group();
+    scene.add(markersGroup);
+
+    // Track marker meshes for raycasting
+    const markerMeshes: THREE.Mesh[] = [];
+    const markerData: { name: string; spending: number; projectCount: number }[] = [];
+    const disposables: { dispose: () => void }[] = [sphereGeom, sphereMat, wireGeom, wireMat];
+
+    // Add ministry markers if data available
+    if (data) {
+      for (const ministry of data.ministries) {
+        const pos = latLonToVec3(ministry.centroid[0], ministry.centroid[1], MARKER_RADIUS);
+
+        // Marker dot — size proportional to area fraction
+        const dotSize = Math.max(0.01, Math.sqrt(ministry.areaFraction) * 0.15);
+        const dotGeom = new THREE.SphereGeometry(dotSize, 16, 16);
+        const dotMat = new THREE.MeshStandardMaterial({
+          color: ministry.color,
+          emissive: ministry.color,
+          emissiveIntensity: 0.5,
+        });
+        const dot = new THREE.Mesh(dotGeom, dotMat);
+        dot.position.copy(pos);
+        markersGroup.add(dot);
+        markerMeshes.push(dot);
+        markerData.push({
+          name: ministry.name,
+          spending: ministry.totalSpending,
+          projectCount: ministry.projectCount,
+        });
+        disposables.push(dotGeom, dotMat);
+
+        // Label sprite (positioned above the dot)
+        const labelPos = latLonToVec3(
+          ministry.centroid[0],
+          ministry.centroid[1],
+          MARKER_RADIUS + dotSize + 0.03
+        );
+        const label = createTextSprite(ministry.name, ministry.color);
+        label.position.copy(labelPos);
+        markersGroup.add(label);
+      }
+    }
 
     // OrbitControls
     const controls = new OrbitControls(camera, renderer.domElement);
@@ -68,13 +168,65 @@ export default function GlobeView() {
     controls.mouseButtons = {
       LEFT: THREE.MOUSE.ROTATE,
       MIDDLE: THREE.MOUSE.DOLLY,
-      RIGHT: undefined as unknown as THREE.MOUSE, // 将来のコンテキストメニュー用に空ける
+      RIGHT: undefined as unknown as THREE.MOUSE,
     };
     controls.minDistance = 1.5;
     controls.maxDistance = 10;
     controls.rotateSpeed = 0.5;
     controls.enableDamping = true;
     controls.dampingFactor = 0.05;
+
+    // Raycaster for hover detection
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    function onMouseMove(event: MouseEvent) {
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObjects(markerMeshes);
+
+      const tooltip = tooltipRef.current;
+      if (!tooltip) return;
+
+      if (intersects.length > 0) {
+        const idx = markerMeshes.indexOf(intersects[0].object as THREE.Mesh);
+        if (idx >= 0) {
+          const d = markerData[idx];
+          tooltip.textContent = `${d.name}  ${formatYen(d.spending)}  (${d.projectCount}事業)`;
+          tooltip.style.display = 'block';
+          tooltip.style.left = `${event.clientX - rect.left + 12}px`;
+          tooltip.style.top = `${event.clientY - rect.top - 8}px`;
+          container.style.cursor = 'pointer';
+          return;
+        }
+      }
+      tooltip.style.display = 'none';
+      container.style.cursor = 'grab';
+    }
+    container.addEventListener('mousemove', onMouseMove);
+
+    // Click handler — log to console
+    function onClick(event: MouseEvent) {
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObjects(markerMeshes);
+      if (intersects.length > 0) {
+        const idx = markerMeshes.indexOf(intersects[0].object as THREE.Mesh);
+        if (idx >= 0) {
+          const d = markerData[idx];
+          console.log(`[Globe] ${d.name}: ${formatYen(d.spending)} (${d.projectCount}事業)`);
+        }
+      }
+    }
+    container.addEventListener('click', onClick);
 
     // Animation loop
     let animationId: number;
@@ -87,6 +239,7 @@ export default function GlobeView() {
       // Slow auto-rotation
       sphere.rotation.y += delta * 0.05;
       wireLines.rotation.y = sphere.rotation.y;
+      markersGroup.rotation.y = sphere.rotation.y;
 
       controls.update();
       renderer.render(scene, camera);
@@ -107,21 +260,37 @@ export default function GlobeView() {
     // Cleanup
     return () => {
       window.removeEventListener('resize', onResize);
+      container.removeEventListener('mousemove', onMouseMove);
+      container.removeEventListener('click', onClick);
       cancelAnimationFrame(animationId);
       controls.dispose();
       renderer.dispose();
-      sphereGeom.dispose();
-      sphereMat.dispose();
-      wireGeom.dispose();
-      wireMat.dispose();
+      for (const d of disposables) d.dispose();
       container.removeChild(renderer.domElement);
     };
-  }, []);
+  }, [data]);
 
   return (
-    <div
-      ref={containerRef}
-      style={{ width: '100%', height: '100%', background: '#000' }}
-    />
+    <div style={{ width: '100%', height: '100%', background: '#000', position: 'relative' }}>
+      <div
+        ref={containerRef}
+        style={{ width: '100%', height: '100%' }}
+      />
+      <div
+        ref={tooltipRef}
+        style={{
+          display: 'none',
+          position: 'absolute',
+          pointerEvents: 'none',
+          background: 'rgba(0, 0, 0, 0.85)',
+          color: '#fff',
+          padding: '6px 10px',
+          borderRadius: '4px',
+          fontSize: '13px',
+          whiteSpace: 'nowrap',
+          zIndex: 10,
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- `/api/map/globe` API: 37省庁の totalSpending, areaFraction, projectCount を算出し、Fibonacci格子で球面座標を付与
- GlobeView: 面積比例サイズのマーカードット + 省庁名ラベルを球面上に描画
- ホバーでツールチップ（省庁名・金額・事業数）、クリックでコンソール出力
- 省庁ごとにHSL色相を37分割で割り当て

## Test plan
- [ ] `/globe` に37個の色付きマーカーが表示される
- [ ] 各マーカーに省庁名が読める
- [ ] ホバーでツールチップが表示される
- [ ] `/api/map/globe` が正しいJSONを返す
- [ ] `npm run build` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an interactive 3D globe visualization displaying ministry data including spending amounts and project counts
  * Added hover tooltips showing ministry details when interacting with globe markers
  * Implemented click functionality on ministry markers for enhanced interactivity
  * Globe markers dynamically rotate with the sphere for seamless 3D experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->