### PR TITLE
feat: /sankey-svg ノードラベル常時表示トグルと小ノード専用間隔拡張

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -367,19 +367,35 @@ export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[]
   }
 
   const effectivePad = Math.max(NODE_PAD, minNodeGap);
+
+  // Compute the total rendered column height at a given ky using the exact same
+  // gap rule used in placement below.
+  const colHeight = (colNodes: RawNode[], candidateKy: number): number => {
+    let total = 0;
+    for (const node of colNodes) {
+      const h = Math.max(1, node.value * candidateKy);
+      const gap = (effectivePad > NODE_PAD && h < effectivePad) ? effectivePad : NODE_PAD;
+      total += h + gap;
+    }
+    return total;
+  };
+
+  // Binary-search for the largest ky such that every column fits within innerH.
   let ky = Infinity;
   for (const [, colNodes] of columns) {
     const totalValue = colNodes.reduce((s, n) => s + n.value, 0);
-    // Estimate extra gap count: use baseKy (NODE_PAD only) to approximate which nodes are "small"
-    const baseKy = totalValue > 0 ? (innerH - Math.max(0, (colNodes.length - 1) * NODE_PAD)) / totalValue : 0;
-    const extraGapCount = effectivePad > NODE_PAD
-      ? colNodes.map(n => Math.max(1, n.value * Math.max(0, baseKy))).filter(h => h < effectivePad).length
-      : 0;
-    const totalPadding = Math.max(0, (colNodes.length - 1) * NODE_PAD + extraGapCount * (effectivePad - NODE_PAD));
-    const available = innerH - totalPadding;
-    if (totalValue > 0) ky = Math.min(ky, available / totalValue);
+    if (totalValue <= 0) continue;
+    let lo = 0;
+    let hi = innerH / totalValue;  // upper bound: ignores floor(1) and gap overhead
+    // Expand hi until the column fits at hi (lo stays valid lower bound of ky)
+    while (colHeight(colNodes, hi) > innerH && hi > 1e-9) hi /= 2;
+    for (let i = 0; i < 50; i++) {
+      const mid = (lo + hi) / 2;
+      if (colHeight(colNodes, mid) <= innerH) lo = mid; else hi = mid;
+    }
+    ky = Math.min(ky, lo);
   }
-  if (!isFinite(ky)) ky = 1;
+  if (!isFinite(ky) || ky <= 0) ky = 1;
 
   for (const [col, colNodes] of columns) {
     for (const node of colNodes) {

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -313,7 +313,7 @@ export function filterTopN(
 
 // ── Custom Layout Engine ──
 
-export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[], containerWidth: number, containerHeight: number) {
+export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[], containerWidth: number, containerHeight: number, minNodeGap: number = NODE_PAD) {
   const innerW = containerWidth - MARGIN.left - MARGIN.right;
   const innerH = containerHeight - MARGIN.top - MARGIN.bottom;
   const usedCols = new Set<number>();
@@ -366,10 +366,11 @@ export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[]
     });
   }
 
+  const effectivePad = Math.max(NODE_PAD, minNodeGap);
   let ky = Infinity;
   for (const [, colNodes] of columns) {
     const totalValue = colNodes.reduce((s, n) => s + n.value, 0);
-    const totalPadding = Math.max(0, (colNodes.length - 1) * NODE_PAD);
+    const totalPadding = Math.max(0, (colNodes.length - 1) * effectivePad);
     const available = innerH - totalPadding;
     if (totalValue > 0) ky = Math.min(ky, available / totalValue);
   }
@@ -385,7 +386,9 @@ export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[]
       const h = Math.max(1, node.value * ky);
       node.y0 = y;
       node.y1 = y + h;
-      y += h + NODE_PAD;
+      // Apply extra gap only for small nodes (those whose label would be hidden in OFF mode)
+      const gap = (effectivePad > NODE_PAD && h < effectivePad) ? effectivePad : NODE_PAD;
+      y += h + gap;
     }
   }
 

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -370,7 +370,12 @@ export function computeLayout(filteredNodes: RawNode[], filteredEdges: RawEdge[]
   let ky = Infinity;
   for (const [, colNodes] of columns) {
     const totalValue = colNodes.reduce((s, n) => s + n.value, 0);
-    const totalPadding = Math.max(0, (colNodes.length - 1) * effectivePad);
+    // Estimate extra gap count: use baseKy (NODE_PAD only) to approximate which nodes are "small"
+    const baseKy = totalValue > 0 ? (innerH - Math.max(0, (colNodes.length - 1) * NODE_PAD)) / totalValue : 0;
+    const extraGapCount = effectivePad > NODE_PAD
+      ? colNodes.map(n => Math.max(1, n.value * Math.max(0, baseKy))).filter(h => h < effectivePad).length
+      : 0;
+    const totalPadding = Math.max(0, (colNodes.length - 1) * NODE_PAD + extraGapCount * (effectivePad - NODE_PAD));
     const available = innerH - totalPadding;
     if (totalValue > 0) ky = Math.min(ky, available / totalValue);
   }

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -190,12 +190,14 @@ export default function RealDataSankeyPage() {
     return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId);
   }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId]);
 
+  const minNodeGap = showLabels ? 12 / zoom : undefined;
+
   const layout = useMemo(() => {
     if (!filtered) return null;
-    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, showLabels ? 12 / zoom : undefined);
+    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, minNodeGap);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH };
     return result;
-  }, [filtered, svgWidth, svgHeight, showLabels, zoom]);
+  }, [filtered, svgWidth, svgHeight, minNodeGap]);
 
   const selectedNode = useMemo(() => {
     if (!selectedNodeId) return null;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -24,6 +24,7 @@ export default function RealDataSankeyPage() {
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
   const [showSettings, setShowSettings] = useState(false);
+  const [showLabels, setShowLabels] = useState(true);
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
   const [zoomInputValue, setZoomInputValue] = useState('');
@@ -191,10 +192,10 @@ export default function RealDataSankeyPage() {
 
   const layout = useMemo(() => {
     if (!filtered) return null;
-    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
+    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, showLabels ? 12 / zoom : undefined);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH };
     return result;
-  }, [filtered, svgWidth, svgHeight]);
+  }, [filtered, svgWidth, svgHeight, showLabels, zoom]);
 
   const selectedNode = useMemo(() => {
     if (!selectedNodeId) return null;
@@ -719,12 +720,9 @@ export default function RealDataSankeyPage() {
                   const lastCol = layout.maxCol;
                   return layout.nodes.map((node) => {
                     const h = node.y1 - node.y0;
-                    // Label is 9px on screen (fontSize 9/zoom * zoom = 9).
-                    // Available space per node on screen = (h + NODE_PAD) * zoom.
-                    // Show label when available space exceeds font height,
-                    // or when the node is selected / connected to the selected node.
                     const isSelected = node.id === selectedNodeId;
-                    const showLabel = (h + NODE_PAD) * zoom > 10 || isSelected;
+                    // When showLabels is off, use legacy rule: show only when there is enough screen space or node is selected.
+                    const labelVisible = showLabels || (h + NODE_PAD) * zoom > 10 || isSelected;
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
                     return (
@@ -754,13 +752,13 @@ export default function RealDataSankeyPage() {
                           onMouseLeave={() => setHoveredNode(null)}
                           onClick={(e) => handleNodeClick(node, e)}
                         />
-                        {showLabel && (
+                        {labelVisible && (
                           <text
                             x={node.x1 + 3}
                             y={node.y0 + h / 2}
                             fontSize={9 / zoom}
                             dominantBaseline="middle"
-                            fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#999' : '#333'}
+                            fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : '#333'}
                             style={{ userSelect: 'none', pointerEvents: 'none' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
                           >
@@ -1000,7 +998,7 @@ export default function RealDataSankeyPage() {
                               <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(item.value)}</span>
                             </button>
                           ))}
-                          <div style={{ display: 'flex', gap: 0, padding: '2px 4px', alignItems: 'center' }}>
+                          <div style={{ display: 'flex', gap: 0, padding: '2px 4px', alignItems: 'center', justifyContent: 'flex-end' }}>
                             {remaining > 0 && <>
                               <button onClick={() => setMinistryDisplayCounts(prev => new Map(prev).set(ministry, displayCount + 10))} style={btnStyle}>さらに{Math.min(10, remaining)}件（残{remaining}）</button>
                               <button onClick={() => setMinistryDisplayCounts(prev => new Map(prev).set(ministry, items.length))} style={iconBtnStyle} title="すべて表示" aria-label="すべて表示">{svgExpandAll}</button>
@@ -1090,7 +1088,7 @@ export default function RealDataSankeyPage() {
                                   </button>
                                 ))}
                                 {(() => { const rem = expandedInEdges.length - inDisplayCount; return (
-                                  <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center' }}>
+                                  <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center', justifyContent: 'flex-end' }}>
                                     {rem > 0 && <>
                                       <button onClick={() => setInDisplayCount(c => c + 10)} style={{ fontSize: 11, color: '#4a90d9', background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 4px' }}>さらに{Math.min(10, rem)}件（残{rem}）</button>
                                       <button onClick={() => setInDisplayCount(expandedInEdges.length)} style={iconBtnStyle} title="すべて表示" aria-label="すべて表示">{svgExpandAll}</button>
@@ -1129,7 +1127,7 @@ export default function RealDataSankeyPage() {
                               </button>
                             ))}
                             {(() => { const rem = expandedOutEdges.length - outDisplayCount; return (
-                              <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center' }}>
+                              <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center', justifyContent: 'flex-end' }}>
                                 {rem > 0 && <>
                                   <button onClick={() => setOutDisplayCount(c => c + 10)} style={{ fontSize: 11, color: '#4a90d9', background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 4px' }}>さらに{Math.min(10, rem)}件（残{rem}）</button>
                                   <button onClick={() => setOutDisplayCount(expandedOutEdges.length)} style={iconBtnStyle} title="すべて表示" aria-label="すべて表示">{svgExpandAll}</button>
@@ -1311,6 +1309,10 @@ export default function RealDataSankeyPage() {
                 <span style={{ width: 48, color: '#555' }}>支出先:</span>
                 <input type="number" min={1} max={100} value={topRecipient} onChange={e => setTopRecipient(Math.max(1, Math.min(100, Number(e.target.value) || 1)))} style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: 12 }} />
                 <input type="range" min={1} max={100} value={topRecipient} onChange={e => setTopRecipient(Number(e.target.value))} style={{ flex: 1 }} />
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={showLabels} onChange={e => setShowLabels(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>
               </label>
             </div>
           </>


### PR DESCRIPTION
## 目的

ユーザーが /sankey-svg でノードが小さくてもラベルを確認できるようにし、かつノード間隔の拡張を必要な箇所だけに限定することで視認性とレイアウトの両立を実現する。

## 変更内容

### 設定パネル
- 「すべてのノードラベルを表示」チェックボックスを追加（`showLabels` state、デフォルト ON）

### ノードラベル表示
- **ON 時**: 全ノードラベルを常時表示
- **OFF 時**: 従来通り、ノード高さ × zoom が一定値以下のラベルを非表示

### ノード間隔拡張（ON 時のみ）
- `computeLayout` に `minNodeGap` パラメータを追加（`12 / zoom` を渡す）
- **小ノード**（高さ < `minNodeGap`、OFF モードならラベル非表示になるもの）のみ間隔を拡張
- 大ノードは従来の `NODE_PAD` を維持 → 不要な間隔拡張を抑制

### サイドパネル
- すべて表示/折りたたむボタンを右寄せ（`justifyContent: flex-end`）に変更
- 非選択ノードのラベル色を `#999` → `#bbb`（より薄く）

## テスト方法

```bash
npm run dev
# localhost:3002/sankey-svg
```

1. 設定パネルを開き「すべてのノードラベルを表示」をON/OFFして切り替えを確認
2. ON 時: 小さいノードにも間隔が広がりラベルが重ならないことを確認
3. OFF 時: 従来通りの間隔・ラベル表示になることを確認
4. ズームを変えたとき間隔が適切にスケールされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to show/hide all node labels.

* **Improvements**
  * More flexible node spacing to reduce overlaps and improve layout.
  * Labels now recompute with zoom and toggle changes for more consistent placement.
  * Improved label color contrast for dimmed/unconnected nodes.
  * Aligned inline controls for cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->