### PR TITLE
fix: /sankey-svg 支出先開始位置入力をZoomと同様の編集時のみ表示に変更 (#117)

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -952,7 +952,7 @@ export default function RealDataSankeyPage() {
                 <button
                   onClick={() => { setOffsetInputValue(String(rangeStart)); setIsEditingOffset(true); }}
                   title="クリックして開始位置を入力"
-                  style={{ width: 40, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: 12, background: '#fff', cursor: 'text', padding: '1px 0' }}
+                  style={{ color: '#999', fontSize: 11, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
                 >{rangeStart}</button>
               )}
               <span style={{ color: '#999', fontSize: 11 }}>〜{rangeEnd}位</span>


### PR DESCRIPTION
## 目的

支出先オフセットの数値入力がZoomコントロールと見た目が統一されておらず、常時テキストボックスが露出していた状態を解消する。

## 変更内容

- 非編集時: ボタン表示（現在の開始位置 `N`）
- クリックで `type="number"` 入力に切り替え（スピンボタン付き）
- `onChange` で即時反映
- Enter / Escape / フォーカスアウトで閉じる

## テスト方法

```bash
npm run dev  # localhost:3002/sankey-svg
```

1. 右上パネルの支出先開始位置がボタン表示になっていることを確認
2. クリックで数値入力に切り替わることを確認
3. スピンボタンで即時反映されることを確認
4. Enter/Escape/フォーカスアウトでボタン表示に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recipient offset input with toggle-based editing mode—displays the value as a button when not editing and switches to an input field when clicked for a cleaner interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->