### PR TITLE
feat: /sankey-svg 検索ボックス追加

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -743,19 +743,40 @@ export default function RealDataSankeyPage() {
       selectNode(nodeId);
       return;
     }
-    // Recipient outside window: jump offset so it's visible, then select
+    // Helper: jump recipientOffset to center on a recipient rank
+    const jumpToRecipientRank = (rank: number, totalCount: number) => {
+      const maxOffset = Math.max(0, totalCount - topRecipient);
+      const newOffset = Math.max(0, Math.min(rank - Math.floor(topRecipient / 2), maxOffset));
+      setRecipientOffset(newOffset);
+    };
+
     if (nodeId.startsWith('r-') && filtered) {
+      // Recipient outside window: jump offset so it's visible
       const rank = allRecipientRanks.get(nodeId);
-      if (rank !== undefined) {
-        const maxOffset = Math.max(0, filtered.totalRecipientCount - topRecipient);
-        const newOffset = Math.max(0, Math.min(rank - Math.floor(topRecipient / 2), maxOffset));
-        setRecipientOffset(newOffset);
+      if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);
+    } else if ((nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-')) && filtered && graphData) {
+      // Project outside TopN: find its highest-value recipient edge and jump there.
+      // This shifts the window so the project's window spending increases → likely enters TopN.
+      const spendingId = nodeId.startsWith('project-budget-')
+        ? nodeId.replace('project-budget-', 'project-spending-')
+        : nodeId;
+      let bestRecipientId: string | null = null;
+      let bestValue = 0;
+      for (const e of graphData.edges) {
+        if (e.source === spendingId && e.target.startsWith('r-') && e.value > bestValue) {
+          bestValue = e.value;
+          bestRecipientId = e.target;
+        }
+      }
+      if (bestRecipientId !== null) {
+        const rank = allRecipientRanks.get(bestRecipientId);
+        if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);
       }
     }
-    // Any other node not in layout (ministry/project outside TopN):
-    // select anyway — panel shows info from graphData, no highlight/dim applied
+    // select — if node enters layout after offset change, highlight/dim applies;
+    // otherwise panel shows info from graphData only
     selectNode(nodeId);
-  }, [layout, filtered, allRecipientRanks, topRecipient, selectNode]);
+  }, [layout, filtered, allRecipientRanks, topRecipient, selectNode, graphData]);
 
   const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
## 目的

ノード名でインクリメンタルサーチでき、目的のノードにすぐにジャンプできるようにする。

## 変更内容

- 左上のタイトルバッジを削除し、検索ボックスを配置（/sankey2スタイル）
- 2文字以上の入力でノード名部分一致サーチ（150ms デバウンス）
- ドロップダウン: ノード種別カラー + 名前 + 金額（value 降順・最大20件）
- 選択時: `selectNode` + ウィンドウ外の支出先は `recipientOffset` を自動調整
- Escape / ✕ボタンで検索クリア

## テスト方法

```bash
npm run dev
```

1. `localhost:3002/sankey-svg` を開く
2. 左上の検索ボックスに2文字以上入力 → ドロップダウン表示を確認
3. ドロップダウンの項目をクリック → サイドパネルが開き対象ノードがハイライトされることを確認
4. ウィンドウ外の支出先名を入力 → クリックでオフセットが自動調整されて表示されることを確認
5. Escape / ✕ボタンで検索クリアを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-left node search UI with text input, optional clear button, and focus-driven results.
  * Debounced input (150ms) for live results; shows up to 20 sorted matches in a scrollable list.
  * Selecting a result navigates to the node and hides results; shows “該当なし” when no matches.
* **Bug Fixes / Behavior**
  * Selecting nodes not currently visible still opens the details panel; visual highlight applies only to nodes present in the view.
  * Selection is cleared only when a node is removed from the underlying data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->