### PR TITLE
fix: /sankey-svg TopN以外事業集約ノードの件数をウィンドウ連動に修正 (#114)

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -171,15 +171,16 @@ function filterTopN(
 
   // 5. Aggregated values
   let otherProjectWindowTotal = 0;
-  for (const e of allEdges) {
-    if (otherProjectSpendingIds.has(e.source) && windowRecipientIds.has(e.target)) {
-      otherProjectWindowTotal += e.value;
-    }
-  }
   let otherProjectTailTotal = 0;
+  const otherProjectsWithFlow = new Set<string>();
   for (const e of allEdges) {
-    if (otherProjectSpendingIds.has(e.source) && tailRecipientIds.has(e.target)) {
+    if (!otherProjectSpendingIds.has(e.source)) continue;
+    if (windowRecipientIds.has(e.target)) {
+      otherProjectWindowTotal += e.value;
+      otherProjectsWithFlow.add(e.source);
+    } else if (tailRecipientIds.has(e.target)) {
       otherProjectTailTotal += e.value;
+      otherProjectsWithFlow.add(e.source);
     }
   }
 
@@ -237,9 +238,9 @@ function filterTopN(
       : 0;
     const projectLayoutCap = minTopProjectWindowValue > 0 ? minTopProjectWindowValue * topProject : otherProjectTailTotal;
     if (otherProjectWindowTotal > 0) {
-      nodes.push({ id: '__agg-project-budget', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-budget', value: otherProjectWindowTotal, layoutCap: projectLayoutCap, aggregated: true });
+      nodes.push({ id: '__agg-project-budget', name: `${otherProjectsWithFlow.size.toLocaleString()}事業`, type: 'project-budget', value: otherProjectWindowTotal, layoutCap: projectLayoutCap, aggregated: true });
     }
-    nodes.push({ id: '__agg-project-spending', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-spending', value: otherProjectWindowTotal, layoutCap: projectLayoutCap, aggregated: true });
+    nodes.push({ id: '__agg-project-spending', name: `${otherProjectsWithFlow.size.toLocaleString()}事業`, type: 'project-spending', value: otherProjectWindowTotal, layoutCap: projectLayoutCap, aggregated: true });
   }
 
   for (const [rid] of windowRecipients) {


### PR DESCRIPTION
## 目的

ユーザーが支出先オフセットスライダーを動かしても、TopN以外事業の集約ノードラベル（`N事業`）の件数が変わらない問題を解消する。

## 変更内容

**原因**: `otherProjects.length` は「topN以外の全事業数」の固定値（例: 5614）で、オフセット変更に関わらず常に一定だった。

**修正**: 2つのループを1つに統合し、実際にウィンドウ内または末尾の支出先へエッジがある事業IDを `Set<string>` で追跡。このセットのサイズをラベルに使用するよう変更。

```
// 変更前
name: `${otherProjects.length.toLocaleString()}事業`  // 固定値

// 変更後
name: `${otherProjectsWithFlow.size.toLocaleString()}事業`  // オフセット連動
```

**動作**:
- オフセット=0: 支出先の多くがウィンドウ内 → 件数は大きい
- オフセット増加: 一部の支出先がプレウィンドウ（非表示）に移動 → その支出先へのフローしかない事業はカウントから外れる
- 結果として、オフセット変更でラベルの件数も動的に変化する

## テスト方法

```bash
npm run dev  # localhost:3002/sankey-svg
```

1. `/sankey-svg` を開く
2. 支出先オフセットスライダーを動かす
3. TopN以外事業の集約ノードラベルの件数が変化することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved the accuracy of aggregate project flow calculations. The system now ensures that label counts reflect only projects with actual outgoing flow to recipients, eliminating previously inflated counts from projects with no active flow. This results in more precise project flow metrics and prevents overcounting in aggregated project data visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->