### PR TITLE
feat: /sankey-svg 選択ノードと隣接ノードのラベルを常時表示

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -669,8 +669,10 @@ export default function RealDataSankeyPage() {
                     const h = node.y1 - node.y0;
                     // Label is 9px on screen (fontSize 9/zoom * zoom = 9).
                     // Available space per node on screen = (h + NODE_PAD) * zoom.
-                    // Show label when available space exceeds font height.
-                    const showLabel = (h + NODE_PAD) * zoom > 10;
+                    // Show label when available space exceeds font height,
+                    // or when the node is selected / connected to the selected node.
+                    const isHighlighted = connectedNodeIds?.has(node.id) ?? false;
+                    const showLabel = (h + NODE_PAD) * zoom > 10 || isHighlighted;
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
                     return (


### PR DESCRIPTION
## 目的（Why）

ユーザーが選択ノードおよびその接続先ノードを確認する際、ズームレベルが低くノード高さが小さいと接続先のラベルが表示されず、どのノードが強調されているか把握しづらい状態を解消するため。

## 変更内容

`app/sankey-svg/page.tsx` のノード描画ロジックを1箇所修正:

```ts
// Before
const showLabel = (h + NODE_PAD) * zoom > 10;

// After
const isHighlighted = connectedNodeIds?.has(node.id) ?? false;
const showLabel = (h + NODE_PAD) * zoom > 10 || isHighlighted;
```

- `connectedNodeIds` は選択中ノード + その1ホップ隣接ノードのIDセット（既存の useMemo）
- 選択・強調状態のノードはズームレベルに関わらずラベルを表示

## テスト方法

1. `npm run dev` → http://localhost:3002/sankey-svg
2. 任意のノードをクリックして選択
3. ズームを下げてノード高さが小さくなる状態にする
4. 選択ノード・その接続先ノードのラベルが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label visibility in Sankey diagrams: selected nodes and their connected nodes now display labels consistently, even when screen space is limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->