### PR TITLE
/sankey Global View: 自前SVG + 事前計算レイアウト移行

### DIFF
--- a/app/lib/sankey-generator.ts
+++ b/app/lib/sankey-generator.ts
@@ -16,6 +16,22 @@ let cachedMOFData: MOFFundingData | null = null;
 const resultCache = new Map<string, RS2024PresetData>();
 const CACHE_SIZE_LIMIT = 100;
 
+// Cache for Global View common computation (shared across spendingDrilldownLevel)
+interface GlobalBaseCache {
+  topMinistries: Array<{ name: string; id: number; totalBudget: number; bureauCount: number }>;
+  otherMinistriesBudget: number;
+  otherMinistriesSpending: number;
+  projectsFromSelectedMinistries: BudgetRecord[];
+  allRecipients: SpendingRecord[];
+  recipientSpendingFromSelectedMinistries: Map<number, number>;
+  totalFilteredRecipients: number;
+  // Reverse index: projectId → [{spendingId, amount}]
+  projectToSpendings: Map<number, Array<{ spendingId: number; amount: number }>>;
+  // Cached otherNamedSpendingByProject (same for all levels)
+  otherNamedSpendingByProject: Map<number, number>;
+}
+let globalBaseCache: { key: string; value: GlobalBaseCache } | null = null;
+
 interface GenerateOptions {
   ministryOffset?: number;
   projectOffset?: number; // Deprecated: use projectDrilldownLevel instead
@@ -268,6 +284,8 @@ interface DataSelection {
   // Global View スライダー用
   totalFilteredRecipients?: number; // フィルタ後の支出先総数（"その他"除外）
   allRecipientsForClient?: RecipientSummary[]; // クライアント側ページング用の全支出先データ
+  recipientSpendingFromSelectedMinistries?: Map<number, number>; // spendingId → 選択府省庁からの支出額
+  allSortedRecipientIds?: number[]; // 全支出先のspendingId（支出額降順ソート済み）
 
   // Ministry View用
   ministryTotalProjects?: number; // 選択した府省庁の総事業数
@@ -327,6 +345,8 @@ function selectData(
   // Global View スライダー用
   let totalFilteredRecipients: number | undefined = undefined;
   let allRecipientsForClient: RecipientSummary[] | undefined = undefined;
+  let recipientSpendingFromSelectedMinistries: Map<number, number> | undefined = undefined;
+  let allSortedRecipientIds: number[] | undefined = undefined;
 
   if (targetRecipientName) {
     // --- Spending View (Reverse Flow) ---
@@ -500,95 +520,155 @@ function selectData(
     // --- Global View ---
     // IMPORTANT: Select ministries FIRST, then filter projects and spendings based on selected ministries
 
-    // 1. Select TopN ministries (not all ministries)
-    const allMinistries = data.budgetTree.ministries
-      .sort((a, b) => b.totalBudget - a.totalBudget);
+    // Cache key for the common computation (independent of spendingDrilldownLevel)
+    const globalBaseCacheKey = `${offset}:${limit}:${drilldownLevel}`;
 
-    if (drilldownLevel > 0) {
-      // Drilldown mode: show ministries EXCLUDING previously shown TopN
-      // Level 1: Exclude Top10, show Top11-20
-      // Level 2: Exclude Top10 & Top11-20, show Top21-30
-      const excludeCount = limit * drilldownLevel;
-      const excludedMinistries = allMinistries.slice(0, excludeCount);
-      const remainingMinistries = allMinistries.slice(excludeCount);
+    let base: GlobalBaseCache;
 
-      // Take next 'limit' ministries from remainingMinistries (offset is already applied via excludeCount)
-      topMinistries = remainingMinistries.slice(0, limit).map(m => ({
-        name: m.name,
-        id: m.id,
-        totalBudget: m.totalBudget,
-        bureauCount: m.bureaus.length,
-      }));
-
-      // "Other Ministries" in this mode only includes ministries beyond current page
-      // (not the original excluded TopN)
-      const afterPage = remainingMinistries.slice(limit);
-      otherMinistriesBudget = afterPage.reduce((sum, m) => sum + m.totalBudget, 0);
-
-      // Calculate spending for "other" (only afterPage)
-      for (const ministry of afterPage) {
-        const ministryStats = data.statistics.byMinistry[ministry.name];
-        if (ministryStats) {
-          otherMinistriesSpending += ministryStats.totalSpending;
-        }
-      }
+    if (globalBaseCache && globalBaseCache.key === globalBaseCacheKey) {
+      // Cache hit: reuse expensive computation
+      base = globalBaseCache.value;
     } else {
-      // Normal mode: show TopN ministries
-      // Use 'limit' parameter for ministry selection (default: 3)
-      topMinistries = allMinistries.slice(0, limit).map(m => ({
-        name: m.name,
-        id: m.id,
-        totalBudget: m.totalBudget,
-        bureauCount: m.bureaus.length,
-      }));
+      // Cache miss: compute from scratch
 
-      // Calculate "Other Ministries" budget and spending
-      const otherMinistries = allMinistries.slice(limit);
-      otherMinistriesBudget = otherMinistries.reduce((sum, m) => sum + m.totalBudget, 0);
+      // 1. Select TopN ministries (not all ministries)
+      const allMinistries = data.budgetTree.ministries
+        .sort((a, b) => b.totalBudget - a.totalBudget);
 
-      // Calculate other ministries spending
-      for (const ministry of otherMinistries) {
-        const ministryStats = data.statistics.byMinistry[ministry.name];
-        if (ministryStats) {
-          otherMinistriesSpending += ministryStats.totalSpending;
+      let baseTopMinistries: GlobalBaseCache['topMinistries'];
+      let baseOtherMinistriesBudget = 0;
+      let baseOtherMinistriesSpending = 0;
+
+      if (drilldownLevel > 0) {
+        const excludeCount = limit * drilldownLevel;
+        const remainingMinistries = allMinistries.slice(excludeCount);
+
+        baseTopMinistries = remainingMinistries.slice(0, limit).map(m => ({
+          name: m.name,
+          id: m.id,
+          totalBudget: m.totalBudget,
+          bureauCount: m.bureaus.length,
+        }));
+
+        const afterPage = remainingMinistries.slice(limit);
+        baseOtherMinistriesBudget = afterPage.reduce((sum, m) => sum + m.totalBudget, 0);
+
+        for (const ministry of afterPage) {
+          const ministryStats = data.statistics.byMinistry[ministry.name];
+          if (ministryStats) {
+            baseOtherMinistriesSpending += ministryStats.totalSpending;
+          }
+        }
+      } else {
+        baseTopMinistries = allMinistries.slice(0, limit).map(m => ({
+          name: m.name,
+          id: m.id,
+          totalBudget: m.totalBudget,
+          bureauCount: m.bureaus.length,
+        }));
+
+        const otherMinistries = allMinistries.slice(limit);
+        baseOtherMinistriesBudget = otherMinistries.reduce((sum, m) => sum + m.totalBudget, 0);
+
+        for (const ministry of otherMinistries) {
+          const ministryStats = data.statistics.byMinistry[ministry.name];
+          if (ministryStats) {
+            baseOtherMinistriesSpending += ministryStats.totalSpending;
+          }
         }
       }
-    }
 
-    // 2. Filter projects to only those from selected ministries
-    const selectedMinistryNames = new Set(topMinistries.map(m => m.name));
-    const projectsFromSelectedMinistries = data.budgets.filter(b =>
-      selectedMinistryNames.has(b.ministry)
-    );
+      // 2. Filter projects to only those from selected ministries
+      const selectedMinistryNames = new Set(baseTopMinistries.map(m => m.name));
+      const baseProjectsFromSelectedMinistries = data.budgets.filter(b =>
+        selectedMinistryNames.has(b.ministry)
+      );
 
-    // 3. Select Top N Recipients (excluding "その他") based on spending from selected ministries
-    // Calculate spending per recipient from selected ministries only
-    const recipientSpendingFromSelectedMinistries = new Map<number, number>();
-    for (const spending of data.spendings) {
-      if (spending.spendingName === 'その他') continue;
+      // 3. Select Top N Recipients (excluding "その他") based on spending from selected ministries
+      const baseRecipientSpending = new Map<number, number>();
+      for (const spending of data.spendings) {
+        if (spending.spendingName === 'その他') continue;
 
-      let totalFromSelected = 0;
-      for (const project of spending.projects) {
-        const budgetRecord = projectsFromSelectedMinistries.find(b => b.projectId === project.projectId);
-        if (budgetRecord) {
-          totalFromSelected += project.amount;
+        let totalFromSelected = 0;
+        for (const project of spending.projects) {
+          const budgetRecord = baseProjectsFromSelectedMinistries.find(b => b.projectId === project.projectId);
+          if (budgetRecord) {
+            totalFromSelected += project.amount;
+          }
+        }
+        if (totalFromSelected > 0) {
+          baseRecipientSpending.set(spending.spendingId, totalFromSelected);
         }
       }
-      if (totalFromSelected > 0) {
-        recipientSpendingFromSelectedMinistries.set(spending.spendingId, totalFromSelected);
+
+      const baseAllRecipients = data.spendings
+        .filter(s => baseRecipientSpending.has(s.spendingId))
+        .sort((a, b) => {
+          const aSpending = baseRecipientSpending.get(a.spendingId) || 0;
+          const bSpending = baseRecipientSpending.get(b.spendingId) || 0;
+          return bSpending - aSpending;
+        });
+
+      // Build reverse index: projectId → [{spendingId, amount}]
+      const baseProjectToSpendings = new Map<number, Array<{ spendingId: number; amount: number }>>();
+      for (const spending of data.spendings) {
+        for (const p of spending.projects) {
+          let arr = baseProjectToSpendings.get(p.projectId);
+          if (!arr) {
+            arr = [];
+            baseProjectToSpendings.set(p.projectId, arr);
+          }
+          arr.push({ spendingId: spending.spendingId, amount: p.amount });
+        }
       }
+
+      // Pre-compute otherNamedSpendingByProject (same for all levels)
+      const baseOtherNamedSpendingByProject = new Map<number, number>();
+      const spendingLookup = new Map(data.spendings.map(s => [s.spendingId, s]));
+      for (const project of data.budgets) {
+        let otherNamedTotal = 0;
+        const entries = baseProjectToSpendings.get(project.projectId);
+        if (entries) {
+          for (const entry of entries) {
+            const spending = spendingLookup.get(entry.spendingId);
+            if (spending && spending.spendingName === 'その他') {
+              const directAmount = spending.projects
+                .filter(p => p.projectId === project.projectId && p.isDirectFromGov !== false)
+                .reduce((sum, p) => sum + p.amount, 0);
+              otherNamedTotal += directAmount;
+            }
+          }
+        }
+        if (otherNamedTotal > 0) {
+          baseOtherNamedSpendingByProject.set(project.projectId, otherNamedTotal);
+        }
+      }
+
+      base = {
+        topMinistries: baseTopMinistries,
+        otherMinistriesBudget: baseOtherMinistriesBudget,
+        otherMinistriesSpending: baseOtherMinistriesSpending,
+        projectsFromSelectedMinistries: baseProjectsFromSelectedMinistries,
+        allRecipients: baseAllRecipients,
+        recipientSpendingFromSelectedMinistries: baseRecipientSpending,
+        totalFilteredRecipients: baseAllRecipients.length,
+        projectToSpendings: baseProjectToSpendings,
+        otherNamedSpendingByProject: baseOtherNamedSpendingByProject,
+      };
+
+      globalBaseCache = { key: globalBaseCacheKey, value: base };
     }
 
-    // Sort recipients by spending from selected ministries
-    const allRecipients = data.spendings
-      .filter(s => recipientSpendingFromSelectedMinistries.has(s.spendingId))
-      .sort((a, b) => {
-        const aSpending = recipientSpendingFromSelectedMinistries.get(a.spendingId) || 0;
-        const bSpending = recipientSpendingFromSelectedMinistries.get(b.spendingId) || 0;
-        return bSpending - aSpending;
-      });
-
-    totalFilteredRecipients = allRecipients.length;
+    // Apply cached base values
+    topMinistries = base.topMinistries;
+    otherMinistriesBudget = base.otherMinistriesBudget;
+    otherMinistriesSpending = base.otherMinistriesSpending;
+    const projectsFromSelectedMinistries = base.projectsFromSelectedMinistries;
+    const allRecipients = base.allRecipients;
+    recipientSpendingFromSelectedMinistries = base.recipientSpendingFromSelectedMinistries;
+    allSortedRecipientIds = allRecipients.map(s => s.spendingId);
+    totalFilteredRecipients = base.totalFilteredRecipients;
+    const projectToSpendings = base.projectToSpendings;
 
     // Build lightweight recipient data for client-side paging
     const topProjectIds = new Set(topProjects.map(p => p.projectId));
@@ -632,7 +712,7 @@ function selectData(
       const cumulativeRecipients = allRecipients.slice(0, cumulativeEndIndex);
       cumulativeSpendings = cumulativeRecipients; // Store for later use
       top10SpendingTotal = cumulativeRecipients.reduce((sum, r) => {
-        return sum + (recipientSpendingFromSelectedMinistries.get(r.spendingId) || 0);
+        return sum + (recipientSpendingFromSelectedMinistries!.get(r.spendingId) || 0);
       }, 0);
 
       // Calculate cumulative projects (projects that contributed to cumulativeRecipients)
@@ -640,15 +720,12 @@ function selectData(
       const projectSpendingToCumulative = new Map<number, number>();
 
       for (const project of projectsFromSelectedMinistries) {
+        const entries = projectToSpendings.get(project.projectId);
+        if (!entries) continue;
         let spendingToCumulative = 0;
-        const projectSpendings = data.spendings.filter(s =>
-          s.projects.some(p => p.projectId === project.projectId)
-        );
-        for (const spending of projectSpendings) {
-          if (cumulativeRecipientIds.has(spending.spendingId)) {
-            spendingToCumulative += spending.projects
-              .filter(p => p.projectId === project.projectId)
-              .reduce((sum, p) => sum + p.amount, 0);
+        for (const entry of entries) {
+          if (cumulativeRecipientIds.has(entry.spendingId)) {
+            spendingToCumulative += entry.amount;
           }
         }
         if (spendingToCumulative > 0) {
@@ -678,15 +755,12 @@ function selectData(
     // Calculate each project's spending to top recipients
     const projectSpendingToTopRecipients = new Map<number, number>();
     for (const project of projectSource) {
+      const entries = projectToSpendings.get(project.projectId);
+      if (!entries) continue;
       let spendingToTop = 0;
-      const projectSpendings = data.spendings.filter(s =>
-        s.projects.some(p => p.projectId === project.projectId)
-      );
-      for (const spending of projectSpendings) {
-        if (topRecipientIds.has(spending.spendingId)) {
-          spendingToTop += spending.projects
-            .filter(p => p.projectId === project.projectId)
-            .reduce((sum, p) => sum + p.amount, 0);
+      for (const entry of entries) {
+        if (topRecipientIds.has(entry.spendingId)) {
+          spendingToTop += entry.amount;
         }
       }
       if (spendingToTop > 0) {
@@ -724,6 +798,11 @@ function selectData(
         otherProjectsSpendingByMinistry.set(ministry.name, otherSpending);
       }
     }
+
+    // Populate otherNamedSpendingByProject from cache (avoids O(N×M) recomputation)
+    for (const [k, v] of base.otherNamedSpendingByProject) {
+      otherNamedSpendingByProject.set(k, v);
+    }
   }
 
   // --- Common Logic for Spendings (except for Spending View which is handled above) ---
@@ -732,7 +811,8 @@ function selectData(
   // In Project View, we need to select top spendings for the single project.
 
   // Aggregate "Other" named spendings (all views except Recipient View)
-  if (!targetRecipientName) {
+  // For Global View, this is pre-computed in GlobalBaseCache — skip if already populated
+  if (!targetRecipientName && otherNamedSpendingByProject.size === 0) {
     for (const project of data.budgets) {
       const projectSpendings = data.spendings
         .filter(s => project.spendingIds.includes(s.spendingId))
@@ -895,6 +975,8 @@ function selectData(
     ministryTotalProjects,
     totalFilteredRecipients,
     allRecipientsForClient,
+    recipientSpendingFromSelectedMinistries,
+    allSortedRecipientIds,
     spendingDrilldownLevel,
     top10SpendingTotal,
     cumulativeSpendings,
@@ -941,6 +1023,9 @@ function buildSankeyData(
 
   const nodes: SankeyNode[] = [];
   const links: SankeyLink[] = [];
+
+  // Lookup map: spendingId → SpendingRecord (avoids O(N) fullData.spendings.find per lookup)
+  const spendingById = new Map(fullData.spendings.map(s => [s.spendingId, s]));
 
   // --- SPENDING VIEW (Reverse Flow with Budget) ---
   if (targetRecipientName) {
@@ -2275,49 +2360,20 @@ function buildSankeyData(
     // Strategy: Calculate total spending to recipients BEYOND the current drilldown threshold
     // This means excluding recipients from position 0 to (spendingDrilldownLevel + 1) * spendingLimit
 
-    // First, rebuild the full sorted recipient list to get all recipients up to current threshold
-    const selectedMinistryNames = new Set(topMinistries.map(m => m.name));
-    const recipientSpendingFromSelectedMinistries = new Map<number, number>();
-
-    for (const spending of fullData.spendings) {
-      let totalFromSelected = 0;
-      for (const project of spending.projects) {
-        const budgetRecord = fullData.budgets.find((b: { projectId: number }) => b.projectId === project.projectId);
-        if (budgetRecord && selectedMinistryNames.has(budgetRecord.ministry)) {
-          totalFromSelected += project.amount;
-        }
-      }
-      if (totalFromSelected > 0) {
-        recipientSpendingFromSelectedMinistries.set(spending.spendingId, totalFromSelected);
-      }
-    }
-
-    // Sort all recipients by spending amount (same order as in selectData)
-    const allSortedRecipients = fullData.spendings
-      .filter(s => recipientSpendingFromSelectedMinistries.has(s.spendingId))
-      .sort((a, b) => {
-        const aSpending = recipientSpendingFromSelectedMinistries.get(a.spendingId) || 0;
-        const bSpending = recipientSpendingFromSelectedMinistries.get(b.spendingId) || 0;
-        return bSpending - aSpending;
-      });
+    // Use pre-computed data from selectData (avoids O(N²) recomputation and O(N log N) re-sort)
+    const recipientSpendingMap = selection.recipientSpendingFromSelectedMinistries ?? new Map<number, number>();
+    const sortedIds = selection.allSortedRecipientIds ?? [];
 
     // Calculate the threshold: exclude all recipients from 0 to (spendingDrilldownLevel + 1) * spendingLimit
     const excludeUpToIndex = (spendingDrilldownLevel + 1) * spendingLimit;
-    const excludedRecipients = allSortedRecipients.slice(0, excludeUpToIndex);
-    const excludedRecipientIds = new Set(excludedRecipients.map(s => s.spendingId));
+    const excludedRecipientIds = new Set(sortedIds.slice(0, excludeUpToIndex));
 
     // Calculate total spending to "Other Recipients" (beyond current threshold)
-    // Include spending from both Top Projects and Other Projects
-    for (const spending of allSortedRecipients) {
-      // Skip if this recipient is within the excluded range (0 to current threshold)
-      if (excludedRecipientIds.has(spending.spendingId)) continue;
-
-      // Skip "その他" (handled separately)
-      if (spending.spendingName === 'その他') continue;
-
-      // Sum up all spending to this recipient from selected ministries
-      const spendingAmount = recipientSpendingFromSelectedMinistries.get(spending.spendingId) || 0;
-      totalOtherRecipientAmount += spendingAmount;
+    for (let i = excludeUpToIndex; i < sortedIds.length; i++) {
+      const id = sortedIds[i];
+      const s = spendingById.get(id);
+      if (!s || s.spendingName === 'その他') continue;
+      totalOtherRecipientAmount += recipientSpendingMap.get(id) || 0;
     }
 
     // Store the breakdown by project for linking purposes
@@ -2326,7 +2382,7 @@ function buildSankeyData(
       let projectTotalToOthers = 0;
 
       for (const spendingId of project.spendingIds) {
-        const spending = fullData.spendings.find(s => s.spendingId === spendingId);
+        const spending = spendingById.get(spendingId);
         if (!spending) continue;
 
         // Skip excluded recipients and "その他"
@@ -2400,16 +2456,8 @@ function buildSankeyData(
             .reduce((sum, p) => sum + p.amount, 0);
         }
 
-        // Calculate total spending from selected ministries only (not all ministries)
-        const selectedMinistryNames = new Set(topMinistries.map(m => m.name));
-        let totalFromSelectedMinistries = 0;
-        for (const spendingProject of recipient.projects) {
-          // Only count if project is from selected ministries
-          const projectInData = fullData.budgets.find((b: { projectId: number; ministry: string }) => b.projectId === spendingProject.projectId);
-          if (projectInData && selectedMinistryNames.has(projectInData.ministry)) {
-            totalFromSelectedMinistries += spendingProject.amount;
-          }
-        }
+        // Use pre-computed map from selectData (avoids O(N) budgets.find per recipient)
+        const totalFromSelectedMinistries = selection.recipientSpendingFromSelectedMinistries?.get(recipient.spendingId) ?? 0;
 
         const remainder = totalFromSelectedMinistries - receivedFromTopProjects;
         if (remainder > 0 && otherProjectsSpendingNode) {

--- a/app/lib/sankey-generator.ts
+++ b/app/lib/sankey-generator.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type { RS2024StructuredData, BudgetRecord, SpendingRecord, MOFFundingData, FundingSources } from '@/types/structured';
 import type {
   RS2024PresetData,
+  RecipientSummary,
   SankeyNode,
   SankeyLink,
 } from '@/types/preset';
@@ -234,6 +235,7 @@ export async function generateSankeyData(options: GenerateOptions = {}): Promise
       },
     },
     sankey: sankeyData,
+    allRecipients: selection.allRecipientsForClient,
   };
 
   // Update cache
@@ -265,6 +267,7 @@ interface DataSelection {
 
   // Global View スライダー用
   totalFilteredRecipients?: number; // フィルタ後の支出先総数（"その他"除外）
+  allRecipientsForClient?: RecipientSummary[]; // クライアント側ページング用の全支出先データ
 
   // Ministry View用
   ministryTotalProjects?: number; // 選択した府省庁の総事業数
@@ -323,6 +326,7 @@ function selectData(
 
   // Global View スライダー用
   let totalFilteredRecipients: number | undefined = undefined;
+  let allRecipientsForClient: RecipientSummary[] | undefined = undefined;
 
   if (targetRecipientName) {
     // --- Spending View (Reverse Flow) ---
@@ -585,6 +589,35 @@ function selectData(
       });
 
     totalFilteredRecipients = allRecipients.length;
+
+    // Build lightweight recipient data for client-side paging
+    const topProjectIds = new Set(topProjects.map(p => p.projectId));
+    allRecipientsForClient = allRecipients.map(s => {
+      const projects: RecipientSummary['projects'] = [];
+      for (const sp of s.projects) {
+        if (!topProjectIds.has(sp.projectId)) continue;
+        // In ministry drilldown, further filter by selected ministries
+        if (drilldownLevel > 0) {
+          const budgetRecord = projectsFromSelectedMinistries.find(b => b.projectId === sp.projectId);
+          if (!budgetRecord) continue;
+        }
+        projects.push({
+          projectId: sp.projectId,
+          amount: sp.amount,
+          contractMethod: sp.contractMethod || undefined,
+          blockName: sp.blockName || undefined,
+        });
+      }
+      return {
+        spendingId: s.spendingId,
+        spendingName: s.spendingName,
+        corporateNumber: s.corporateNumber,
+        location: s.location,
+        projectCount: s.projectCount,
+        tags: s.tags,
+        projects,
+      };
+    });
 
     // Apply spending drilldown if enabled
     const topRecipients = allRecipients.slice(spendingOffset, spendingOffset + spendingLimit);
@@ -861,6 +894,7 @@ function selectData(
     hasMoreProjects,
     ministryTotalProjects,
     totalFilteredRecipients,
+    allRecipientsForClient,
     spendingDrilldownLevel,
     top10SpendingTotal,
     cumulativeSpendings,

--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -57,9 +57,8 @@ function SankeyContent() {
     subcontracts?: { name: string; amount: number; flowType: string }[];
   } | null>(null);
 
-  // Client-side cache for prefetched spending drilldown pages (Global View)
-  const spendingPageCache = useRef<Map<string, RS2024PresetData>>(new Map());
-  const prefetchAbortRef = useRef<AbortController | null>(null);
+  // Global View: base data (level 0) with allRecipients for client-side paging
+  const globalBaseData = useRef<RS2024PresetData | null>(null);
 
   // Sync state from URL parameters (runs on mount and whenever URL changes via browser back/forward)
   useEffect(() => {
@@ -140,38 +139,169 @@ function SankeyContent() {
     loadStructuredData();
   }, []);
 
-  // Build Global View API params for a given spendingDrilldownLevel
-  const buildGlobalParams = useCallback((spendingLevel: number) => {
-    const params = new URLSearchParams();
-    params.set('limit', topNSettings.global.ministry.toString());
-    params.set('projectLimit', '3');
-    params.set('spendingLimit', topNSettings.global.spending.toString());
-    params.set('subcontractLimit', topNSettings.global.subcontract.toString());
-    params.set('drilldownLevel', viewState.drilldownLevel.toString());
-    params.set('spendingDrilldownLevel', spendingLevel.toString());
-    return params.toString();
-  }, [topNSettings, viewState.drilldownLevel]);
+  // Build sankey data with client-side recipient paging for Global View
+  const buildGlobalSankeyForLevel = useCallback((base: RS2024PresetData, level: number): RS2024PresetData => {
+    if (level === 0 || !base.allRecipients) return base;
+
+    const spendingLimit = topNSettings.global.spending || 10;
+    const offset = level * spendingLimit;
+    const pageRecipients = base.allRecipients.slice(offset, offset + spendingLimit);
+
+    // Remove existing recipient nodes/links from base sankey
+    const baseNodes = base.sankey.nodes.filter(n =>
+      n.type !== 'recipient' && n.type !== 'subcontract-recipient'
+    );
+    const recipientNodeIds = new Set(base.sankey.nodes.filter(n => n.type === 'recipient' || n.type === 'subcontract-recipient').map(n => n.id));
+    const baseLinks = base.sankey.links.filter(l =>
+      !recipientNodeIds.has(l.target) && l.target !== 'recipient-other-aggregated' && l.target !== 'recipient-other-named' && l.target !== 'recipient-top10-summary'
+    );
+
+    // Also remove "recipient-other-aggregated", "recipient-other-named", "recipient-top10-summary" from baseNodes
+    const filteredBaseNodes = baseNodes.filter(n =>
+      n.id !== 'recipient-other-aggregated' && n.id !== 'recipient-other-named' && n.id !== 'recipient-top10-summary'
+    );
+
+    // Build new recipient nodes
+    const newNodes = [...filteredBaseNodes];
+    const newLinks = [...baseLinks];
+    const topProjectIds = new Set(base.sankey.nodes.filter(n => n.type === 'project-spending').map(n => n.originalId));
+
+    // "支出先(Top{prev})" summary node for cumulative
+    const prevEnd = level * spendingLimit;
+    const prevRecipients = base.allRecipients.slice(0, prevEnd);
+    const prevTotal = prevRecipients.reduce((sum, r) => r.projects.reduce((acc, p) => acc + p.amount, sum), 0);
+
+    newNodes.push({
+      id: 'recipient-top10-summary',
+      name: `支出先\n(Top${prevEnd})`,
+      type: 'recipient',
+      value: prevTotal || 0.001,
+      details: { corporateNumber: '', location: '', projectCount: prevEnd, actualValue: prevTotal },
+    });
+
+    // Add cumulative link from "project-spending-cumulative" if it exists
+    const cumulativeNode = filteredBaseNodes.find(n => n.id === 'project-spending-cumulative');
+    if (cumulativeNode) {
+      newLinks.push({
+        source: 'project-spending-cumulative',
+        target: 'recipient-top10-summary',
+        value: 0.001,
+      });
+    }
+
+    // Current page recipient nodes + links
+    for (const r of pageRecipients) {
+      const spendingFromTopProjects = r.projects
+        .filter(p => topProjectIds.has(p.projectId))
+        .reduce((sum, p) => sum + p.amount, 0);
+
+      newNodes.push({
+        id: `recipient-${r.spendingId}`,
+        name: r.spendingName,
+        type: 'recipient',
+        value: spendingFromTopProjects,
+        originalId: r.spendingId,
+        details: {
+          corporateNumber: r.corporateNumber,
+          location: r.location,
+          projectCount: r.projectCount,
+          tags: r.tags,
+        },
+      });
+
+      for (const p of r.projects) {
+        if (!topProjectIds.has(p.projectId)) continue;
+        newLinks.push({
+          source: `project-spending-${p.projectId}`,
+          target: `recipient-${r.spendingId}`,
+          value: p.amount,
+          details: {
+            contractMethod: p.contractMethod,
+            blockName: p.blockName,
+          },
+        });
+      }
+    }
+
+    // "その他" named spending node (from base level 0 data)
+    const otherNamedNode = base.sankey.nodes.find(n => n.id === 'recipient-other-named');
+    if (otherNamedNode) {
+      newNodes.push(otherNamedNode);
+      // Copy links to this node from base
+      for (const l of base.sankey.links) {
+        if (l.target === 'recipient-other-named') newLinks.push(l);
+      }
+    }
+
+    // "支出先(TopN以外)" aggregated node
+    const excludeUpTo = (level + 1) * spendingLimit;
+    const remainingRecipients = base.allRecipients.slice(excludeUpTo);
+    const totalOtherAmount = remainingRecipients.reduce((sum, r) =>
+      r.projects.filter(p => topProjectIds.has(p.projectId)).reduce((acc, p) => acc + p.amount, sum), 0);
+
+    if (totalOtherAmount > 0) {
+      newNodes.push({
+        id: 'recipient-other-aggregated',
+        name: `支出先\n(Top${excludeUpTo}以外)`,
+        type: 'recipient',
+        value: totalOtherAmount,
+      });
+
+      // Links from each top project to "other aggregated"
+      for (const projectNode of base.sankey.nodes.filter(n => n.type === 'project-spending' && n.originalId)) {
+        let projectToOther = 0;
+        for (const r of remainingRecipients) {
+          for (const p of r.projects) {
+            if (p.projectId === projectNode.originalId) projectToOther += p.amount;
+          }
+        }
+        if (projectToOther > 0) {
+          newLinks.push({
+            source: projectNode.id,
+            target: 'recipient-other-aggregated',
+            value: projectToOther,
+          });
+        }
+      }
+    }
+
+    return {
+      ...base,
+      sankey: { nodes: newNodes, links: newLinks },
+    };
+  }, [topNSettings.global.spending]);
 
   useEffect(() => {
     async function loadData() {
+      setLoading(true);
       try {
-        let params: URLSearchParams;
+        const params = new URLSearchParams();
 
         if (viewState.mode === 'global') {
-          const cacheKey = buildGlobalParams(viewState.spendingDrilldownLevel);
+          // For Global View, always fetch level 0 (base data with allRecipients)
+          // Then client-side generates the current level's recipient nodes
+          if (!globalBaseData.current || viewState.drilldownLevel !== (globalBaseData.current as RS2024PresetData & { _drilldownLevel?: number })._drilldownLevel) {
+            params.set('limit', topNSettings.global.ministry.toString());
+            params.set('projectLimit', '3');
+            params.set('spendingLimit', topNSettings.global.spending.toString());
+            params.set('subcontractLimit', topNSettings.global.subcontract.toString());
+            params.set('drilldownLevel', viewState.drilldownLevel.toString());
+            params.set('spendingDrilldownLevel', '0');
 
-          // Check client-side cache first
-          const cached = spendingPageCache.current.get(cacheKey);
-          if (cached) {
-            setData(cached);
-            return;
+            const response = await fetch(`/api/sankey?${params.toString()}`);
+            if (!response.ok) throw new Error('Failed to load data');
+            const json: RS2024PresetData = await response.json();
+            globalBaseData.current = json;
+            // Tag with drilldown level to invalidate when ministry drilldown changes
+            (globalBaseData.current as RS2024PresetData & { _drilldownLevel?: number })._drilldownLevel = viewState.drilldownLevel;
           }
 
-          setLoading(true);
-          params = new URLSearchParams(cacheKey);
+          // Generate sankey for current spending drilldown level client-side
+          const result = buildGlobalSankeyForLevel(globalBaseData.current, viewState.spendingDrilldownLevel);
+          setData(result);
         } else {
-          setLoading(true);
-          params = new URLSearchParams();
+          // Non-global views: standard API fetch
+          globalBaseData.current = null;
 
           if (viewState.mode === 'ministry' && viewState.selectedMinistry) {
             params.set('ministryName', viewState.selectedMinistry);
@@ -188,18 +318,11 @@ function SankeyContent() {
             params.set('limit', topNSettings.spending.ministry.toString());
             params.set('subcontractLimit', topNSettings.spending.subcontract.toString());
           }
-        }
 
-        const response = await fetch(`/api/sankey?${params.toString()}`);
-        if (!response.ok) {
-          throw new Error('Failed to load data');
-        }
-        const json: RS2024PresetData = await response.json();
-        setData(json);
-
-        // Cache Global View responses
-        if (viewState.mode === 'global') {
-          spendingPageCache.current.set(params.toString(), json);
+          const response = await fetch(`/api/sankey?${params.toString()}`);
+          if (!response.ok) throw new Error('Failed to load data');
+          const json: RS2024PresetData = await response.json();
+          setData(json);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
@@ -209,44 +332,7 @@ function SankeyContent() {
     }
 
     loadData();
-  }, [viewState, topNSettings, buildGlobalParams]);
-
-  // Prefetch all spending drilldown pages in background (Global View only)
-  useEffect(() => {
-    if (viewState.mode !== 'global' || !data?.metadata?.summary?.totalFilteredSpendings) return;
-
-    // Cancel any previous prefetch
-    prefetchAbortRef.current?.abort();
-    const controller = new AbortController();
-    prefetchAbortRef.current = controller;
-
-    const total = data.metadata.summary.totalFilteredSpendings;
-    const step = topNSettings.global.spending || 10;
-    const maxLevel = Math.ceil(total / step) - 1;
-
-    async function prefetchAll() {
-      for (let level = 0; level <= maxLevel; level++) {
-        if (controller.signal.aborted) return;
-        const cacheKey = buildGlobalParams(level);
-        if (spendingPageCache.current.has(cacheKey)) continue;
-
-        try {
-          const response = await fetch(`/api/sankey?${cacheKey}`, { signal: controller.signal });
-          if (response.ok) {
-            const json: RS2024PresetData = await response.json();
-            spendingPageCache.current.set(cacheKey, json);
-          }
-        } catch {
-          // Abort or network error — stop silently
-          return;
-        }
-      }
-    }
-
-    prefetchAll();
-
-    return () => { controller.abort(); };
-  }, [viewState.mode, data?.metadata?.summary?.totalFilteredSpendings, topNSettings.global.spending, buildGlobalParams]);
+  }, [viewState, topNSettings, buildGlobalSankeyForLevel]);
 
   // スマホ判定
   useEffect(() => {

--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -11,6 +11,7 @@ import SpendingListModal from '@/client/components/SpendingListModal';
 import ProjectDetailPanel from '@/client/components/ProjectDetailPanel';
 import SubcontractDetailDialog from '@/client/components/SubcontractDetailDialog';
 import RecipientRangeSlider from '@/client/components/RecipientRangeSlider';
+import SankeyGlobalView from '@/client/components/SankeyGlobalView';
 
 function SankeyContent() {
   const router = useRouter();
@@ -825,13 +826,27 @@ function SankeyContent() {
             style={isMobile ? { WebkitOverflowScrolling: 'touch' } : {}}
           >
             <div style={{ height: '800px', minWidth: isMobile ? '1200px' : 'auto', backgroundColor: 'white' }}>
+              {viewState.mode === 'global' ? (
+                <SankeyGlobalView
+                  data={sankey}
+                  width={isMobile ? 1200 : 1200}
+                  height={800}
+                  margin={{ top: 40, right: 100, bottom: 40, left: 100 }}
+                  hasSubcontractNodes={sankey.nodes.some(n => n.type === 'subcontract-recipient')}
+                  onNodeClick={handleNodeClick}
+                  formatCurrency={formatCurrency}
+                  getActualValue={getActualValue}
+                  viewState={viewState}
+                  topNSettings={topNSettings}
+                />
+              ) : (
               <ResponsiveSankey
                 data={sankey}
                 margin={isMobile
                   ? { top: 40, right: 100, bottom: 40, left: 100 }
                   : { top: 40, right: 100, bottom: 40, left: 100 }
                 }
-                align={(viewState.mode === 'global' || viewState.mode === 'ministry' || viewState.mode === 'project') && sankey.nodes.some(n => n.type === 'subcontract-recipient') ? 'start' : 'justify'}
+                align={(viewState.mode === 'ministry' || viewState.mode === 'project') && sankey.nodes.some(n => n.type === 'subcontract-recipient') ? 'start' : 'justify'}
                 sort="input"
                 nodeInnerPadding={0}
                 colors={(node) => {
@@ -1249,6 +1264,7 @@ function SankeyContent() {
                   );
                 }}
               />
+              )}
             </div>
           </div>
 

--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ResponsiveSankey } from '@nivo/sankey';
 import type { RS2024PresetData } from '@/types/preset';
@@ -56,6 +56,10 @@ function SankeyContent() {
     furtherOutflows?: { name: string; amount: number; flowType: string }[];
     subcontracts?: { name: string; amount: number; flowType: string }[];
   } | null>(null);
+
+  // Client-side cache for prefetched spending drilldown pages (Global View)
+  const spendingPageCache = useRef<Map<string, RS2024PresetData>>(new Map());
+  const prefetchAbortRef = useRef<AbortController | null>(null);
 
   // Sync state from URL parameters (runs on mount and whenever URL changes via browser back/forward)
   useEffect(() => {
@@ -136,33 +140,54 @@ function SankeyContent() {
     loadStructuredData();
   }, []);
 
+  // Build Global View API params for a given spendingDrilldownLevel
+  const buildGlobalParams = useCallback((spendingLevel: number) => {
+    const params = new URLSearchParams();
+    params.set('limit', topNSettings.global.ministry.toString());
+    params.set('projectLimit', '3');
+    params.set('spendingLimit', topNSettings.global.spending.toString());
+    params.set('subcontractLimit', topNSettings.global.subcontract.toString());
+    params.set('drilldownLevel', viewState.drilldownLevel.toString());
+    params.set('spendingDrilldownLevel', spendingLevel.toString());
+    return params.toString();
+  }, [topNSettings, viewState.drilldownLevel]);
+
   useEffect(() => {
     async function loadData() {
-      setLoading(true);
       try {
-        const params = new URLSearchParams();
+        let params: URLSearchParams;
 
         if (viewState.mode === 'global') {
-          params.set('limit', topNSettings.global.ministry.toString());
-          params.set('projectLimit', '3'); // Fixed for global view to avoid clutter
-          params.set('spendingLimit', topNSettings.global.spending.toString());
-          params.set('subcontractLimit', topNSettings.global.subcontract.toString());
-          params.set('drilldownLevel', viewState.drilldownLevel.toString());
-          params.set('spendingDrilldownLevel', viewState.spendingDrilldownLevel.toString());
-        } else if (viewState.mode === 'ministry' && viewState.selectedMinistry) {
-          params.set('ministryName', viewState.selectedMinistry);
-          params.set('projectLimit', topNSettings.ministry.project.toString());
-          params.set('spendingLimit', topNSettings.ministry.spending.toString());
-          params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
-        } else if (viewState.mode === 'project' && viewState.selectedProject) {
-          params.set('projectName', viewState.selectedProject);
-          params.set('spendingLimit', topNSettings.project.spending.toString());
-        } else if (viewState.mode === 'spending' && viewState.selectedRecipient) {
-          params.set('recipientName', viewState.selectedRecipient);
-          params.set('projectLimit', topNSettings.spending.project.toString());
-          params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
-          params.set('limit', topNSettings.spending.ministry.toString());
-          params.set('subcontractLimit', topNSettings.spending.subcontract.toString());
+          const cacheKey = buildGlobalParams(viewState.spendingDrilldownLevel);
+
+          // Check client-side cache first
+          const cached = spendingPageCache.current.get(cacheKey);
+          if (cached) {
+            setData(cached);
+            return;
+          }
+
+          setLoading(true);
+          params = new URLSearchParams(cacheKey);
+        } else {
+          setLoading(true);
+          params = new URLSearchParams();
+
+          if (viewState.mode === 'ministry' && viewState.selectedMinistry) {
+            params.set('ministryName', viewState.selectedMinistry);
+            params.set('projectLimit', topNSettings.ministry.project.toString());
+            params.set('spendingLimit', topNSettings.ministry.spending.toString());
+            params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
+          } else if (viewState.mode === 'project' && viewState.selectedProject) {
+            params.set('projectName', viewState.selectedProject);
+            params.set('spendingLimit', topNSettings.project.spending.toString());
+          } else if (viewState.mode === 'spending' && viewState.selectedRecipient) {
+            params.set('recipientName', viewState.selectedRecipient);
+            params.set('projectLimit', topNSettings.spending.project.toString());
+            params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
+            params.set('limit', topNSettings.spending.ministry.toString());
+            params.set('subcontractLimit', topNSettings.spending.subcontract.toString());
+          }
         }
 
         const response = await fetch(`/api/sankey?${params.toString()}`);
@@ -171,6 +196,11 @@ function SankeyContent() {
         }
         const json: RS2024PresetData = await response.json();
         setData(json);
+
+        // Cache Global View responses
+        if (viewState.mode === 'global') {
+          spendingPageCache.current.set(params.toString(), json);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
@@ -179,7 +209,44 @@ function SankeyContent() {
     }
 
     loadData();
-  }, [viewState, topNSettings]);
+  }, [viewState, topNSettings, buildGlobalParams]);
+
+  // Prefetch all spending drilldown pages in background (Global View only)
+  useEffect(() => {
+    if (viewState.mode !== 'global' || !data?.metadata?.summary?.totalFilteredSpendings) return;
+
+    // Cancel any previous prefetch
+    prefetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    prefetchAbortRef.current = controller;
+
+    const total = data.metadata.summary.totalFilteredSpendings;
+    const step = topNSettings.global.spending || 10;
+    const maxLevel = Math.ceil(total / step) - 1;
+
+    async function prefetchAll() {
+      for (let level = 0; level <= maxLevel; level++) {
+        if (controller.signal.aborted) return;
+        const cacheKey = buildGlobalParams(level);
+        if (spendingPageCache.current.has(cacheKey)) continue;
+
+        try {
+          const response = await fetch(`/api/sankey?${cacheKey}`, { signal: controller.signal });
+          if (response.ok) {
+            const json: RS2024PresetData = await response.json();
+            spendingPageCache.current.set(cacheKey, json);
+          }
+        } catch {
+          // Abort or network error — stop silently
+          return;
+        }
+      }
+    }
+
+    prefetchAll();
+
+    return () => { controller.abort(); };
+  }, [viewState.mode, data?.metadata?.summary?.totalFilteredSpendings, topNSettings.global.spending, buildGlobalParams]);
 
   // スマホ判定
   useEffect(() => {

--- a/app/sankey/page.tsx
+++ b/app/sankey/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ResponsiveSankey } from '@nivo/sankey';
 import type { RS2024PresetData } from '@/types/preset';
@@ -11,7 +11,7 @@ import SpendingListModal from '@/client/components/SpendingListModal';
 import ProjectDetailPanel from '@/client/components/ProjectDetailPanel';
 import SubcontractDetailDialog from '@/client/components/SubcontractDetailDialog';
 import RecipientRangeSlider from '@/client/components/RecipientRangeSlider';
-import SankeyGlobalView from '@/client/components/SankeyGlobalView';
+import SankeyGlobalView, { type GlobalLayoutData, type LevelLayout } from '@/client/components/SankeyGlobalView';
 
 function SankeyContent() {
   const router = useRouter();
@@ -57,8 +57,8 @@ function SankeyContent() {
     subcontracts?: { name: string; amount: number; flowType: string }[];
   } | null>(null);
 
-  // Global View: base data (level 0) with allRecipients for client-side paging
-  const globalBaseData = useRef<RS2024PresetData | null>(null);
+  // Global View: pre-computed layout data (all levels)
+  const [globalLayoutData, setGlobalLayoutData] = useState<GlobalLayoutData | null>(null);
 
   // Sync state from URL parameters (runs on mount and whenever URL changes via browser back/forward)
   useEffect(() => {
@@ -139,191 +139,84 @@ function SankeyContent() {
     loadStructuredData();
   }, []);
 
-  // Build sankey data with client-side recipient paging for Global View
-  const buildGlobalSankeyForLevel = useCallback((base: RS2024PresetData, level: number): RS2024PresetData => {
-    if (level === 0 || !base.allRecipients) return base;
-
-    const spendingLimit = topNSettings.global.spending || 10;
-    const offset = level * spendingLimit;
-    const pageRecipients = base.allRecipients.slice(offset, offset + spendingLimit);
-
-    // Remove existing recipient nodes/links from base sankey
-    const baseNodes = base.sankey.nodes.filter(n =>
-      n.type !== 'recipient' && n.type !== 'subcontract-recipient'
-    );
-    const recipientNodeIds = new Set(base.sankey.nodes.filter(n => n.type === 'recipient' || n.type === 'subcontract-recipient').map(n => n.id));
-    const baseLinks = base.sankey.links.filter(l =>
-      !recipientNodeIds.has(l.target) && l.target !== 'recipient-other-aggregated' && l.target !== 'recipient-other-named' && l.target !== 'recipient-top10-summary'
-    );
-
-    // Also remove "recipient-other-aggregated", "recipient-other-named", "recipient-top10-summary" from baseNodes
-    const filteredBaseNodes = baseNodes.filter(n =>
-      n.id !== 'recipient-other-aggregated' && n.id !== 'recipient-other-named' && n.id !== 'recipient-top10-summary'
-    );
-
-    // Build new recipient nodes
-    const newNodes = [...filteredBaseNodes];
-    const newLinks = [...baseLinks];
-    const topProjectIds = new Set(base.sankey.nodes.filter(n => n.type === 'project-spending').map(n => n.originalId));
-
-    // "支出先(Top{prev})" summary node for cumulative
-    const prevEnd = level * spendingLimit;
-    const prevRecipients = base.allRecipients.slice(0, prevEnd);
-    const prevTotal = prevRecipients.reduce((sum, r) => r.projects.reduce((acc, p) => acc + p.amount, sum), 0);
-
-    newNodes.push({
-      id: 'recipient-top10-summary',
-      name: `支出先\n(Top${prevEnd})`,
-      type: 'recipient',
-      value: prevTotal || 0.001,
-      details: { corporateNumber: '', location: '', projectCount: prevEnd, actualValue: prevTotal },
-    });
-
-    // Add cumulative link from "project-spending-cumulative" if it exists
-    const cumulativeNode = filteredBaseNodes.find(n => n.id === 'project-spending-cumulative');
-    if (cumulativeNode) {
-      newLinks.push({
-        source: 'project-spending-cumulative',
-        target: 'recipient-top10-summary',
-        value: 0.001,
-      });
-    }
-
-    // Current page recipient nodes + links
-    for (const r of pageRecipients) {
-      const spendingFromTopProjects = r.projects
-        .filter(p => topProjectIds.has(p.projectId))
-        .reduce((sum, p) => sum + p.amount, 0);
-
-      newNodes.push({
-        id: `recipient-${r.spendingId}`,
-        name: r.spendingName,
-        type: 'recipient',
-        value: spendingFromTopProjects,
-        originalId: r.spendingId,
-        details: {
-          corporateNumber: r.corporateNumber,
-          location: r.location,
-          projectCount: r.projectCount,
-          tags: r.tags,
-        },
-      });
-
-      for (const p of r.projects) {
-        if (!topProjectIds.has(p.projectId)) continue;
-        newLinks.push({
-          source: `project-spending-${p.projectId}`,
-          target: `recipient-${r.spendingId}`,
-          value: p.amount,
-          details: {
-            contractMethod: p.contractMethod,
-            blockName: p.blockName,
-          },
-        });
-      }
-    }
-
-    // "その他" named spending node (from base level 0 data)
-    const otherNamedNode = base.sankey.nodes.find(n => n.id === 'recipient-other-named');
-    if (otherNamedNode) {
-      newNodes.push(otherNamedNode);
-      // Copy links to this node from base
-      for (const l of base.sankey.links) {
-        if (l.target === 'recipient-other-named') newLinks.push(l);
-      }
-    }
-
-    // "支出先(TopN以外)" aggregated node
-    const excludeUpTo = (level + 1) * spendingLimit;
-    const remainingRecipients = base.allRecipients.slice(excludeUpTo);
-    const totalOtherAmount = remainingRecipients.reduce((sum, r) =>
-      r.projects.filter(p => topProjectIds.has(p.projectId)).reduce((acc, p) => acc + p.amount, sum), 0);
-
-    if (totalOtherAmount > 0) {
-      newNodes.push({
-        id: 'recipient-other-aggregated',
-        name: `支出先\n(Top${excludeUpTo}以外)`,
-        type: 'recipient',
-        value: totalOtherAmount,
-      });
-
-      // Links from each top project to "other aggregated"
-      for (const projectNode of base.sankey.nodes.filter(n => n.type === 'project-spending' && n.originalId)) {
-        let projectToOther = 0;
-        for (const r of remainingRecipients) {
-          for (const p of r.projects) {
-            if (p.projectId === projectNode.originalId) projectToOther += p.amount;
-          }
+  // Load pre-computed Global View layout data once
+  useEffect(() => {
+    async function loadGlobalLayout() {
+      try {
+        const response = await fetch('/data/sankey-global-layout.json');
+        if (!response.ok) {
+          console.error('Failed to load sankey-global-layout.json. Run: npm run compute-sankey-global-layout');
+          return;
         }
-        if (projectToOther > 0) {
-          newLinks.push({
-            source: projectNode.id,
-            target: 'recipient-other-aggregated',
-            value: projectToOther,
-          });
-        }
+        const json: GlobalLayoutData = await response.json();
+        setGlobalLayoutData(json);
+      } catch (err) {
+        console.error('Failed to load global layout:', err);
       }
     }
+    loadGlobalLayout();
+  }, []);
 
-    return {
-      ...base,
-      sankey: { nodes: newNodes, links: newLinks },
-    };
-  }, [topNSettings.global.spending]);
+  // Current level layout for Global View (O(1) lookup)
+  const currentGlobalLayout: LevelLayout | null = globalLayoutData
+    ? globalLayoutData.levels[String(viewState.spendingDrilldownLevel)] || null
+    : null;
 
   useEffect(() => {
     async function loadData() {
+      if (viewState.mode === 'global') {
+        // Global View uses pre-computed layout — no API call needed
+        // Just set loading state based on whether layout data is available
+        if (globalLayoutData) {
+          setLoading(false);
+          // Set minimal data for metadata (slider total, etc.)
+          setData({
+            metadata: {
+              generatedAt: '',
+              fiscalYear: 2024,
+              presetType: 'global',
+              sourceFile: '',
+              filterSettings: { topMinistries: 3, topProjects: 3, topSpendings: 10, sortBy: 'budget' },
+              summary: {
+                totalMinistries: 0, totalProjects: 0, totalSpendings: 0,
+                selectedMinistries: 0, selectedProjects: 0, selectedSpendings: 0,
+                totalBudget: 0, selectedBudget: 0, coverageRate: 0,
+                totalFilteredSpendings: globalLayoutData.metadata.totalRecipients,
+              },
+            },
+            sankey: { nodes: [], links: [] },
+          });
+        } else {
+          setLoading(true);
+        }
+        return;
+      }
+
+      // Non-global views: standard API fetch
       setLoading(true);
       try {
         const params = new URLSearchParams();
 
-        if (viewState.mode === 'global') {
-          // For Global View, always fetch level 0 (base data with allRecipients)
-          // Then client-side generates the current level's recipient nodes
-          if (!globalBaseData.current || viewState.drilldownLevel !== (globalBaseData.current as RS2024PresetData & { _drilldownLevel?: number })._drilldownLevel) {
-            params.set('limit', topNSettings.global.ministry.toString());
-            params.set('projectLimit', '3');
-            params.set('spendingLimit', topNSettings.global.spending.toString());
-            params.set('subcontractLimit', topNSettings.global.subcontract.toString());
-            params.set('drilldownLevel', viewState.drilldownLevel.toString());
-            params.set('spendingDrilldownLevel', '0');
-
-            const response = await fetch(`/api/sankey?${params.toString()}`);
-            if (!response.ok) throw new Error('Failed to load data');
-            const json: RS2024PresetData = await response.json();
-            globalBaseData.current = json;
-            // Tag with drilldown level to invalidate when ministry drilldown changes
-            (globalBaseData.current as RS2024PresetData & { _drilldownLevel?: number })._drilldownLevel = viewState.drilldownLevel;
-          }
-
-          // Generate sankey for current spending drilldown level client-side
-          const result = buildGlobalSankeyForLevel(globalBaseData.current, viewState.spendingDrilldownLevel);
-          setData(result);
-        } else {
-          // Non-global views: standard API fetch
-          globalBaseData.current = null;
-
-          if (viewState.mode === 'ministry' && viewState.selectedMinistry) {
-            params.set('ministryName', viewState.selectedMinistry);
-            params.set('projectLimit', topNSettings.ministry.project.toString());
-            params.set('spendingLimit', topNSettings.ministry.spending.toString());
-            params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
-          } else if (viewState.mode === 'project' && viewState.selectedProject) {
-            params.set('projectName', viewState.selectedProject);
-            params.set('spendingLimit', topNSettings.project.spending.toString());
-          } else if (viewState.mode === 'spending' && viewState.selectedRecipient) {
-            params.set('recipientName', viewState.selectedRecipient);
-            params.set('projectLimit', topNSettings.spending.project.toString());
-            params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
-            params.set('limit', topNSettings.spending.ministry.toString());
-            params.set('subcontractLimit', topNSettings.spending.subcontract.toString());
-          }
-
-          const response = await fetch(`/api/sankey?${params.toString()}`);
-          if (!response.ok) throw new Error('Failed to load data');
-          const json: RS2024PresetData = await response.json();
-          setData(json);
+        if (viewState.mode === 'ministry' && viewState.selectedMinistry) {
+          params.set('ministryName', viewState.selectedMinistry);
+          params.set('projectLimit', topNSettings.ministry.project.toString());
+          params.set('spendingLimit', topNSettings.ministry.spending.toString());
+          params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
+        } else if (viewState.mode === 'project' && viewState.selectedProject) {
+          params.set('projectName', viewState.selectedProject);
+          params.set('spendingLimit', topNSettings.project.spending.toString());
+        } else if (viewState.mode === 'spending' && viewState.selectedRecipient) {
+          params.set('recipientName', viewState.selectedRecipient);
+          params.set('projectLimit', topNSettings.spending.project.toString());
+          params.set('projectDrilldownLevel', viewState.projectDrilldownLevel.toString());
+          params.set('limit', topNSettings.spending.ministry.toString());
+          params.set('subcontractLimit', topNSettings.spending.subcontract.toString());
         }
+
+        const response = await fetch(`/api/sankey?${params.toString()}`);
+        if (!response.ok) throw new Error('Failed to load data');
+        const json: RS2024PresetData = await response.json();
+        setData(json);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
@@ -332,7 +225,7 @@ function SankeyContent() {
     }
 
     loadData();
-  }, [viewState, topNSettings, buildGlobalSankeyForLevel]);
+  }, [viewState, topNSettings, globalLayoutData]);
 
   // スマホ判定
   useEffect(() => {
@@ -346,7 +239,12 @@ function SankeyContent() {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleNodeClick = (node: any) => {
-    const actualNode = data?.sankey.nodes.find(n => n.id === node.id);
+    // Look up node in either pre-computed layout (Global View) or API data (other views)
+    const layoutNode = currentGlobalLayout?.nodes.find(n => n.id === node.id);
+    const apiNode = data?.sankey.nodes.find(n => n.id === node.id);
+    const actualNode = layoutNode
+      ? { id: layoutNode.id, name: layoutNode.name, type: layoutNode.type, value: layoutNode.value, originalId: layoutNode.originalId, details: layoutNode.details }
+      : apiNode;
     if (!actualNode) return;
 
     // Handle "Other Ministries" drill-down
@@ -947,14 +845,14 @@ function SankeyContent() {
               <span className="w-3 h-3 rounded-full bg-[#6b7280]"></span>
               <span className="text-gray-700">その他</span>
             </div>
-            {viewState.mode === 'global' && data?.metadata?.summary?.totalFilteredSpendings && (
+            {viewState.mode === 'global' && globalLayoutData && (
               <div className="ml-auto w-[400px]">
                 <RecipientRangeSlider
-                  value={viewState.spendingDrilldownLevel * (topNSettings.global.spending || 10)}
-                  total={data.metadata.summary.totalFilteredSpendings}
-                  step={topNSettings.global.spending || 10}
+                  value={viewState.spendingDrilldownLevel * (globalLayoutData.metadata.recipientsPerLevel)}
+                  total={globalLayoutData.metadata.totalRecipients}
+                  step={globalLayoutData.metadata.recipientsPerLevel}
                   onChangeCommitted={(newValue) => {
-                    const newLevel = Math.floor(newValue / (topNSettings.global.spending || 10));
+                    const newLevel = Math.floor(newValue / globalLayoutData.metadata.recipientsPerLevel);
                     navigateToView({ mode: 'global', spendingDrilldownLevel: newLevel });
                   }}
                 />
@@ -979,16 +877,14 @@ function SankeyContent() {
             style={isMobile ? { WebkitOverflowScrolling: 'touch' } : {}}
           >
             <div style={{ height: '800px', minWidth: isMobile ? '1200px' : 'auto', backgroundColor: 'white' }}>
-              {viewState.mode === 'global' ? (
+              {viewState.mode === 'global' && currentGlobalLayout ? (
                 <SankeyGlobalView
-                  data={sankey}
+                  layout={currentGlobalLayout}
                   width={isMobile ? 1200 : 1200}
                   height={800}
                   margin={{ top: 40, right: 100, bottom: 40, left: 100 }}
-                  hasSubcontractNodes={sankey.nodes.some(n => n.type === 'subcontract-recipient')}
                   onNodeClick={handleNodeClick}
                   formatCurrency={formatCurrency}
-                  getActualValue={getActualValue}
                   viewState={viewState}
                   topNSettings={topNSettings}
                 />

--- a/client/components/SankeyGlobalView.tsx
+++ b/client/components/SankeyGlobalView.tsx
@@ -1,40 +1,51 @@
 'use client';
 
 import React, { useMemo, useState, useCallback, useRef } from 'react';
-import {
-  sankey as d3Sankey,
-  sankeyLinkHorizontal,
-  sankeyJustify,
-  sankeyLeft,
-} from 'd3-sankey';
 import type { SankeyNode, SankeyLink } from '@/types/preset';
 
-// d3-sankey augmented types
-interface D3Node {
+// Pre-computed layout node (from sankey-global-layout.json)
+interface LayoutNode {
   id: string;
   name: string;
   type: string;
   value: number;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+  originalId?: number;
   details?: SankeyNode['details'];
-  // d3-sankey computed
-  x0?: number;
-  x1?: number;
-  y0?: number;
-  y1?: number;
-  index?: number;
-  sourceLinks?: D3Link[];
-  targetLinks?: D3Link[];
 }
 
-interface D3Link {
-  source: D3Node;
-  target: D3Node;
+// Pre-computed layout link (from sankey-global-layout.json)
+interface LayoutLink {
+  source: string;
+  target: string;
   value: number;
+  path: string;
+  width: number;
+  y0: number;
+  y1: number;
   details?: SankeyLink['details'];
-  width?: number;
-  y0?: number;
-  y1?: number;
-  index?: number;
+}
+
+// Pre-computed level layout
+export interface LevelLayout {
+  nodes: LayoutNode[];
+  links: LayoutLink[];
+}
+
+// Full pre-computed layout data
+export interface GlobalLayoutData {
+  metadata: {
+    totalLevels: number;
+    recipientsPerLevel: number;
+    totalRecipients: number;
+    svgWidth: number;
+    svgHeight: number;
+    margin: { top: number; right: number; bottom: number; left: number };
+  };
+  levels: Record<string, LevelLayout>;
 }
 
 // ── Color helpers ──
@@ -65,24 +76,20 @@ const MemoNode = React.memo(function MemoNode({
   onMouseLeave,
   onClick,
 }: {
-  node: D3Node;
+  node: LayoutNode;
   opacity: number;
   onMouseEnter: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
   onClick: () => void;
 }) {
-  const x = node.x0 ?? 0;
-  const y = node.y0 ?? 0;
-  const w = (node.x1 ?? 0) - x;
-  const h = (node.y1 ?? 0) - y;
   const color = getNodeColor(node.type, node.name);
 
   return (
     <rect
-      x={x}
-      y={y}
-      width={w}
-      height={h}
+      x={node.x0}
+      y={node.y0}
+      width={node.x1 - node.x0}
+      height={node.y1 - node.y0}
       fill={color}
       opacity={opacity}
       style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
@@ -96,25 +103,22 @@ const MemoNode = React.memo(function MemoNode({
 const MemoLink = React.memo(function MemoLink({
   link,
   opacity,
-  pathGenerator,
   onMouseEnter,
   onMouseLeave,
 }: {
-  link: D3Link;
+  link: LayoutLink;
   opacity: number;
-  pathGenerator: (link: D3Link) => string | null;
   onMouseEnter: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
 }) {
-  const d = pathGenerator(link);
-  if (!d) return null;
+  if (!link.path) return null;
 
   return (
     <path
-      d={d}
+      d={link.path}
       fill="none"
       stroke="#9ca3af"
-      strokeWidth={Math.max(link.width ?? 1, 1)}
+      strokeWidth={Math.max(link.width, 1)}
       strokeOpacity={opacity}
       style={{ transition: 'stroke-opacity 0.15s' }}
       onMouseEnter={onMouseEnter}
@@ -126,31 +130,26 @@ const MemoLink = React.memo(function MemoLink({
 // ── Main component ──
 
 interface Props {
-  data: { nodes: SankeyNode[]; links: SankeyLink[] };
+  layout: LevelLayout;
   width: number;
   height: number;
   margin?: { top: number; right: number; bottom: number; left: number };
-  hasSubcontractNodes?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onNodeClick: (node: any) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formatCurrency: (value: number | undefined, nodeOrDetails?: any) => string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getActualValue: (value: number | undefined, nodeOrDetails?: any) => number | undefined;
   viewState: { mode: string; projectDrilldownLevel: number; spendingDrilldownLevel: number };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   topNSettings: any;
 }
 
 export default function SankeyGlobalView({
-  data,
+  layout,
   width,
   height,
   margin = { top: 40, right: 100, bottom: 40, left: 100 },
-  hasSubcontractNodes = false,
   onNodeClick,
   formatCurrency,
-  getActualValue,
   viewState,
   topNSettings,
 }: Props) {
@@ -161,64 +160,22 @@ export default function SankeyGlobalView({
     type: 'node' | 'link';
     x: number;
     y: number;
-    node?: D3Node;
-    link?: D3Link;
+    node?: LayoutNode;
+    link?: LayoutLink;
   } | null>(null);
 
-  const innerWidth = width - margin.left - margin.right;
-  const innerHeight = height - margin.top - margin.bottom;
-
-  // ── d3-sankey layout ──
-  const { layoutNodes, layoutLinks, pathGenerator } = useMemo(() => {
-    const nodes: D3Node[] = data.nodes.map((n) => ({
-      id: n.id,
-      name: n.name,
-      type: n.type,
-      value: n.value,
-      details: n.details,
-    }));
-
-    const nodeMap = new Map(nodes.map((n, i) => [n.id, i]));
-    const links: D3Link[] = data.links
-      .filter((l) => nodeMap.has(l.source) && nodeMap.has(l.target))
-      .map((l) => ({
-        source: nodes[nodeMap.get(l.source)!],
-        target: nodes[nodeMap.get(l.target)!],
-        value: l.value,
-        details: l.details,
-      }));
-
-    const generator = d3Sankey<D3Node, D3Link>()
-      .nodeId((d) => d.id)
-      .nodeWidth(44)
-      .nodePadding(22)
-      .nodeAlign(hasSubcontractNodes ? sankeyLeft : sankeyJustify)
-      .nodeSort(null) // preserve input order
-      .extent([
-        [0, 0],
-        [innerWidth, innerHeight],
-      ]);
-
-    const { nodes: layoutNodes, links: layoutLinks } = generator({
-      nodes,
-      links,
-    });
-
-    const pathGen = sankeyLinkHorizontal<D3Node, D3Link>();
-
-    return { layoutNodes, layoutLinks, pathGenerator: pathGen };
-  }, [data, innerWidth, innerHeight, hasSubcontractNodes]);
+  // Use pre-computed layout directly (no d3-sankey computation)
+  const layoutNodes = layout.nodes;
+  const layoutLinks = layout.links;
 
   // ── Adjacency map for hover highlight ──
   const adjacency = useMemo(() => {
     const map = new Map<string, Set<string>>();
     for (const link of layoutLinks) {
-      const sId = link.source.id;
-      const tId = link.target.id;
-      if (!map.has(sId)) map.set(sId, new Set());
-      if (!map.has(tId)) map.set(tId, new Set());
-      map.get(sId)!.add(tId);
-      map.get(tId)!.add(sId);
+      if (!map.has(link.source)) map.set(link.source, new Set());
+      if (!map.has(link.target)) map.set(link.target, new Set());
+      map.get(link.source)!.add(link.target);
+      map.get(link.target)!.add(link.source);
     }
     return map;
   }, [layoutLinks]);
@@ -233,16 +190,16 @@ export default function SankeyGlobalView({
   );
 
   const isLinkConnected = useCallback(
-    (link: D3Link) => {
+    (link: LayoutLink) => {
       if (!hoveredNodeId) return true;
-      return link.source.id === hoveredNodeId || link.target.id === hoveredNodeId;
+      return link.source === hoveredNodeId || link.target === hoveredNodeId;
     },
     [hoveredNodeId]
   );
 
   // ── Event handlers ──
   const handleNodeMouseEnter = useCallback(
-    (node: D3Node, event: React.MouseEvent) => {
+    (node: LayoutNode, event: React.MouseEvent) => {
       setHoveredNodeId(node.id);
       const svgRect = svgRef.current?.getBoundingClientRect();
       if (svgRect) {
@@ -263,7 +220,7 @@ export default function SankeyGlobalView({
   }, []);
 
   const handleLinkMouseEnter = useCallback(
-    (link: D3Link, index: number, event: React.MouseEvent) => {
+    (link: LayoutLink, index: number, event: React.MouseEvent) => {
       setHoveredLinkIndex(index);
       setHoveredNodeId(null);
       const svgRect = svgRef.current?.getBoundingClientRect();
@@ -286,7 +243,7 @@ export default function SankeyGlobalView({
 
   // ── Label helpers (ported from nivo custom layer) ──
   const getDisplayAmount = useCallback(
-    (node: D3Node): string => {
+    (node: LayoutNode): string => {
       let displayAmount: number | undefined = node.value;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const details = node.details as any;
@@ -305,7 +262,7 @@ export default function SankeyGlobalView({
   );
 
   const getDisplayName = useCallback(
-    (node: D3Node): string => {
+    (node: LayoutNode): string => {
       let name = node.name;
       if (
         (name.match(/^事業\(Top\d+以外.*\)$/) || name.match(/^事業\n\(Top\d+以外.*\)$/)) &&
@@ -322,7 +279,7 @@ export default function SankeyGlobalView({
     [viewState, topNSettings]
   );
 
-  const isClickable = useCallback((node: D3Node): boolean => {
+  const isClickable = useCallback((node: LayoutNode): boolean => {
     const name = node.name;
     const isProjectOtherNode = name.match(/^事業\n?\(Top\d+以外.*\)$/);
     const isSubcontractOtherNode = name.match(/^再委託先\n?\(Top\d+以外.*\)$/);
@@ -341,14 +298,12 @@ export default function SankeyGlobalView({
 
   // ── Node tooltip renderer ──
   const renderNodeTooltip = useCallback(
-    (node: D3Node) => {
-      const actualNode = data.nodes.find((n) => n.id === node.id);
-      if (!actualNode) return null;
-      const name = actualNode.name;
-      const nodeType = actualNode.type || '';
+    (node: LayoutNode) => {
+      const name = node.name;
+      const nodeType = node.type || '';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const details = actualNode.details as any;
-      const value = formatCurrency(node.value, actualNode);
+      const details = node.details as any;
+      const value = formatCurrency(node.value, node);
 
       return (
         <div className="bg-white px-3 py-2 rounded shadow-lg border border-gray-200 min-w-[280px]">
@@ -423,20 +378,26 @@ export default function SankeyGlobalView({
         </div>
       );
     },
-    [data.nodes, formatCurrency]
+    [formatCurrency]
   );
+
+  // ── Node map for tooltip lookups ──
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, LayoutNode>();
+    for (const n of layoutNodes) map.set(n.id, n);
+    return map;
+  }, [layoutNodes]);
 
   // ── Link tooltip renderer ──
   const renderLinkTooltip = useCallback(
-    (link: D3Link) => {
-      const sourceNode = data.nodes.find((n) => n.id === link.source.id);
-      const targetNode = data.nodes.find((n) => n.id === link.target.id);
-      const actualLink = data.links.find((l) => l.source === link.source.id && l.target === link.target.id);
+    (link: LayoutLink) => {
+      const sourceNode = nodeMap.get(link.source);
+      const targetNode = nodeMap.get(link.target);
 
-      const sourceName = sourceNode?.name || link.source.id;
-      const targetName = targetNode?.name || link.target.id;
-      const sourceValue = formatCurrency(link.source.value, sourceNode);
-      const targetValue = formatCurrency(link.target.value, targetNode);
+      const sourceName = sourceNode?.name || link.source;
+      const targetName = targetNode?.name || link.target;
+      const sourceValue = formatCurrency(sourceNode?.value, sourceNode);
+      const targetValue = formatCurrency(targetNode?.value, targetNode);
       const linkValue = formatCurrency(link.value, sourceNode);
 
       const isProjectBudgetToSpending =
@@ -475,18 +436,18 @@ export default function SankeyGlobalView({
             )}
             <div className="text-sm font-medium text-gray-700">{targetValue}</div>
           </div>
-          {actualLink?.details && (actualLink.details.contractMethod || actualLink.details.blockName) && (
+          {link.details && (link.details.contractMethod || link.details.blockName) && (
             <div className="mt-3 pt-2 border-t border-gray-200">
-              {actualLink.details.contractMethod && (
+              {link.details.contractMethod && (
                 <div className="mb-1">
                   <span className="text-xs text-gray-500">契約方式: </span>
-                  <span className="text-xs font-medium text-gray-900">{actualLink.details.contractMethod}</span>
+                  <span className="text-xs font-medium text-gray-900">{link.details.contractMethod}</span>
                 </div>
               )}
-              {actualLink.details.blockName && (
+              {link.details.blockName && (
                 <div>
                   <span className="text-xs text-gray-500">支出ブロック: </span>
-                  <span className="text-xs font-medium text-gray-900">{actualLink.details.blockName}</span>
+                  <span className="text-xs font-medium text-gray-900">{link.details.blockName}</span>
                 </div>
               )}
             </div>
@@ -494,7 +455,7 @@ export default function SankeyGlobalView({
         </div>
       );
     },
-    [data.nodes, data.links, formatCurrency]
+    [nodeMap, formatCurrency]
   );
 
   return (
@@ -507,10 +468,9 @@ export default function SankeyGlobalView({
               const linkOpacity = hoveredLinkIndex === i ? 0.8 : isLinkConnected(link) ? 0.5 : 0.1;
               return (
                 <MemoLink
-                  key={`${link.source.id}-${link.target.id}-${i}`}
+                  key={`${link.source}-${link.target}-${i}`}
                   link={link}
                   opacity={linkOpacity}
-                  pathGenerator={pathGenerator}
                   onMouseEnter={(e: React.MouseEvent) => handleLinkMouseEnter(link, i, e)}
                   onMouseLeave={handleLinkMouseLeave}
                 />
@@ -529,7 +489,7 @@ export default function SankeyGlobalView({
                   opacity={nodeOpacity}
                   onMouseEnter={(e: React.MouseEvent) => handleNodeMouseEnter(node, e)}
                   onMouseLeave={handleNodeMouseLeave}
-                  onClick={() => onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: (node.x1 ?? 0) - (node.x0 ?? 0), height: (node.y1 ?? 0) - (node.y0 ?? 0) })}
+                  onClick={() => onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: node.x1 - node.x0, height: node.y1 - node.y0 })}
                 />
               );
             })}
@@ -539,11 +499,11 @@ export default function SankeyGlobalView({
           <g>
             {layoutNodes.map((node) => {
               const isBudgetNode = node.type === 'ministry-budget' || node.type === 'project-budget';
-              const x = isBudgetNode ? (node.x0 ?? 0) - 4 : (node.x1 ?? 0) + 4;
+              const x = isBudgetNode ? node.x0 - 4 : node.x1 + 4;
               const textAnchor = isBudgetNode ? 'end' : 'start';
-              const amountX = ((node.x0 ?? 0) + (node.x1 ?? 0)) / 2;
-              const nodeY = node.y0 ?? 0;
-              const nodeH = (node.y1 ?? 0) - nodeY;
+              const amountX = (node.x0 + node.x1) / 2;
+              const nodeY = node.y0;
+              const nodeH = node.y1 - nodeY;
               const clickable = isClickable(node);
               const color = clickable ? '#2563eb' : '#1f2937';
               const fontWeight = clickable ? 'bold' : 500;
@@ -571,7 +531,7 @@ export default function SankeyGlobalView({
                     textAnchor={textAnchor}
                     dominantBaseline="middle"
                     style={{ fill: color, fontSize: 12, fontWeight, pointerEvents: clickable ? 'auto' : 'none', cursor: cursorStyle }}
-                    onClick={() => clickable && onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: (node.x1 ?? 0) - (node.x0 ?? 0), height: (node.y1 ?? 0) - (node.y0 ?? 0) })}
+                    onClick={() => clickable && onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: node.x1 - node.x0, height: node.y1 - node.y0 })}
                   >
                     {displayName.includes('\n') ? (
                       displayName.split('\n').map((line, i) => (

--- a/client/components/SankeyGlobalView.tsx
+++ b/client/components/SankeyGlobalView.tsx
@@ -1,0 +1,610 @@
+'use client';
+
+import React, { useMemo, useState, useCallback, useRef } from 'react';
+import {
+  sankey as d3Sankey,
+  sankeyLinkHorizontal,
+  sankeyJustify,
+  sankeyLeft,
+} from 'd3-sankey';
+import type { SankeyNode, SankeyLink } from '@/types/preset';
+
+// d3-sankey augmented types
+interface D3Node {
+  id: string;
+  name: string;
+  type: string;
+  value: number;
+  details?: SankeyNode['details'];
+  // d3-sankey computed
+  x0?: number;
+  x1?: number;
+  y0?: number;
+  y1?: number;
+  index?: number;
+  sourceLinks?: D3Link[];
+  targetLinks?: D3Link[];
+}
+
+interface D3Link {
+  source: D3Node;
+  target: D3Node;
+  value: number;
+  details?: SankeyLink['details'];
+  width?: number;
+  y0?: number;
+  y1?: number;
+  index?: number;
+}
+
+// ── Color helpers ──
+
+function getNodeColor(type: string, name: string): string {
+  if (
+    name.startsWith('その他') ||
+    name.match(/^府省庁\(Top\d+以外.*\)$/) ||
+    name.match(/^事業\(Top\d+以外.*\)$/) ||
+    name.match(/^事業\n\(Top\d+以外.*\)$/) ||
+    name.match(/^支出先\(Top\d+以外.*\)$/) ||
+    name.match(/^支出先\n\(Top\d+以外.*\)$/) ||
+    name.match(/^再委託先\n?\(Top\d+以外.*\)$/)
+  ) {
+    return '#6b7280';
+  }
+  if (type === 'ministry-budget' || type === 'project-budget') return '#10b981';
+  if (type === 'project-spending' || type === 'recipient' || type === 'subcontract-recipient') return '#ef4444';
+  return '#6b7280';
+}
+
+// ── Memoized sub-components ──
+
+const MemoNode = React.memo(function MemoNode({
+  node,
+  opacity,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}: {
+  node: D3Node;
+  opacity: number;
+  onMouseEnter: (e: React.MouseEvent) => void;
+  onMouseLeave: () => void;
+  onClick: () => void;
+}) {
+  const x = node.x0 ?? 0;
+  const y = node.y0 ?? 0;
+  const w = (node.x1 ?? 0) - x;
+  const h = (node.y1 ?? 0) - y;
+  const color = getNodeColor(node.type, node.name);
+
+  return (
+    <rect
+      x={x}
+      y={y}
+      width={w}
+      height={h}
+      fill={color}
+      opacity={opacity}
+      style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    />
+  );
+});
+
+const MemoLink = React.memo(function MemoLink({
+  link,
+  opacity,
+  pathGenerator,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  link: D3Link;
+  opacity: number;
+  pathGenerator: (link: D3Link) => string | null;
+  onMouseEnter: (e: React.MouseEvent) => void;
+  onMouseLeave: () => void;
+}) {
+  const d = pathGenerator(link);
+  if (!d) return null;
+
+  return (
+    <path
+      d={d}
+      fill="none"
+      stroke="#9ca3af"
+      strokeWidth={Math.max(link.width ?? 1, 1)}
+      strokeOpacity={opacity}
+      style={{ transition: 'stroke-opacity 0.15s' }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    />
+  );
+});
+
+// ── Main component ──
+
+interface Props {
+  data: { nodes: SankeyNode[]; links: SankeyLink[] };
+  width: number;
+  height: number;
+  margin?: { top: number; right: number; bottom: number; left: number };
+  hasSubcontractNodes?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onNodeClick: (node: any) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formatCurrency: (value: number | undefined, nodeOrDetails?: any) => string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getActualValue: (value: number | undefined, nodeOrDetails?: any) => number | undefined;
+  viewState: { mode: string; projectDrilldownLevel: number; spendingDrilldownLevel: number };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  topNSettings: any;
+}
+
+export default function SankeyGlobalView({
+  data,
+  width,
+  height,
+  margin = { top: 40, right: 100, bottom: 40, left: 100 },
+  hasSubcontractNodes = false,
+  onNodeClick,
+  formatCurrency,
+  getActualValue,
+  viewState,
+  topNSettings,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [hoveredLinkIndex, setHoveredLinkIndex] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    type: 'node' | 'link';
+    x: number;
+    y: number;
+    node?: D3Node;
+    link?: D3Link;
+  } | null>(null);
+
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+
+  // ── d3-sankey layout ──
+  const { layoutNodes, layoutLinks, pathGenerator } = useMemo(() => {
+    const nodes: D3Node[] = data.nodes.map((n) => ({
+      id: n.id,
+      name: n.name,
+      type: n.type,
+      value: n.value,
+      details: n.details,
+    }));
+
+    const nodeMap = new Map(nodes.map((n, i) => [n.id, i]));
+    const links: D3Link[] = data.links
+      .filter((l) => nodeMap.has(l.source) && nodeMap.has(l.target))
+      .map((l) => ({
+        source: nodes[nodeMap.get(l.source)!],
+        target: nodes[nodeMap.get(l.target)!],
+        value: l.value,
+        details: l.details,
+      }));
+
+    const generator = d3Sankey<D3Node, D3Link>()
+      .nodeId((d) => d.id)
+      .nodeWidth(44)
+      .nodePadding(22)
+      .nodeAlign(hasSubcontractNodes ? sankeyLeft : sankeyJustify)
+      .nodeSort(null) // preserve input order
+      .extent([
+        [0, 0],
+        [innerWidth, innerHeight],
+      ]);
+
+    const { nodes: layoutNodes, links: layoutLinks } = generator({
+      nodes,
+      links,
+    });
+
+    const pathGen = sankeyLinkHorizontal<D3Node, D3Link>();
+
+    return { layoutNodes, layoutLinks, pathGenerator: pathGen };
+  }, [data, innerWidth, innerHeight, hasSubcontractNodes]);
+
+  // ── Adjacency map for hover highlight ──
+  const adjacency = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const link of layoutLinks) {
+      const sId = link.source.id;
+      const tId = link.target.id;
+      if (!map.has(sId)) map.set(sId, new Set());
+      if (!map.has(tId)) map.set(tId, new Set());
+      map.get(sId)!.add(tId);
+      map.get(tId)!.add(sId);
+    }
+    return map;
+  }, [layoutLinks]);
+
+  const isConnected = useCallback(
+    (nodeId: string) => {
+      if (!hoveredNodeId) return true;
+      if (nodeId === hoveredNodeId) return true;
+      return adjacency.get(hoveredNodeId)?.has(nodeId) ?? false;
+    },
+    [hoveredNodeId, adjacency]
+  );
+
+  const isLinkConnected = useCallback(
+    (link: D3Link) => {
+      if (!hoveredNodeId) return true;
+      return link.source.id === hoveredNodeId || link.target.id === hoveredNodeId;
+    },
+    [hoveredNodeId]
+  );
+
+  // ── Event handlers ──
+  const handleNodeMouseEnter = useCallback(
+    (node: D3Node, event: React.MouseEvent) => {
+      setHoveredNodeId(node.id);
+      const svgRect = svgRef.current?.getBoundingClientRect();
+      if (svgRect) {
+        setTooltip({
+          type: 'node',
+          x: event.clientX - svgRect.left,
+          y: event.clientY - svgRect.top,
+          node,
+        });
+      }
+    },
+    []
+  );
+
+  const handleNodeMouseLeave = useCallback(() => {
+    setHoveredNodeId(null);
+    setTooltip(null);
+  }, []);
+
+  const handleLinkMouseEnter = useCallback(
+    (link: D3Link, index: number, event: React.MouseEvent) => {
+      setHoveredLinkIndex(index);
+      setHoveredNodeId(null);
+      const svgRect = svgRef.current?.getBoundingClientRect();
+      if (svgRect) {
+        setTooltip({
+          type: 'link',
+          x: event.clientX - svgRect.left,
+          y: event.clientY - svgRect.top,
+          link,
+        });
+      }
+    },
+    []
+  );
+
+  const handleLinkMouseLeave = useCallback(() => {
+    setHoveredLinkIndex(null);
+    setTooltip(null);
+  }, []);
+
+  // ── Label helpers (ported from nivo custom layer) ──
+  const getDisplayAmount = useCallback(
+    (node: D3Node): string => {
+      let displayAmount: number | undefined = node.value;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const details = node.details as any;
+      if (details && 'actualValue' in details) {
+        displayAmount = details.actualValue as number;
+      } else if (node.value === 0.001) {
+        if (node.type === 'project-budget' && details?.totalBudget === 0) {
+          displayAmount = 0;
+        } else if (node.type === 'ministry-budget') {
+          displayAmount = 0;
+        }
+      }
+      return formatCurrency(displayAmount);
+    },
+    [formatCurrency]
+  );
+
+  const getDisplayName = useCallback(
+    (node: D3Node): string => {
+      let name = node.name;
+      if (
+        (name.match(/^事業\(Top\d+以外.*\)$/) || name.match(/^事業\n\(Top\d+以外.*\)$/)) &&
+        viewState.mode === 'ministry'
+      ) {
+        const currentEnd = (viewState.projectDrilldownLevel + 1) * topNSettings.ministry.project;
+        return `事業\n(Top${currentEnd}以外)`;
+      }
+      if (!name.includes('\n') && name.length > 10) {
+        name = name.substring(0, 10) + '...';
+      }
+      return name;
+    },
+    [viewState, topNSettings]
+  );
+
+  const isClickable = useCallback((node: D3Node): boolean => {
+    const name = node.name;
+    const isProjectOtherNode = name.match(/^事業\n?\(Top\d+以外.*\)$/);
+    const isSubcontractOtherNode = name.match(/^再委託先\n?\(Top\d+以外.*\)$/);
+
+    return (
+      node.id === 'ministry-budget-other' ||
+      node.id === 'total-budget' ||
+      node.id === 'recipient-top10-summary' ||
+      node.id === 'recipient-other-aggregated' ||
+      (node.type === 'ministry-budget' && node.id !== 'total-budget' && node.id !== 'ministry-budget-other') ||
+      ((node.type === 'project-budget' || node.type === 'project-spending') && !isProjectOtherNode) ||
+      (node.type === 'recipient' && node.id !== 'recipient-top10-summary' && node.id !== 'recipient-other-aggregated') ||
+      (node.type === 'subcontract-recipient' && !isSubcontractOtherNode)
+    );
+  }, []);
+
+  // ── Node tooltip renderer ──
+  const renderNodeTooltip = useCallback(
+    (node: D3Node) => {
+      const actualNode = data.nodes.find((n) => n.id === node.id);
+      if (!actualNode) return null;
+      const name = actualNode.name;
+      const nodeType = actualNode.type || '';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const details = actualNode.details as any;
+      const value = formatCurrency(node.value, actualNode);
+
+      return (
+        <div className="bg-white px-3 py-2 rounded shadow-lg border border-gray-200 min-w-[280px]">
+          <div className="font-bold text-gray-900 mb-1">{name}</div>
+          <div className="text-sm text-gray-600">金額: {value}</div>
+          {details && (
+            <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+              {details.projectCount !== undefined && <div>選択事業数: {details.projectCount}</div>}
+              {details.bureauCount !== undefined && <div>局・庁数: {details.bureauCount}</div>}
+              {details.ministry && <div>府省庁: {details.ministry}</div>}
+              {details.bureau && <div>局・庁: {details.bureau}</div>}
+              {details.accountCategory && <div>会計区分: {details.accountCategory}</div>}
+              {details.initialBudget !== undefined && <div>当初予算: {formatCurrency(details.initialBudget)}</div>}
+              {details.supplementaryBudget !== undefined && details.supplementaryBudget > 0 && (
+                <div>補正予算: {formatCurrency(details.supplementaryBudget)}</div>
+              )}
+              {details.carryoverBudget !== undefined && details.carryoverBudget > 0 && (
+                <div>前年度繰越: {formatCurrency(details.carryoverBudget)}</div>
+              )}
+              {details.reserveFund !== undefined && details.reserveFund > 0 && (
+                <div>予備費等: {formatCurrency(details.reserveFund)}</div>
+              )}
+              {details.totalBudget !== undefined && nodeType === 'project-budget' && (
+                <div className="font-semibold">歳出予算現額: {formatCurrency(details.totalBudget)}</div>
+              )}
+              {details.executedAmount !== undefined && nodeType === 'project-budget' && details.executedAmount > 0 && (
+                <div>執行額: {formatCurrency(details.executedAmount)}</div>
+              )}
+              {details.carryoverToNext !== undefined && details.carryoverToNext > 0 && (
+                <div>翌年度繰越: {formatCurrency(details.carryoverToNext)}</div>
+              )}
+              {details.executionRate !== undefined && details.executionRate > 0 && (
+                <div>執行率: {details.executionRate.toFixed(1)}%</div>
+              )}
+              {details.spendingCount !== undefined && <div>支出先数: {details.spendingCount}</div>}
+              {details.corporateNumber && <div>法人番号: {details.corporateNumber}</div>}
+              {details.location && <div>所在地: {details.location}</div>}
+              {details.tags && (
+                <div className="mt-1 pt-1 border-t border-gray-300">
+                  <div className="flex flex-wrap gap-1 items-center">
+                    <span className="px-2 py-0.5 bg-blue-100 text-blue-800 rounded text-xs font-medium">
+                      {details.tags.secondaryCategory}
+                    </span>
+                    <span className="px-2 py-0.5 bg-green-100 text-green-800 rounded text-xs font-medium">
+                      {details.tags.primaryIndustryTag}
+                    </span>
+                  </div>
+                </div>
+              )}
+              {nodeType === 'subcontract-recipient' && details.sourceRecipient && (
+                <div className="mt-1 pt-1 border-t border-gray-300">
+                  <div className="font-semibold">委託元: {details.sourceRecipient}</div>
+                  {details.flowTypes && <div>資金の流れ: {details.flowTypes}</div>}
+                  {details.projects && details.projects.length > 0 && (
+                    <div className="mt-1">
+                      <div className="font-semibold">関連事業:</div>
+                      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                      {details.projects.slice(0, 5).map((proj: any, idx: number) => (
+                        <div key={idx} className="ml-2">
+                          &#x2022; {proj.projectName}: {formatCurrency(proj.amount)}
+                        </div>
+                      ))}
+                      {details.projects.length > 5 && (
+                        <div className="ml-2 text-gray-400">... 他{details.projects.length - 5}事業</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    },
+    [data.nodes, formatCurrency]
+  );
+
+  // ── Link tooltip renderer ──
+  const renderLinkTooltip = useCallback(
+    (link: D3Link) => {
+      const sourceNode = data.nodes.find((n) => n.id === link.source.id);
+      const targetNode = data.nodes.find((n) => n.id === link.target.id);
+      const actualLink = data.links.find((l) => l.source === link.source.id && l.target === link.target.id);
+
+      const sourceName = sourceNode?.name || link.source.id;
+      const targetName = targetNode?.name || link.target.id;
+      const sourceValue = formatCurrency(link.source.value, sourceNode);
+      const targetValue = formatCurrency(link.target.value, targetNode);
+      const linkValue = formatCurrency(link.value, sourceNode);
+
+      const isProjectBudgetToSpending =
+        sourceNode?.type === 'project-budget' && targetNode?.type === 'project-spending';
+
+      let title = '';
+      if (isProjectBudgetToSpending) {
+        title = sourceName;
+      } else if (sourceNode?.type === 'ministry-budget') {
+        title = `${sourceName} → 事業`;
+      } else if (sourceNode?.type === 'project-spending') {
+        title = `${sourceName} → 支出先`;
+      } else {
+        title = '資金の流れ';
+      }
+
+      return (
+        <div className="bg-white px-4 py-3 rounded shadow-lg border border-gray-200 min-w-[280px] max-w-md">
+          <div className="text-sm font-bold text-gray-900 mb-2 border-b border-gray-200 pb-2">{title}</div>
+          <div className="mb-2">
+            {isProjectBudgetToSpending ? (
+              <div className="text-xs text-gray-500">予算</div>
+            ) : (
+              <div className="text-sm font-semibold text-gray-900 truncate">{sourceName}</div>
+            )}
+            <div className="text-sm font-medium text-gray-700">{sourceValue}</div>
+          </div>
+          <div className="text-center my-2">
+            <div className="text-sm font-bold text-gray-900">↓ {linkValue}</div>
+          </div>
+          <div className="mb-2">
+            {isProjectBudgetToSpending ? (
+              <div className="text-xs text-gray-500">支出</div>
+            ) : (
+              <div className="text-sm font-semibold text-gray-900 truncate">{targetName}</div>
+            )}
+            <div className="text-sm font-medium text-gray-700">{targetValue}</div>
+          </div>
+          {actualLink?.details && (actualLink.details.contractMethod || actualLink.details.blockName) && (
+            <div className="mt-3 pt-2 border-t border-gray-200">
+              {actualLink.details.contractMethod && (
+                <div className="mb-1">
+                  <span className="text-xs text-gray-500">契約方式: </span>
+                  <span className="text-xs font-medium text-gray-900">{actualLink.details.contractMethod}</span>
+                </div>
+              )}
+              {actualLink.details.blockName && (
+                <div>
+                  <span className="text-xs text-gray-500">支出ブロック: </span>
+                  <span className="text-xs font-medium text-gray-900">{actualLink.details.blockName}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    },
+    [data.nodes, data.links, formatCurrency]
+  );
+
+  return (
+    <div style={{ position: 'relative', width, height }}>
+      <svg ref={svgRef} width={width} height={height}>
+        <g transform={`translate(${margin.left},${margin.top})`}>
+          {/* Links */}
+          <g>
+            {layoutLinks.map((link, i) => {
+              const linkOpacity = hoveredLinkIndex === i ? 0.8 : isLinkConnected(link) ? 0.5 : 0.1;
+              return (
+                <MemoLink
+                  key={`${link.source.id}-${link.target.id}-${i}`}
+                  link={link}
+                  opacity={linkOpacity}
+                  pathGenerator={pathGenerator}
+                  onMouseEnter={(e: React.MouseEvent) => handleLinkMouseEnter(link, i, e)}
+                  onMouseLeave={handleLinkMouseLeave}
+                />
+              );
+            })}
+          </g>
+
+          {/* Nodes */}
+          <g>
+            {layoutNodes.map((node) => {
+              const nodeOpacity = isConnected(node.id) ? 1 : 0.35;
+              return (
+                <MemoNode
+                  key={node.id}
+                  node={node}
+                  opacity={nodeOpacity}
+                  onMouseEnter={(e: React.MouseEvent) => handleNodeMouseEnter(node, e)}
+                  onMouseLeave={handleNodeMouseLeave}
+                  onClick={() => onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: (node.x1 ?? 0) - (node.x0 ?? 0), height: (node.y1 ?? 0) - (node.y0 ?? 0) })}
+                />
+              );
+            })}
+          </g>
+
+          {/* Labels */}
+          <g>
+            {layoutNodes.map((node) => {
+              const isBudgetNode = node.type === 'ministry-budget' || node.type === 'project-budget';
+              const x = isBudgetNode ? (node.x0 ?? 0) - 4 : (node.x1 ?? 0) + 4;
+              const textAnchor = isBudgetNode ? 'end' : 'start';
+              const amountX = ((node.x0 ?? 0) + (node.x1 ?? 0)) / 2;
+              const nodeY = node.y0 ?? 0;
+              const nodeH = (node.y1 ?? 0) - nodeY;
+              const clickable = isClickable(node);
+              const color = clickable ? '#2563eb' : '#1f2937';
+              const fontWeight = clickable ? 'bold' : 500;
+              const cursorStyle = clickable ? 'pointer' : 'default';
+              const displayName = getDisplayName(node);
+              const amount = getDisplayAmount(node);
+              const labelOpacity = isConnected(node.id) ? 1 : 0.35;
+
+              return (
+                <g key={`label-${node.id}`} style={{ cursor: cursorStyle, opacity: labelOpacity, transition: 'opacity 0.15s' }}>
+                  {/* 金額ラベル */}
+                  <text
+                    x={amountX}
+                    y={nodeY - 6}
+                    textAnchor="middle"
+                    dominantBaseline="auto"
+                    style={{ fontSize: 11, fontWeight: 600, fill: '#1f2937', pointerEvents: 'none' }}
+                  >
+                    {amount}
+                  </text>
+                  {/* 名前ラベル */}
+                  <text
+                    x={x}
+                    y={nodeY + nodeH / 2}
+                    textAnchor={textAnchor}
+                    dominantBaseline="middle"
+                    style={{ fill: color, fontSize: 12, fontWeight, pointerEvents: clickable ? 'auto' : 'none', cursor: cursorStyle }}
+                    onClick={() => clickable && onNodeClick({ id: node.id, x: node.x0, y: node.y0, width: (node.x1 ?? 0) - (node.x0 ?? 0), height: (node.y1 ?? 0) - (node.y0 ?? 0) })}
+                  >
+                    {displayName.includes('\n') ? (
+                      displayName.split('\n').map((line, i) => (
+                        <tspan key={i} x={x} dy={i === 0 ? '-0.5em' : '1.2em'}>
+                          {line}
+                        </tspan>
+                      ))
+                    ) : (
+                      displayName
+                    )}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </g>
+      </svg>
+
+      {/* Tooltip overlay */}
+      {tooltip && (
+        <div
+          style={{
+            position: 'absolute',
+            left: tooltip.x + 10,
+            top: tooltip.y - 10,
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        >
+          {tooltip.type === 'node' && tooltip.node && renderNodeTooltip(tooltip.node)}
+          {tooltip.type === 'link' && tooltip.link && renderLinkTooltip(tooltip.link)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/tasks/20260324_0536_sankey_Global_View自前SVG移行計画.md
+++ b/docs/tasks/20260324_0536_sankey_Global_View自前SVG移行計画.md
@@ -1,0 +1,136 @@
+# /sankey Global View 自前SVG移行計画
+
+## 目的
+
+ユーザーがスライダー等のインタラクション操作をした際に、nivo の SVG 全再構築による描画遅延を解消するため。React.memo による差分更新で、変更のないノード・リンクの再描画をスキップできるようにする。
+
+## スコープ
+
+- **対象**: Global View の Sankey 描画を nivo → 自前SVG（/sankey2方式）に置き換え
+- **対象外**: Ministry / Project / Spending View（引き続き nivo を使用）
+- **nivo 依存**: `/sankey` 以外（`/mof-budget-overview` 等）でも使用しているため、パッケージ自体は残す
+
+## 現状分析
+
+### nivo が提供している機能（Global View で使用中）
+
+| 機能 | nivo の実装 | 自前SVG での代替 |
+|------|-----------|-----------------|
+| ノード配置（x, y 座標計算） | nivo 内部で d3-sankey を使用 | API レスポンスの nodes/links から自前計算、または既存 `sankey-generator.ts` にレイアウト計算を追加 |
+| リンク描画（ベジェ曲線） | nivo 内部で path 生成 | SVG `<path>` に d3-sankey の `sankeyLinkHorizontal` を直接使用 |
+| ノード描画 | SVG `<rect>` | SVG `<rect>` + React.memo |
+| ラベル描画 | カスタムレイヤーで `<text>` | SVG `<text>` または `<foreignObject>`（/sankey2方式） |
+| ホバーハイライト | `nodeHoverOthersOpacity: 0.35` | state + opacity 制御 |
+| ツールチップ | nivo HTML overlay | HTML div overlay（既存のツールチップJSXをそのまま流用） |
+| クリックハンドラ | `onClick` prop | SVG 要素の `onClick`（既存の `handleNodeClick` をそのまま流用） |
+| ノードソート | `sort="input"` | データ順序をそのまま描画 |
+
+### 最大の課題: レイアウト計算
+
+nivo は内部で d3-sankey を使ってノードの x, y 座標とリンクのパスを計算している。自前SVG移行ではこの計算を自分で行う必要がある。
+
+**選択肢:**
+
+1. **d3-sankey を直接使用**: `d3-sankey` パッケージを import してレイアウト計算し、結果を SVG で描画
+2. **サーバー側でレイアウト計算**: `sankey-generator.ts` で座標も計算してAPIレスポンスに含める（/sankey2 の `compute-sankey2-layout.ts` と同じアプローチ）
+
+→ **選択肢1を採用**: クライアント側で d3-sankey を使い、nivo と同等のレイアウトを維持する。サーバー側変更が不要で、既存APIレスポンス（nodes + links）をそのまま使える。
+
+## 設計
+
+### コンポーネント構成
+
+```
+app/sankey/page.tsx
+  └─ viewState.mode === 'global'
+       ? <SankeyGlobalView />  ← 新規（自前SVG）
+       : <ResponsiveSankey />  ← 既存（nivo、Ministry/Project/Spending用）
+```
+
+### SankeyGlobalView コンポーネント
+
+`client/components/SankeyGlobalView.tsx` を新規作成。
+
+**入力:**
+- `data`: API レスポンスの `sankey`（`{ nodes: SankeyNode[], links: SankeyLink[] }`）
+- `onNodeClick`: 既存の `handleNodeClick`
+- `formatCurrency`: 既存の金額フォーマット関数
+
+**内部処理:**
+1. `useMemo` で d3-sankey レイアウトを計算（nodes に x0, x1, y0, y1 を付与、links にパスを付与）
+2. SVG `<g>` 内にリンク→ノード→ラベルの順で描画
+3. React.memo でノード・リンクをメモ化
+
+**サブコンポーネント:**
+
+| コンポーネント | 役割 |
+|--------------|------|
+| `MemoSankeyNode` | 単一ノードの `<rect>` + ホバー/クリック |
+| `MemoSankeyLink` | 単一リンクの `<path>` |
+| `SankeyLabels` | ノードラベル（金額 + 名前、既存カスタムレイヤーのロジックを移植） |
+
+### ホバーハイライト
+
+- `hoveredNodeId` state を管理
+- ホバー中ノードに接続しているリンク・ノードは通常の opacity
+- それ以外は `opacity: 0.35`（nivo の `nodeHoverOthersOpacity` と同じ値）
+- 接続判定: `links` から source/target の隣接マップを事前構築
+
+### ツールチップ
+
+既存の `nodeTooltip` / `linkTooltip` の JSX をそのまま流用。SVG の上に absolute 配置の HTML div として重ねる。マウス座標から位置を計算。
+
+### スライダー連携の改善
+
+自前SVG移行により、スライダー操作時の描画が高速化される理由:
+- API レスポンス受信後、d3-sankey レイアウトは `useMemo` で再計算（軽量）
+- **変更のないノード（府省庁・事業列）は React.memo でスキップ**
+- 変更のある支出先ノード・リンクのみ DOM 更新
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `client/components/SankeyGlobalView.tsx`（新規） | 自前SVG描画コンポーネント |
+| `app/sankey/page.tsx` | Global View 時に `SankeyGlobalView` を使用、それ以外は既存 nivo を維持 |
+| `package.json` | `d3-sankey` + `@types/d3-sankey` を追加 |
+
+## ロードマップ
+
+### Step 1: d3-sankey でレイアウト計算の検証
+
+- `d3-sankey` をインストール
+- 既存の API レスポンス（nodes + links）を d3-sankey に渡してレイアウト計算
+- nivo と同等の座標が得られることを確認
+
+### Step 2: SankeyGlobalView 基本描画
+
+- ノード（`<rect>`）+ リンク（`<path>`）+ ラベル（`<text>`）の静的描画
+- 既存の色分けロジック（緑=予算、赤=支出、グレー=その他）を移植
+- 固定サイズ（800px高）での表示
+
+### Step 3: インタラクション実装
+
+- ノードクリック: 既存 `handleNodeClick` を接続
+- ホバーハイライト: 隣接ノード・リンクの opacity 制御
+- ツールチップ: 既存のツールチップ JSX を HTML overlay として配置
+
+### Step 4: page.tsx の条件分岐
+
+- `viewState.mode === 'global'` で `SankeyGlobalView` を使用
+- それ以外のビューでは既存 `ResponsiveSankey` を維持
+- スライダーとの連携動作を確認
+
+### Step 5: 動作確認・調整
+
+- nivo との見た目の差分を確認・調整
+- スライダー操作時のパフォーマンスを確認
+- `npm run lint` + `npx tsc --noEmit`
+
+## レイヤー設計ルール適合チェック
+
+- `scripts/`: 変更なし
+- `app/lib/`: 変更なし（既存の sankey-generator.ts はそのまま）
+- `app/api/`: 変更なし
+- `client/components/`: 再利用可能UI。直接APIコールなし
+- `app/sankey/page.tsx`: 描画コンポーネントの切り替えのみ

--- a/docs/tasks/20260324_0752_sankey_Global_View_sankey2方式移行計画.md
+++ b/docs/tasks/20260324_0752_sankey_Global_View_sankey2方式移行計画.md
@@ -1,0 +1,230 @@
+# /sankey Global View → /sankey2 方式移行計画
+
+## 目的
+
+ユーザーがスライダーで支出先の表示範囲を変更した際に、全列（府省庁・事業・支出先）が動的に入れ替わるインタラクションを **即座（16ms以内）** に実現するため。
+
+現在の SVG + d3-sankey 方式では、ノード入れ替えのたびにレイアウト全体を再計算する必要があり、スライダー操作に数百msの遅延が発生する。/sankey2 方式（事前計算レイアウト + SVG描画）に移行することで、ランタイムのレイアウト計算をゼロにする。
+
+## 現状の課題
+
+| 項目 | 現在の実装（SVG + d3-sankey） | 問題 |
+|------|---------------------------|------|
+| レイアウト計算 | スライダー操作のたびに d3-sankey で全ノード再計算 | 数百msの遅延 |
+| 描画更新 | React.memo で差分更新 | レイアウト計算がボトルネックで効果限定的 |
+| データ取得 | API + クライアント側生成のハイブリッド | 複雑で保守困難 |
+| 全列入れ替え | 未実装（支出先列のみ差し替え） | 本来やりたいことができない |
+
+## /sankey2 方式の核心
+
+/sankey2 は以下の2段階パイプラインで動作する:
+
+1. **ビルド時**: 全ノード・全エッジの座標を事前計算し、JSONに保存
+2. **ランタイム**: クライアントはJSONから座標を読み、表示対象のノード・エッジだけをSVGに描画
+
+ランタイムにレイアウト計算が一切ない。表示対象の切り替え = 配列のフィルタリングのみ。
+
+## 設計
+
+### アプローチ: スライダーレベル別の事前計算レイアウト
+
+Global View のスライダーは「支出先の表示範囲」を10件ずつページングする。各レベル（ページ）に応じて表示する府省庁・事業・支出先が変わる。
+
+**事前計算の単位**: スライダーの各レベル（0, 1, 2, ...）ごとに、表示すべきノード・リンクとその座標を計算してJSONに格納する。
+
+### データパイプライン
+
+```
+[既存] sankey-generator.ts (selectData + buildSankeyData)
+    ↓ レベルごとにノード・リンクを生成
+[新規] compute-sankey-global-layout.ts
+    ↓ 各レベルのノード・リンクに座標を付与
+[出力] sankey-global-layout.json(.gz)
+```
+
+### レイアウト計算方式
+
+/sankey2 はツリーマップ（面積ベース）のレイアウトだが、/sankey の Global View は**列ベースの Sankey レイアウト**（左から右への流れ）。
+
+レイアウト計算には2つの選択肢がある:
+
+#### 選択肢A: d3-sankey をビルド時に実行
+
+- 現在クライアントで行っている d3-sankey のレイアウト計算を、ビルドスクリプトで全レベル分実行
+- 出力: 各レベルの `{ nodes: [{id, x0, x1, y0, y1, ...}], links: [{source, target, path, width, ...}] }`
+- メリット: 現在の見た目をそのまま維持、実装が最もシンプル
+- デメリット: レベル間でノード位置が大きく変わる可能性（アニメーションなしだとジャンプ感）
+
+#### 選択肢B: 固定列 + 可変高さの自前レイアウト
+
+- 府省庁・事業・支出先の3列（+集約ノード）の x 座標を固定
+- 各ノードの y 座標と高さを金額比例で計算（d3-sankey 不使用）
+- リンクはベジェ曲線で接続
+- メリット: レイアウトロジックを完全制御、レベル間の遷移を安定化しやすい
+- デメリット: 実装コスト高、d3-sankey の最適配置アルゴリズムを再実装する必要
+
+→ **選択肢A を推奨**。見た目の変更を最小限にし、実装リスクを抑える。
+
+### 出力データ構造
+
+```
+sankey-global-layout.json:
+{
+  "metadata": {
+    "totalLevels": 2683,        // 総レベル数（ceil(26823/10)）
+    "recipientsPerLevel": 10,
+    "totalRecipients": 26823
+  },
+  "levels": {
+    "0": {
+      "nodes": [
+        { "id": "ministry-budget-1", "name": "...", "type": "ministry-budget",
+          "x0": 0, "x1": 44, "y0": 100, "y1": 300, "value": 12345678,
+          "details": { ... } },
+        ...
+      ],
+      "links": [
+        { "source": "ministry-budget-1", "target": "project-budget-123",
+          "value": 5000000, "path": "M0,150C200,150,200,200,400,200",
+          "details": { ... } },
+        ...
+      ]
+    },
+    "1": { ... },
+    ...
+  }
+}
+```
+
+### ファイルサイズの見積もり
+
+- 各レベル: 約50〜100ノード + 100〜200リンク（座標付き）≒ 約30KB/レベル
+- 総レベル数: ~2,683（26,823件 / 10件）
+- 合計: ~80MB（非圧縮）、~8MB（gzip）
+- 既存の sankey2-layout.json（~45MB gzip）と同程度
+
+### 最適化: 共通ノードの差分格納
+
+多くのレベルで府省庁ノードは共通。差分格納で大幅にサイズを削減できる:
+
+```
+{
+  "baseNodes": [ ... ],        // 全レベル共通のノード（府省庁等）
+  "levels": {
+    "0": {
+      "nodes": [ ... ],        // このレベル固有のノード（支出先等）のみ
+      "links": [ ... ],
+      "removedNodeIds": [ ... ] // baseNodesから除外するID（もしあれば）
+    }
+  }
+}
+```
+
+→ ただし全列入れ替えが要件なので、レベルによって府省庁・事業も変わる可能性あり。初回は差分格納なしで実装し、サイズが問題になったら最適化する。
+
+### クライアント側コンポーネント
+
+```
+app/sankey/page.tsx
+  └─ viewState.mode === 'global'
+       ? <SankeyGlobalView />   ← 改修（事前計算レイアウトを描画）
+       : <ResponsiveSankey />   ← 既存（nivo、Ministry/Project/Spending用）
+```
+
+**SankeyGlobalView の変更点**:
+
+1. データソース変更: d3-sankey レイアウト計算 → 事前計算JSONからレベル別データを取得
+2. スライダー操作: `levels[level]` を参照するだけ（計算なし）
+3. 描画ロジック: 既存のSVG描画（MemoNode, MemoLink）をそのまま活用
+
+### データ読み込み戦略
+
+sankey-global-layout.json は ~8MB(gz) あるため、全レベルを一括読み込みするとメモリ消費が大きい。
+
+#### 方式: レベル別の遅延読み込み + キャッシュ
+
+- JSONを1ファイルにまとめるのではなく、レベルごとに分割ファイルを生成
+- または、1ファイルだがクライアントで全読み込みしてメモリに保持（8MBなら許容範囲）
+
+→ **1ファイル全読み込みを推奨**。8MB(gz)はモダンブラウザで問題なく、レベル切り替えが完全に即座になる。分割ファイルだとフェッチ待ちが発生する。
+
+### スライダー操作時のフロー
+
+```
+ユーザーがスライダーを操作
+  ↓
+spendingDrilldownLevel が変更
+  ↓
+levels[level] からノード・リンクを取得（O(1)参照）
+  ↓
+SVG描画更新（React.memoで差分のみ）
+  ↓
+即座に表示（レイアウト計算なし）
+```
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `scripts/compute-sankey-global-layout.ts`（新規） | 全レベルの事前計算レイアウト生成スクリプト |
+| `client/components/SankeyGlobalView.tsx` | d3-sankey → 事前計算レイアウト参照に変更 |
+| `app/sankey/page.tsx` | データ読み込みを事前計算JSON方式に変更 |
+| `package.json` | scripts に `compute-sankey-global-layout` を追加 |
+
+**変更不要**:
+- `app/lib/sankey-generator.ts` — ビルドスクリプトから呼び出して使用（既存ロジックを流用）
+- `app/api/sankey/route.ts` — Global View以外のビューでは引き続き使用
+- `types/preset.ts` — 既存の型をビルドスクリプトでも使用
+
+## ロードマップ
+
+### Step 1: ビルドスクリプト作成
+
+- `scripts/compute-sankey-global-layout.ts` を新規作成
+- 既存の `sankey-generator.ts` の `selectData` + `buildSankeyData` を呼び出し、全レベル分のノード・リンクを生成
+- 各レベルのデータに d3-sankey でレイアウト座標を付与
+- `public/data/sankey-global-layout.json` に出力
+
+### Step 2: SankeyGlobalView の改修
+
+- d3-sankey のランタイム計算を削除
+- 事前計算JSONからレベル別データを参照して描画
+- 既存のSVG描画ロジック（MemoNode, MemoLink, ホバー, ツールチップ）はそのまま
+
+### Step 3: page.tsx のデータ読み込み変更
+
+- Global View 初期化時に `sankey-global-layout.json` を一括読み込み
+- スライダー操作時は `levels[level]` を参照するだけに簡素化
+- `buildGlobalSankeyForLevel`（クライアント側生成ロジック）を削除
+
+### Step 4: パイプライン統合
+
+- `package.json` に `compute-sankey-global-layout` スクリプトを追加
+- `compress-data` で `.gz` 化
+- `prebuild` で自動展開されることを確認
+
+### Step 5: 動作確認・調整
+
+- スライダー操作の即座性を確認
+- nivo との見た目の差分を確認・調整
+- `npm run lint` + `npx tsc --noEmit`
+
+## レイヤー設計ルール適合チェック
+
+- `scripts/`: CSV/JSON処理のみ。UIやAPIロジックなし
+- `app/lib/`: ビルドスクリプトからの呼び出し用。HTTP・React禁止を維持
+- `app/api/`: Global View 以外のビューで引き続き使用
+- `client/components/`: 再利用可能UI。直接APIコールなし
+- `app/sankey/page.tsx`: 状態管理・データ読み込み・レイアウトのみ
+
+## 検討事項
+
+### 全列入れ替えの実現方法
+
+現在のサーバー側ロジック（`selectData`）は、`spendingDrilldownLevel` に応じて表示する事業・府省庁を動的に選択している。レベル0ではTopN事業のみ、レベル1以降では該当支出先に紐づく全事業が表示される。この既存ロジックをビルドスクリプトでレベルごとに実行することで、全列入れ替えを実現する。
+
+### d3-sankey パッケージの扱い
+
+- ビルドスクリプトで使用（事前計算用）
+- クライアント側では不要になる（`SankeyGlobalView` から削除可能）
+- ただし Ministry/Project/Spending View の nivo が内部で使用しているため、パッケージ自体は残す

--- a/docs/tasks/20260324_1058_sankey_Global_View事前計算の最適化.md
+++ b/docs/tasks/20260324_1058_sankey_Global_View事前計算の最適化.md
@@ -1,0 +1,123 @@
+# /sankey Global View 事前計算の最適化
+
+## 目的
+
+スライダーのレベルごとに全列（府省庁・事業・支出先）が正しく入れ替わる事前計算レイアウトを、実用的な時間（数分以内）で生成できるようにする。
+
+## 問題
+
+### 現在の不具合: 支出先ノードが表示されない
+
+`buildSankeyForLevel`（支出先列のみ差し替え方式）では、レベル0のトップ事業に紐づくプロジェクト参照しか `allRecipients` に含まれていない。下位の支出先は別の事業に紐づいているため、リンクが0本 → ノードがフィルタアウトされる。
+
+### d3-sankey の列シフト問題
+
+支出先ノードがないと、d3-sankey の `sankeyJustify` アライメントが事業ノードを最右列に押し出す。これは d3-sankey の仕様（下流リンクのないノードを右端に配置）。
+
+### パフォーマンス問題
+
+`generateSankeyData` を全レベル（~1,042回）呼ぶと、`selectData` 内の以下の処理が毎回繰り返される:
+
+| 処理 | 計算量 | レベル依存 |
+|------|--------|-----------|
+| 1. 府省庁選択 | O(37) | なし（共通） |
+| 2. 事業フィルタ | O(5,003) | なし（共通） |
+| 3. 支出先ランキング計算 | O(26,823 × projects) | なし（共通） |
+| 4. 支出先スライス | O(1) | **レベルごとに異なる** |
+| 5. 貢献事業の選択 | O(5,003 × spendings) | **レベルごとに異なる** |
+| 6. その他事業の集計 | O(ministries) | **レベルごとに異なる** |
+
+処理1-3は全レベルで同一の結果を返す。処理4-6のみがレベルに依存する。
+
+## 設計
+
+### アプローチ: `selectData` を2段階に分離
+
+`selectData` を「共通計算」と「レベル依存計算」に分離する。
+
+#### Phase 1: 共通計算（1回のみ実行）
+
+```
+selectGlobalBase(data, { limit, drilldownLevel })
+  → topMinistries
+  → projectsFromSelectedMinistries
+  → allRecipients（ランキング済み、全件）
+  → recipientSpendingMap
+  → otherMinistriesBudget / otherMinistriesSpending
+```
+
+#### Phase 2: レベル依存計算（レベルごとに実行）
+
+```
+selectGlobalLevel(base, { spendingOffset, spendingLimit })
+  → topSpendings（スライス）
+  → topProjects（貢献事業の選択）
+  → otherProjectsBudgetByMinistry
+  → otherProjectsSpendingByMinistry
+  → otherSpendingsByProject
+  → otherNamedSpendingByProject
+```
+
+### ビルドスクリプトのフロー
+
+```
+1. selectGlobalBase() を1回呼ぶ（~3秒）
+2. for level in 0..totalLevels:
+     a. selectGlobalLevel(base, level) でデータ選択（~数ms）
+     b. buildSankeyData(selection) でノード・リンク構築（~数ms）
+     c. computeLayout() で d3-sankey レイアウト計算（~数ms）
+     d. 結果を levels[level] に格納
+3. JSON出力
+```
+
+### 既存コードへの影響
+
+`selectData` を直接分割するのではなく、**ビルドスクリプト専用の関数を新設**する。
+
+理由:
+- `selectData` は既にMinistry/Project/Spending Viewでも使われており、分割するとリスクが高い
+- ビルドスクリプトはGlobal Viewのみが対象
+- 既存の `generateSankeyData` のAPIコールパスは変更しない
+
+### 新設する関数
+
+`scripts/compute-sankey-global-layout.ts` 内に以下の関数を実装:
+
+1. **`computeGlobalBase()`** — 共通計算。`selectData` のGlobal View部分（L500-590）を抽出
+2. **`computeGlobalLevel()`** — レベル依存計算。`selectData` のL622-726を抽出
+3. **`buildGlobalSankeyNodes()`** — `buildSankeyData` のGlobal View固有パスを抽出
+
+これらはスクリプト内のローカル関数とし、`app/lib/` には追加しない（レイヤー設計ルール: `scripts/` にUIやAPIロジック禁止）。
+
+### 処理5の最適化: 逆引きインデックス
+
+現在の「各事業の支出先への支出額計算」は、事業ごとに全支出先をスキャンしている（O(N×M)）。
+
+事前に「支出先ID → [(projectId, amount)]」の逆引きマップを構築することで O(N+M) に削減:
+
+```
+spendingToProjects: Map<spendingId, Array<{projectId, amount}>>
+
+for spending in data.spendings:
+  for project in spending.projects:
+    spendingToProjects[spending.spendingId].push({projectId, amount})
+```
+
+これにより、レベルごとの貢献事業計算が:
+- Before: 5,003事業 × 26,823支出先のネストループ
+- After: 10支出先 × 平均projects数のルックアップ
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `scripts/compute-sankey-global-layout.ts` | 共通計算分離 + 逆引きインデックス + レベル別データ生成 |
+
+**変更なし**: `app/lib/sankey-generator.ts`, `client/components/SankeyGlobalView.tsx`, `app/sankey/page.tsx`
+（前回のコミットでの変更をそのまま維持）
+
+## レイヤー設計ルール適合チェック
+
+- `scripts/`: CSV/JSON処理のみ。新設関数はスクリプト内ローカル
+- `app/lib/`: 変更なし
+- `client/components/`: 変更なし

--- a/docs/tasks/20260325_0524_sankey_Global_View自前SVG移行振り返り.md
+++ b/docs/tasks/20260325_0524_sankey_Global_View自前SVG移行振り返り.md
@@ -1,0 +1,90 @@
+# /sankey Global View 自前SVG移行 振り返り
+
+## 概要
+
+`/sankey` Global View を nivo ベースの描画から **自前SVG + 事前計算レイアウト** 方式へ移行する試みを実施。
+スライダー操作の即座反映（16ms）は達成したが、**d3-sankey のレイアウト問題**が未解決のためマージ保留。
+
+## ブランチ
+
+`feature/sankey-global-custom-svg`（5 commits）
+
+## 実施内容
+
+### Phase 1: nivo → d3-sankey + React.memo（`e606829`）
+
+- nivo の `ResponsiveSankey` を排除し、`d3-sankey` で直接レイアウト計算
+- `SankeyGlobalView.tsx` を新規作成（MemoNode / MemoLink で個別メモ化）
+- **結果**: 描画自体は動作するが、スライダー操作ごとに API + レイアウト再計算が走り遅い
+
+### Phase 2: 全ページプリフェッチ（`fe1a465`）
+
+- 起動時に全レベル（0〜1042）のデータを API から一括取得しキャッシュ
+- スライダー操作時はキャッシュからO(1)参照 + d3-sankeyレイアウト計算のみ
+- **結果**: API待ちは解消したが、レイアウト計算（~50ms/レベル）が残る
+
+### Phase 3: クライアント側支出先入替（`723c938`）
+
+- レベル0のベースレイアウト（ministry/project列）を固定し、支出先ノードのみ動的入替
+- **問題発覚**: `allRecipients` がレベル0の `topProjectIds` に基づくプロジェクト参照しか持たないため、下位支出先のリンクが生成できず空欄になる
+
+### Phase 4: ビルド時事前計算（`5708410`）— 最終形
+
+- `scripts/compute-sankey-global-layout.ts` で全1042レベルを事前計算
+- `GlobalBaseCache` + 逆引きインデックス（`projectToSpendings`）で `selectData` のO(N^2)を解消
+- `buildSankeyData` 内の `fullData.budgets.find()` を `projectId → ministry` ルックアップMapで置換
+- **結果**: 全1042レベルを **7.2秒** で生成、35MB JSON（gzip 7.3MB）
+- クライアントは起動時に1回フェッチ → スライダーはO(1)参照で即座描画
+
+## 未解決の問題: d3-sankey `sankeyJustify` レイアウト崩れ
+
+### 症状
+
+特定のスライダーレベルで支出先ノードが少ない（または0個）になった場合、d3-sankey の `sankeyJustify` アルゴリズムが**下流リンクを持たないノードを最右列に押し出す**。
+
+具体的には:
+- 事業→支出先ブロックノードが支出先列に移動してしまう
+- 省庁→事業リンクの配置も連鎖的に崩れる
+
+### 原因
+
+d3-sankey の `sankeyJustify` は「下流リンクがないノード = 最終列に配置」というヒューリスティックを持つ。
+これは一般的なSankeyでは合理的だが、本アプリの「固定4列構造（省庁→事業→支出先ブロック→支出先）」では期待と異なる動作になる。
+
+### 検討した対策
+
+| 対策 | 評価 |
+|------|------|
+| `sankeyLeft` に変更 | 左寄せになり別の崩れが発生 |
+| 不可視ダミーノード追加 | 列構造は維持できるがリンク計算が複雑化 |
+| d3-sankey の `computeNodeDepths` を上書き | 列を固定割り当てできるが、d3-sankey内部APIへの依存が大きい |
+| **自前レイアウトエンジン** | d3-sankey を完全排除し列位置を明示指定。最も確実だが工数大 |
+
+### 推奨次ステップ
+
+1. **自前レイアウトエンジンの検討**: `/sankey2` の `compute-sankey2-layout.ts` は既に自前でx座標を列ごとに固定割り当てしている。同様のアプローチを `/sankey` Global View にも適用すれば d3-sankey 依存を排除できる
+2. **ダミーノード方式の試行**: 工数が少ないため先に試す価値あり。各列に不可視ノードを配置し、d3-sankey に列構造を強制する
+
+## 成果物
+
+| ファイル | 役割 |
+|---------|------|
+| `client/components/SankeyGlobalView.tsx` | 自前SVG描画コンポーネント（570行） |
+| `scripts/compute-sankey-global-layout.ts` | ビルド時レイアウト計算（265行） |
+| `public/data/sankey-global-layout.json.gz` | 事前計算済みレイアウト（7.3MB） |
+| `app/lib/sankey-generator.ts` | GlobalBaseCache + 逆引きインデックス最適化 |
+| `types/preset.ts` | `GlobalLayoutData` / `LevelLayout` 型定義 |
+
+## パフォーマンス改善の記録
+
+| 段階 | 全1042レベル生成時間 |
+|------|---------------------|
+| 初回実装（毎回フル計算） | 45分以上（推定） |
+| GlobalBaseCache導入 | ~400秒（1.5s/level × 100で中断） |
+| buildSankeyData最適化（budgets.find→Map） | **7.2秒**（0.007s/level） |
+
+## 学び
+
+- **d3-sankey は固定列構造と相性が悪い**: `sankeyJustify` のヒューリスティックが列の意味的な固定を壊す。固定列が必要なら自前レイアウトが安全
+- **事前計算 + O(1)参照は正しいアーキテクチャ**: 7.2秒のビルドコストで1042レベル全てが即座に表示可能になった
+- **逆引きインデックスの効果は絶大**: `selectData` + `buildSankeyData` の両方で O(N^2) → O(N) 化し、600倍の高速化を実現

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "@xyflow/react": "^12.10.1",
         "d3-hierarchy": "^3.1.2",
         "d3-interpolate": "^3.0.1",
+        "d3-sankey": "^0.12.3",
         "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
         "dagre": "^0.8.5",
         "next": "15.1.11",
         "react": "^18.3.1",
@@ -25,6 +27,8 @@
         "three": "^0.183.2"
       },
       "devDependencies": {
+        "@types/d3-sankey": "^0.12.5",
+        "@types/d3-shape": "^3.1.8",
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -1480,6 +1484,30 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@nivo/sankey/node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/sankey/node_modules/@types/d3-sankey": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.11.2.tgz",
+      "integrity": "sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^1"
+      }
+    },
+    "node_modules/@nivo/sankey/node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
+      }
+    },
     "node_modules/@nivo/text": {
       "version": "0.99.0",
       "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
@@ -1751,9 +1779,10 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-sankey": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.11.2.tgz",
-      "integrity": "sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.12.5.tgz",
+      "integrity": "sha512-/3RZSew0cLAtzGQ+C89hq/Rp3H20QJuVRSqFy6RKLe7E0B8kd2iOS1oBsodrgds4PcNVpqWhdUEng/SHvBcJ6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-shape": "^1"
@@ -1763,12 +1792,14 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
       "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
       "version": "1.3.12",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
       "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "^1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "@xyflow/react": "^12.10.1",
     "d3-hierarchy": "^3.1.2",
     "d3-interpolate": "^3.0.1",
+    "d3-sankey": "^0.12.3",
     "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
     "dagre": "^0.8.5",
     "next": "15.1.11",
     "react": "^18.3.1",
@@ -41,6 +43,8 @@
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@types/d3-sankey": "^0.12.5",
+    "@types/d3-shape": "^3.1.8",
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate-structured": "tsx scripts/generate-structured-json.ts",
     "generate-project-details": "tsx scripts/generate-project-details.ts",
     "generate-mof-data": "tsx scripts/generate-mof-budget-overview-data.ts",
-    "compress-data": "gzip -9 -k public/data/rs2024-structured.json && gzip -9 -k public/data/rs2024-project-details.json && gzip -9 -k public/data/project-quality-recipients.json && gzip -9 -k -f public/data/sankey2-graph.json && gzip -9 -k -f public/data/sankey2-layout.json",
+    "compress-data": "gzip -9 -k public/data/rs2024-structured.json && gzip -9 -k public/data/rs2024-project-details.json && gzip -9 -k public/data/project-quality-recipients.json && gzip -9 -k -f public/data/sankey2-graph.json && gzip -9 -k -f public/data/sankey2-layout.json && gzip -9 -k -f public/data/sankey-global-layout.json",
     "generate-entity-dict": "tsx scripts/generate-entity-dict.ts",
     "validate-tags": "tsx scripts/validate-tags.ts",
     "build-houjin-db": "python3 scripts/build-houjin-sqlite.py",
@@ -21,6 +21,7 @@
     "generate-entity-labels-csv": "python3 scripts/generate-entity-labels-csv.py",
     "generate-sankey2": "tsx scripts/generate-sankey2-data.ts",
     "compute-sankey2-layout": "tsx scripts/compute-sankey2-layout.ts",
+    "compute-sankey-global-layout": "tsx scripts/compute-sankey-global-layout.ts",
     "setup": "npm install && npm run normalize && npm run generate-structured && npm run generate-project-details"
   },
   "dependencies": {

--- a/scripts/compute-sankey-global-layout.ts
+++ b/scripts/compute-sankey-global-layout.ts
@@ -1,0 +1,265 @@
+/**
+ * /sankey Global View 事前計算レイアウトスクリプト
+ *
+ * 全スライダーレベル（支出先ページ）のSankeyレイアウトを事前計算し、
+ * sankey-global-layout.json に出力する。
+ *
+ * generateSankeyData をレベルごとに呼び出す。selectData 内の共通計算
+ * （府省庁選択・支出先ランキング）はキャッシュされるため高速。
+ *
+ * 使い方:
+ *   npm run compute-sankey-global-layout
+ *
+ * 入力: public/data/rs2024-structured.json (要: npm run generate-structured)
+ * 出力: public/data/sankey-global-layout.json
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  sankey as d3Sankey,
+  sankeyJustify,
+  sankeyLinkHorizontal,
+  type SankeyNode as D3SankeyNode,
+  type SankeyLink as D3SankeyLink,
+} from 'd3-sankey';
+import { generateSankeyData } from '../app/lib/sankey-generator';
+import type { SankeyNode, SankeyLink } from '@/types/preset';
+
+// ── Layout constants (matching SankeyGlobalView.tsx) ──
+
+const SVG_WIDTH = 1200;
+const SVG_HEIGHT = 800;
+const MARGIN = { top: 40, right: 100, bottom: 40, left: 100 };
+const INNER_WIDTH = SVG_WIDTH - MARGIN.left - MARGIN.right;
+const INNER_HEIGHT = SVG_HEIGHT - MARGIN.top - MARGIN.bottom;
+const NODE_WIDTH = 44;
+const NODE_PADDING = 22;
+
+// ── d3-sankey types ──
+
+interface D3Node {
+  id: string;
+  name: string;
+  type: string;
+  value: number;
+  details?: SankeyNode['details'];
+  originalId?: number;
+  x0?: number;
+  x1?: number;
+  y0?: number;
+  y1?: number;
+}
+
+interface D3Link {
+  source: D3Node;
+  target: D3Node;
+  value: number;
+  details?: SankeyLink['details'];
+  width?: number;
+  y0?: number;
+  y1?: number;
+}
+
+// ── Output types ──
+
+interface LayoutNodeOutput {
+  id: string;
+  name: string;
+  type: string;
+  value: number;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+  originalId?: number;
+  details?: SankeyNode['details'];
+}
+
+interface LayoutLinkOutput {
+  source: string;
+  target: string;
+  value: number;
+  path: string;
+  width: number;
+  y0: number;
+  y1: number;
+  details?: SankeyLink['details'];
+}
+
+interface LevelLayout {
+  nodes: LayoutNodeOutput[];
+  links: LayoutLinkOutput[];
+}
+
+interface GlobalLayoutData {
+  metadata: {
+    totalLevels: number;
+    recipientsPerLevel: number;
+    totalRecipients: number;
+    svgWidth: number;
+    svgHeight: number;
+    margin: typeof MARGIN;
+  };
+  levels: Record<string, LevelLayout>;
+}
+
+// ── Layout computation ──
+
+function computeLayout(nodes: SankeyNode[], links: SankeyLink[]): LevelLayout {
+  const d3Nodes: D3Node[] = nodes.map((n) => ({
+    id: n.id,
+    name: n.name,
+    type: n.type,
+    value: n.value,
+    details: n.details,
+    originalId: n.originalId,
+  }));
+
+  const nodeMap = new Map(d3Nodes.map((n, i) => [n.id, i]));
+  const d3Links: D3Link[] = links
+    .filter((l) => nodeMap.has(l.source) && nodeMap.has(l.target))
+    .map((l) => ({
+      source: d3Nodes[nodeMap.get(l.source)!],
+      target: d3Nodes[nodeMap.get(l.target)!],
+      value: l.value,
+      details: l.details,
+    }));
+
+  const generator = d3Sankey<D3Node, D3Link>()
+    .nodeId((d) => d.id)
+    .nodeWidth(NODE_WIDTH)
+    .nodePadding(NODE_PADDING)
+    .nodeAlign(sankeyJustify)
+    .nodeSort(null)
+    .extent([
+      [0, 0],
+      [INNER_WIDTH, INNER_HEIGHT],
+    ]);
+
+  const { nodes: layoutNodes, links: layoutLinks } = generator({
+    nodes: d3Nodes,
+    links: d3Links,
+  });
+
+  const pathGen = sankeyLinkHorizontal<
+    D3SankeyNode<D3Node, D3Link>,
+    D3SankeyLink<D3Node, D3Link>
+  >();
+
+  const outputNodes: LayoutNodeOutput[] = layoutNodes.map((n) => ({
+    id: n.id,
+    name: n.name,
+    type: n.type,
+    value: n.value,
+    x0: n.x0 ?? 0,
+    x1: n.x1 ?? 0,
+    y0: n.y0 ?? 0,
+    y1: n.y1 ?? 0,
+    originalId: n.originalId,
+    details: n.details,
+  }));
+
+  const outputLinks: LayoutLinkOutput[] = layoutLinks.map((l) => ({
+    source: l.source.id,
+    target: l.target.id,
+    value: l.value,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    path: pathGen(l as any) || '',
+    width: l.width ?? 1,
+    y0: l.y0 ?? 0,
+    y1: l.y1 ?? 0,
+    details: l.details,
+  }));
+
+  return { nodes: outputNodes, links: outputLinks };
+}
+
+// ── Main ──
+
+async function main() {
+  console.log('Computing Sankey Global View layouts...\n');
+
+  const MINISTRY_LIMIT = 3;
+  const PROJECT_LIMIT = 3;
+  const SPENDING_LIMIT = 10;
+  const SUBCONTRACT_LIMIT = 10;
+
+  // Step 1: Generate level 0 to discover total recipient count
+  console.log('  Generating level 0 (triggers common computation cache)...');
+  const startTime = Date.now();
+
+  const level0Data = await generateSankeyData({
+    ministryLimit: MINISTRY_LIMIT,
+    projectLimit: PROJECT_LIMIT,
+    spendingLimit: SPENDING_LIMIT,
+    subcontractLimit: SUBCONTRACT_LIMIT,
+    spendingDrilldownLevel: 0,
+  });
+
+  const totalRecipients = level0Data.metadata.summary.totalFilteredSpendings ?? 0;
+  const totalLevels = Math.ceil(totalRecipients / SPENDING_LIMIT);
+
+  console.log(`  Total recipients: ${totalRecipients.toLocaleString()}`);
+  console.log(`  Total levels: ${totalLevels}`);
+  console.log(`  Level 0 generated in ${((Date.now() - startTime) / 1000).toFixed(1)}s\n`);
+
+  // Step 2: Compute layout for each level
+  const levels: Record<string, LevelLayout> = {};
+
+  console.log('  Computing all levels...');
+  const layoutStart = Date.now();
+
+  // Level 0
+  levels['0'] = computeLayout(level0Data.sankey.nodes, level0Data.sankey.links);
+
+  // Levels 1..N (selectData common computation is cached, so these are fast)
+  for (let level = 1; level < totalLevels; level++) {
+    if (level % 100 === 0 || level === 1) {
+      const elapsed = ((Date.now() - layoutStart) / 1000).toFixed(1);
+      process.stdout.write(`  Level ${level}/${totalLevels} (${((level / totalLevels) * 100).toFixed(0)}%, ${elapsed}s)...\r`);
+    }
+
+    const data = await generateSankeyData({
+      ministryLimit: MINISTRY_LIMIT,
+      projectLimit: PROJECT_LIMIT,
+      spendingLimit: SPENDING_LIMIT,
+      subcontractLimit: SUBCONTRACT_LIMIT,
+      spendingDrilldownLevel: level,
+    });
+
+    levels[String(level)] = computeLayout(data.sankey.nodes, data.sankey.links);
+  }
+
+  const layoutTime = ((Date.now() - layoutStart) / 1000).toFixed(1);
+  console.log(`\n  All ${totalLevels} levels computed in ${layoutTime}s`);
+
+  // Step 3: Write output
+  const output: GlobalLayoutData = {
+    metadata: {
+      totalLevels,
+      recipientsPerLevel: SPENDING_LIMIT,
+      totalRecipients,
+      svgWidth: SVG_WIDTH,
+      svgHeight: SVG_HEIGHT,
+      margin: MARGIN,
+    },
+    levels,
+  };
+
+  const outputPath = path.join(process.cwd(), 'public/data/sankey-global-layout.json');
+  const jsonStr = JSON.stringify(output);
+  fs.writeFileSync(outputPath, jsonStr);
+
+  const sizeMB = (Buffer.byteLength(jsonStr) / 1024 / 1024).toFixed(1);
+  const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\n  Output: ${outputPath}`);
+  console.log(`  Size: ${sizeMB} MB`);
+  console.log(`  Total time: ${totalTime}s`);
+  console.log('\nDone!');
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/decompress-data.sh
+++ b/scripts/decompress-data.sh
@@ -69,4 +69,15 @@ if [ -f "$DATA_DIR/sankey2-layout.json.gz" ]; then
   fi
 fi
 
+# Decompress sankey-global-layout.json if needed
+if [ -f "$DATA_DIR/sankey-global-layout.json.gz" ]; then
+  if [ ! -f "$DATA_DIR/sankey-global-layout.json" ] || [ "$DATA_DIR/sankey-global-layout.json.gz" -nt "$DATA_DIR/sankey-global-layout.json" ]; then
+    echo "🔓 Decompressing sankey-global-layout.json.gz..."
+    gunzip -k -f "$DATA_DIR/sankey-global-layout.json.gz"
+    echo "✅ Decompression complete ($(du -h "$DATA_DIR/sankey-global-layout.json" | cut -f1))"
+  else
+    echo "✅ sankey-global-layout.json already exists and is up to date"
+  fi
+fi
+
 echo "✅ All data files ready"

--- a/types/preset.ts
+++ b/types/preset.ts
@@ -8,6 +8,20 @@ import type { SpendingTags, FundingSources } from './structured';
 export interface RS2024PresetData {
   metadata: PresetMetadata;
   sankey: SankeyData;
+  // Global View: クライアント側で支出先ページングを行うための全支出先データ（ソート済み）
+  allRecipients?: RecipientSummary[];
+}
+
+// クライアント側支出先ページング用の軽量支出先データ
+export interface RecipientSummary {
+  spendingId: number;
+  spendingName: string;
+  corporateNumber: string;
+  location: string;
+  projectCount: number;
+  tags?: SpendingTags;
+  // この支出先への支出元プロジェクトごとの金額（topProjects に含まれるもののみ）
+  projects: { projectId: number; amount: number; contractMethod?: string; blockName?: string }[];
 }
 
 // プリセットメタデータ


### PR DESCRIPTION
## Summary

- `/sankey` Global View を nivo → **自前SVG描画（d3-sankey + React.memo）** に移行
- 全1042スライダーレベルを**ビルド時に事前計算**（7.2秒生成、7.3MB gzip）
- スライダー操作はO(1)参照で**即座に描画**（API呼び出し不要）
- `selectData` / `buildSankeyData` のO(N²)ボトルネックを逆引きインデックスで解消（600倍高速化）

## Known Issue: d3-sankey レイアウト崩れ

d3-sankey の `sankeyJustify` が下流リンクのないノードを最右列に押し出すため、特定レベルで列構造が崩れる。
**マージ前に要対応**（自前レイアウトエンジン or ダミーノード方式）。

詳細: `docs/tasks/20260325_0524_sankey_Global_View自前SVG移行振り返り.md`

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `client/components/SankeyGlobalView.tsx` | 自前SVG描画コンポーネント（新規570行） |
| `scripts/compute-sankey-global-layout.ts` | ビルド時レイアウト計算スクリプト（新規265行） |
| `app/lib/sankey-generator.ts` | GlobalBaseCache + 逆引きインデックス最適化 |
| `app/sankey/page.tsx` | 事前計算データ読み込み + スライダーO(1)参照 |
| `public/data/sankey-global-layout.json.gz` | 事前計算済みレイアウト（7.3MB） |
| `types/preset.ts` | GlobalLayoutData / LevelLayout 型定義 |

## Test plan

- [ ] `npm run dev` で `/sankey` にアクセスし Global View が表示されること
- [ ] スライダー操作で即座にノード・リンクが切り替わること
- [ ] d3-sankey レイアウト崩れの対策を実施してから main にマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)