### PR TITLE
fix: /sankey-svg オフセット変更時の事業非表示ロジックを path-independent に再設計

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -256,7 +256,7 @@ export function filterTopN(
     const bv = budgetNode?.value ?? 0;
     if (bv > 0) edges.push({ source: `project-budget-${n.projectId}`, target: n.id, value: bv });
   }
-  if (otherProjectBudgetTotal > 0) {
+  if (otherProjectBudgetTotal > 0 && (otherProjectWindowTotal > 0 || otherProjectTailTotal > 0)) {
     edges.push({ source: '__agg-project-budget', target: '__agg-project-spending', value: otherProjectBudgetTotal });
   }
 

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -86,10 +86,13 @@ export function filterTopN(
   // Projects that originally have spending (node.value > 0) but have no flow to any visible recipient
   // (neither window nor tail — all spending goes to above-window recipients only) are effectively hidden.
   // Projects with tail-only flow remain in aggregation and ministry totals.
+  // Pinned projects are exempted: they are kept visible even when effectively hidden so that
+  // ministryBudgetValue and project budget columns stay in sync.
   // This is computed purely from current state (path-independent).
   const effectivelyHiddenIds = new Set(
     allNodes
       .filter(n => n.type === 'project-spending' && n.value > 0
+        && !topProjectIds.has(n.id)  // pinned projects are in topProjectIds — do not hide them
         && (projectWindowValue.get(n.id) || 0) === 0
         && (projectTailValue.get(n.id) || 0) === 0)
       .map(n => n.id)
@@ -178,14 +181,14 @@ export function filterTopN(
     const hidden = projectAboveWindowSpending.get(n.id) || 0;
     nodes.push({ ...n, value: n.value - hidden, skipLinkOverride: true });
   }
-  // Create __agg-project-budget when aggregated projects have budget (otherProjectBudgetTotal > 0),
-  // while still requiring aggregated spending flow via the outer guard.
+  // Create __agg-project-budget when aggregated projects have budget (otherProjectBudgetTotal > 0).
+  // This can happen even when flow is zero (budget-only projects with no spending edges).
+  if (otherProjectBudgetTotal > 0) {
+    nodes.push({ id: '__agg-project-budget', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-budget', value: otherProjectBudgetTotal, skipLinkOverride: true, aggregated: true });
+  }
   // Create __agg-project-spending whenever there is ANY flow through it (window OR tail),
   // so that the tail edge __agg-project-spending→__agg-recipient always has a valid source node.
   if (otherProjectWindowTotal > 0 || otherProjectTailTotal > 0) {
-    if (otherProjectBudgetTotal > 0) {
-      nodes.push({ id: '__agg-project-budget', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-budget', value: otherProjectBudgetTotal, skipLinkOverride: true, aggregated: true });
-    }
     const otherProjectSpendingTotal = otherProjects.reduce((s, p) => s + p.value - (projectAboveWindowSpending.get(p.id) || 0), 0);
     nodes.push({ id: '__agg-project-spending', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-spending', value: otherProjectSpendingTotal, skipLinkOverride: true, aggregated: true });
   }

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -13,8 +13,7 @@ export function filterTopN(
   topRecipient: number,
   recipientOffset: number,
   pinnedProjectId: string | null = null,
-  hiddenProjectIds: Set<string> = new Set(),
-): { nodes: RawNode[]; edges: RawEdge[]; totalRecipientCount: number; aggNodeMembers: Map<string, AggMember[]>; topProjectIds: Set<string>; projectsWithWindowFlow: Set<string> } {
+): { nodes: RawNode[]; edges: RawEdge[]; totalRecipientCount: number; aggNodeMembers: Map<string, AggMember[]>; topProjectIds: Set<string> } {
   // Build O(1) lookup map
   const nodeById = new Map(allNodes.map(n => [n.id, n]));
 
@@ -39,13 +38,16 @@ export function filterTopN(
   const tailRecipients = allSortedRecipients.slice(recipientOffset + topRecipient);
   const tailRecipientIds = new Set(tailRecipients.map(([id]) => id));
 
-  // 3. Per-project and per-recipient window spending (all projects, used for re-ranking)
+  // 3. Per-project and per-recipient window/tail spending (all projects, used for re-ranking)
   const projectWindowValue = new Map<string, number>();
   const recipientWindowValue = new Map<string, number>();
+  const projectTailValue = new Map<string, number>();
   for (const e of allEdges) {
     if (windowRecipientIds.has(e.target)) {
       projectWindowValue.set(e.source, (projectWindowValue.get(e.source) || 0) + e.value);
       recipientWindowValue.set(e.target, (recipientWindowValue.get(e.target) || 0) + e.value);
+    } else if (tailRecipientIds.has(e.target)) {
+      projectTailValue.set(e.source, (projectTailValue.get(e.source) || 0) + e.value);
     }
   }
 
@@ -81,11 +83,28 @@ export function filterTopN(
   }
   const topProjectIds = new Set(topProjectNodes.map(n => n.id));
 
+  // Projects that originally have spending (node.value > 0) but have no flow to any visible recipient
+  // (neither window nor tail — all spending goes to above-window recipients only) are effectively hidden.
+  // Projects with tail-only flow remain in aggregation and ministry totals.
+  // This is computed purely from current state (path-independent).
+  const effectivelyHiddenIds = new Set(
+    allNodes
+      .filter(n => n.type === 'project-spending' && n.value > 0
+        && (projectWindowValue.get(n.id) || 0) === 0
+        && (projectTailValue.get(n.id) || 0) === 0)
+      .map(n => n.id)
+  );
+  const effectivelyHiddenBudgetIds = new Set(
+    allNodes
+      .filter(n => n.type === 'project-spending' && effectivelyHiddenIds.has(n.id) && n.projectId != null)
+      .map(n => `project-budget-${n.projectId}`)
+  );
+
   const otherMinistryProjects = allNodes.filter(
-    n => n.type === 'project-spending' && !topMinistryNames.has(n.ministry || '') && !topProjectIds.has(n.id) && !hiddenProjectIds.has(n.id)
+    n => n.type === 'project-spending' && !topMinistryNames.has(n.ministry || '') && !topProjectIds.has(n.id) && !effectivelyHiddenIds.has(n.id)
   );
   const otherProjects = [
-    ...topMinistryAllProjects.filter(n => !topProjectIds.has(n.id) && !hiddenProjectIds.has(n.id)),
+    ...topMinistryAllProjects.filter(n => !topProjectIds.has(n.id) && !effectivelyHiddenIds.has(n.id)),
     ...otherMinistryProjects,
   ];
   const otherProjectSpendingIds = new Set(otherProjects.map(n => n.id));
@@ -125,12 +144,11 @@ export function filterTopN(
   const otherMinistryWindowValue = otherMinistries.reduce((s, n) => s + (ministryWindowValue.get(n.name) || 0), 0);
 
   // 7. Ministry budget totals (sum of project-budget values per ministry — for node heights)
-  // Exclude hidden projects (projects that left TopN due to offset change)
+  // Exclude effectively hidden projects (had spending but lost window flow at current offset)
   const ministryBudgetValue = new Map<string, number>();
   for (const n of allNodes) {
     if (n.type === 'project-budget' && n.ministry) {
-      const spendingId = n.projectId != null ? `project-spending-${n.projectId}` : null;
-      if (spendingId && hiddenProjectIds.has(spendingId)) continue;
+      if (effectivelyHiddenBudgetIds.has(n.id)) continue;
       ministryBudgetValue.set(n.ministry, (ministryBudgetValue.get(n.ministry) || 0) + n.value);
     }
   }
@@ -179,9 +197,9 @@ export function filterTopN(
   // tailValue = total inflow to rank (offset+topRecipient)+ recipients from ALL projects.
   // otherProjectTailTotal is a subset of tailValue (aggregated projects' tail flow),
   // so it must NOT be added separately — that would double-count.
-  // Also subtract tail spending from hidden projects (they are excluded from project-spending column).
-  const hiddenTailSpending = hiddenProjectIds.size > 0
-    ? allEdges.filter(e => hiddenProjectIds.has(e.source) && tailRecipientIds.has(e.target))
+  // Subtract effectively hidden projects' tail spending (excluded from project-spending column).
+  const hiddenTailSpending = effectivelyHiddenIds.size > 0
+    ? allEdges.filter(e => effectivelyHiddenIds.has(e.source) && tailRecipientIds.has(e.target))
               .reduce((s, e) => s + e.value, 0)
     : 0;
   const tailValue = tailRecipients.reduce((s, [, v]) => s + v, 0) - hiddenTailSpending;
@@ -287,10 +305,7 @@ export function filterTopN(
     }));
   }
 
-  const projectsWithWindowFlow = new Set(
-    allNodes.filter(n => n.type === 'project-spending' && (projectWindowValue.get(n.id) || 0) > 0).map(n => n.id)
-  );
-  return { nodes, edges, totalRecipientCount, aggNodeMembers, topProjectIds, projectsWithWindowFlow };
+  return { nodes, edges, totalRecipientCount, aggNodeMembers, topProjectIds };
 }
 
 // ── Custom Layout Engine ──

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -19,10 +19,6 @@ export default function RealDataSankeyPage() {
   const [topRecipient, setTopRecipient] = useState(20);
   const [recipientOffset, setRecipientOffset] = useState(0);
   const [pinnedProjectId, setPinnedProjectId] = useState<string | null>(null);
-  const [hiddenProjectIds, setHiddenProjectIds] = useState<Set<string>>(new Set());
-  const prevTopProjectIdsRef = useRef<Set<string>>(new Set());
-  // Reset hidden projects when settings other than offset change
-  useEffect(() => { setHiddenProjectIds(new Set()); prevTopProjectIdsRef.current = new Set(); }, [graphData, topMinistry, topProject, topRecipient]);
   const [hoveredLink, setHoveredLink] = useState<LayoutLink | null>(null);
   const [hoveredNode, setHoveredNode] = useState<LayoutNode | null>(null);
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
@@ -186,43 +182,12 @@ export default function RealDataSankeyPage() {
       .catch(e => { setError(String(e)); setLoading(false); });
   }, []);
 
-  // Compute projectsWithWindowFlow independently of hiddenProjectIds to avoid circular deps in the effect below.
-  // This includes ALL projects (not just TopN) that have spending to the current window.
-  const rawProjectsWithWindowFlow = useMemo(() => {
-    if (!graphData) return new Set<string>();
-    const maxOffset = Math.max(0, (graphData.nodes.filter(n => n.type === 'recipient').length) - topRecipient);
-    const clampedOffset = Math.min(recipientOffset, maxOffset);
-    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId).projectsWithWindowFlow;
-  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId]);
-
-  // Update hiddenProjectIds: projects that had window flow before but lost it should be hidden.
-  // No dependency on hiddenProjectIds → no circular loop.
-  useEffect(() => {
-    if (recipientOffset === 0) {
-      setHiddenProjectIds(h => h.size === 0 ? h : new Set());
-      prevTopProjectIdsRef.current = rawProjectsWithWindowFlow;
-      return;
-    }
-    const prev = prevTopProjectIdsRef.current;
-    const curr = rawProjectsWithWindowFlow;
-    if (prev.size > 0) {
-      setHiddenProjectIds(h => {
-        const next = new Set(h);
-        for (const id of prev) { if (!curr.has(id)) next.add(id); }
-        for (const id of h) { if (curr.has(id)) next.delete(id); }
-        if (next.size === h.size && [...h].every(id => next.has(id))) return h;
-        return next;
-      });
-    }
-    prevTopProjectIdsRef.current = curr;
-  }, [rawProjectsWithWindowFlow, recipientOffset]);
-
   const filtered = useMemo(() => {
     if (!graphData) return null;
     const maxOffset = Math.max(0, (graphData.nodes.filter(n => n.type === 'recipient').length) - topRecipient);
     const clampedOffset = Math.min(recipientOffset, maxOffset);
-    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, hiddenProjectIds);
-  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, hiddenProjectIds]);
+    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId);
+  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId]);
 
   const layout = useMemo(() => {
     if (!filtered) return null;

--- a/docs/tasks/20260407_2144_sankey-svg-直接入力時の集約ノード除外処理誤り修正計画.md
+++ b/docs/tasks/20260407_2144_sankey-svg-直接入力時の集約ノード除外処理誤り修正計画.md
@@ -24,10 +24,13 @@
 | 区分 | 条件 | 扱い |
 |---|---|---|
 | 元から0円 | `node.value === 0`（CSV由来の支出額が0） | 常に集約ノードに含む（変化しない） |
-| 支出あり → ウィンドウ外 | `node.value > 0` かつ `projectWindowValue.get(id) === 0` | 個別表示・集約・省庁集計から除外 |
-| 支出あり → ウィンドウ内 | `node.value > 0` かつ `projectWindowValue.get(id) > 0` | TopN判定・通常通り |
+| 支出あり → window も tail もゼロ | `node.value > 0` かつ `windowFlow === 0` かつ `tailFlow === 0` | 個別表示・集約・省庁集計から除外 |
+| 支出あり → tail のみ | `node.value > 0` かつ `windowFlow === 0` かつ `tailFlow > 0` | 集約ノードに含む（省庁集計にも反映） |
+| 支出あり → ウィンドウ内 | `node.value > 0` かつ `windowFlow > 0` | TopN判定・通常通り |
 
-この判定は現在の状態（`node.value` と `projectWindowValue`）だけで決まる。path に依存しない。
+非表示条件は `node.value > 0 && windowFlow === 0 && tailFlow === 0`。tail にのみ支出がある事業は除外しない。
+
+この判定は現在の状態のみで決まる。path に依存しない。
 
 ### 省庁・予算総計への反映
 
@@ -48,7 +51,7 @@
 
 `projectWindowValue` が確定した後、以下を計算する:
 
-- `effectivelyHiddenIds`: `project-spending` ノードのうち `node.value > 0` かつ `projectWindowValue === 0` のセット
+- `effectivelyHiddenIds`: `project-spending` ノードのうち `node.value > 0` かつ `windowFlow === 0` かつ `tailFlow === 0` のセット（tail-only 事業は除外しない）
 
 #### `otherProjects` フィルタ変更
 
@@ -119,4 +122,5 @@ npm run dev
 1. オフセット 0 → TopN の事業(支出)が表示、0円ノードが集約に含まれること
 2. オフセットをスライダーで一気に最大値にした結果と、ボタンで徐々に最大値にした結果が一致すること
 3. 直接入力で任意の値を入力した結果が、ボタン操作で同じ値に到達した結果と一致すること
-4. `npx tsc --noEmit` でエラーなし
+4. オフセット `12388` で防衛省の合計金額が正しく集計されること（tail-only 事業が除外されないことの確認）
+5. `npx tsc --noEmit` でエラーなし

--- a/docs/tasks/20260407_2144_sankey-svg-直接入力時の集約ノード除外処理誤り修正計画.md
+++ b/docs/tasks/20260407_2144_sankey-svg-直接入力時の集約ノード除外処理誤り修正計画.md
@@ -1,0 +1,122 @@
+# /sankey-svg オフセット変更時の事業非表示ロジック設計
+
+> 作成日: 2026-04-07
+> 対象ファイル: `app/sankey-svg/page.tsx`、`app/lib/sankey-svg-filter.ts`
+
+---
+
+## 目的
+
+支出先オフセット変更に伴い、現在のウィンドウに支出先が存在しなくなった事業を正確に非表示にする。現状の path-dependent な `hiddenProjectIds` state 管理を廃止し、現在の状態だけから非表示対象を決定できるようにする。
+
+---
+
+## 現状の問題
+
+`hiddenProjectIds` は「直前の window flow セットとの差分を積み上げる」path-dependent な状態。スライダー・ボタン・直接入力で同じ値に到達しても、経路によって結果が異なる。
+
+---
+
+## 正しい設計
+
+### 非表示の定義
+
+| 区分 | 条件 | 扱い |
+|---|---|---|
+| 元から0円 | `node.value === 0`（CSV由来の支出額が0） | 常に集約ノードに含む（変化しない） |
+| 支出あり → ウィンドウ外 | `node.value > 0` かつ `projectWindowValue.get(id) === 0` | 個別表示・集約・省庁集計から除外 |
+| 支出あり → ウィンドウ内 | `node.value > 0` かつ `projectWindowValue.get(id) > 0` | TopN判定・通常通り |
+
+この判定は現在の状態（`node.value` と `projectWindowValue`）だけで決まる。path に依存しない。
+
+### 省庁・予算総計への反映
+
+- 省庁ノードの予算額 = 所属する「非除外」事業の予算合計
+- 省庁ノードの表示条件 = 省庁予算額 > 0
+- 予算総計 = 全省庁予算合計（同上）
+
+---
+
+## 変更内容
+
+### `app/lib/sankey-svg-filter.ts`
+
+#### シグネチャ変更
+`hiddenProjectIds: Set<string>` パラメータを削除する。
+
+#### ステップ4に「除外対象計算」を追加
+
+`projectWindowValue` が確定した後、以下を計算する:
+
+- `effectivelyHiddenIds`: `project-spending` ノードのうち `node.value > 0` かつ `projectWindowValue === 0` のセット
+
+#### `otherProjects` フィルタ変更
+
+```text
+変更前: topProjectIds に含まれない、かつ hiddenProjectIds に含まれないもの
+変更後: topProjectIds に含まれない、かつ effectivelyHiddenIds に含まれないもの
+```
+
+#### `ministryBudgetValue` 計算変更
+
+```text
+変更前: hiddenProjectIds（spending ID）に対応する budget を除外
+変更後: effectivelyHiddenIds に対応する project-budget-{pid} を除外
+```
+
+#### `tailValue` 計算変更
+
+```text
+変更前: hiddenProjectIds の tail 支出を tailValue から減算
+変更後: effectivelyHiddenIds の tail 支出を tailValue から減算
+```
+
+#### 戻り値変更
+`projectsWithWindowFlow` を削除する（使用箇所がなくなる）。
+
+### `app/sankey-svg/page.tsx`
+
+以下をすべて削除する:
+- `hiddenProjectIds` state
+- `prevTopProjectIdsRef` ref
+- `setHiddenProjectIds` / `prevTopProjectIdsRef.current` をリセットする `useEffect`
+- `rawProjectsWithWindowFlow` useMemo（`filterTopN` を重複呼び出しするためだけに使っていたもの）
+- `hiddenProjectIds` を更新する `useEffect`
+
+`filtered` useMemo の `filterTopN` 呼び出しから `hiddenProjectIds` 引数を削除する。
+
+---
+
+## 期待する動作
+
+| 操作 | 期待結果 |
+|---|---|
+| オフセット0 | 5664事業すべて表示（元から0円含む）、支出あり事業はすべてウィンドウ内 |
+| オフセット増加（ボタン） | 支出ありかつウィンドウ外になった事業が除外される |
+| オフセット増加（直接入力） | ボタン操作と同じ結果になる |
+| オフセット減少 | 戻ったウィンドウに支出先があれば再表示される |
+| スライダー一気移動 | ボタン操作と同じ結果になる |
+
+---
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/lib/sankey-svg-filter.ts` | `hiddenProjectIds` パラメータ削除、`effectivelyHiddenIds` をインライン計算、`projectsWithWindowFlow` 戻り値削除 |
+| `app/sankey-svg/page.tsx` | `hiddenProjectIds` 関連 state/ref/useEffect/useMemo をすべて削除 |
+
+---
+
+## 検証方法
+
+```bash
+npm run dev
+# localhost:3002/sankey-svg
+```
+
+確認ポイント:
+1. オフセット 0 → TopN の事業(支出)が表示、0円ノードが集約に含まれること
+2. オフセットをスライダーで一気に最大値にした結果と、ボタンで徐々に最大値にした結果が一致すること
+3. 直接入力で任意の値を入力した結果が、ボタン操作で同じ値に到達した結果と一致すること
+4. `npx tsc --noEmit` でエラーなし


### PR DESCRIPTION
## 目的

スライダー・調整ボタン・直接入力のどの操作でも同じオフセット値に到達したとき同じ結果になるよう、事業非表示ロジックを経路非依存（path-independent）に変更する。また、tail にのみ支出がある事業が誤って省庁集計から除外されていた問題を修正する。

## 問題の原因

`hiddenProjectIds`（経路依存 state）が「直前のウィンドウフローセットとの差分を積み上げる」方式だったため、スライダーで一気に移動した場合と調整ボタンで1ステップずつ移動した場合で結果が異なっていた。また `effectivelyHiddenIds` が `projectWindowValue === 0` のみを条件にしていたため、tail にのみ支出がある事業（ウィンドウ外だが集約ノードには含まれるべき）まで誤って除外していた（防衛省の金額ズレ等）。

## 変更内容

### `app/lib/sankey-svg-filter.ts`

- `hiddenProjectIds` パラメータを削除
- `effectivelyHiddenIds` をインライン計算（非表示条件: `node.value > 0` かつ `windowFlow = 0` かつ `tailFlow = 0`）
- tail 支出も追跡する `projectTailValue` マップを追加
- `projectsWithWindowFlow` 戻り値を削除（使用箇所がなくなったため）

### `app/sankey-svg/page.tsx`

- `hiddenProjectIds` state・`prevTopProjectIdsRef` ref・関連 useEffect を削除
- `rawProjectsWithWindowFlow` useMemo を削除（filterTopN を重複呼び出しするためだけに使用）

## テスト方法

```bash
npm run dev
# localhost:3002/sankey-svg
```

1. オフセット `12388` で防衛省の金額が正しく集計されること
2. スライダーで最大値に移動した結果と、調整ボタンで同じ値に到達した結果が一致すること
3. オフセット直接入力で任意の値を入力した結果がボタン操作と一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sankey project visibility is now consistent when adjusting recipient offset; “effectively hidden” projects with no window or tail flow are excluded.
  * Aggregated budget nodes and their edges only appear when appropriate totals exist, fixing prior incorrect aggregation behavior.

* **Refactor**
  * Filtering is fully deterministic and derived from current graph state and controls, removing path-dependent state.

* **Documentation**
  * Added design notes describing the new deterministic filtering and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->