### PR TITLE
feat: /sankey-svg 事業(予算)ノード高さをウィンドウ内支出に合わせてスケーリング (#130)

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -15,6 +15,7 @@ export function filterTopN(
   pinnedProjectId: string | null = null,
   includeZeroSpending: boolean = true,
   showAggRecipient: boolean = true,
+  scaleBudgetToVisible: boolean = true,
 ): { nodes: RawNode[]; edges: RawEdge[]; totalRecipientCount: number; aggNodeMembers: Map<string, AggMember[]>; topProjectIds: Set<string> } {
   // Build O(1) lookup map
   const nodeById = new Map(allNodes.map(n => [n.id, n]));
@@ -75,6 +76,21 @@ export function filterTopN(
         projectAboveWindowSpending.set(e.source, (projectAboveWindowSpending.get(e.source) || 0) + e.value);
       }
     }
+  }
+
+  // 3b. Adjusted budget values: scale each project-budget by visible spending fraction.
+  // visibleFraction = clamp(spendingValue / n.value, 0, 1)  (1 when n.value=0)
+  // Only applied when scaleBudgetToVisible=true.
+  const projectAdjustedBudget = new Map<string, number>();
+  for (const n of allNodes) {
+    if (n.type !== 'project-spending' || n.projectId == null) continue;
+    const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
+    if (!budgetNode) continue;
+    const sv = !showAggRecipient
+      ? (projectWindowValue.get(n.id) || 0)
+      : n.value - (projectAboveWindowSpending.get(n.id) || 0);
+    const fraction = (scaleBudgetToVisible && n.value > 0) ? Math.max(0, Math.min(1, sv / n.value)) : 1;
+    projectAdjustedBudget.set(`project-budget-${n.projectId}`, budgetNode.value * fraction);
   }
 
   // 4. TopN projects re-ranked by WINDOW spending (dynamic as offset changes)
@@ -140,10 +156,14 @@ export function filterTopN(
       otherProjectsWithFlow.add(e.source);
     }
   }
-  // Sum of budget amounts for aggregated projects (budget-column height basis).
+  // Sum of adjusted budget amounts for aggregated projects (budget-column height basis).
   const otherProjectBudgetTotal = otherProjects.reduce((s, p) => {
-    const bn = p.projectId != null ? nodeById.get(`project-budget-${p.projectId}`) : undefined;
-    return s + (bn?.value ?? 0);
+    if (p.projectId == null) return s;
+    const budgetId = `project-budget-${p.projectId}`;
+    return s + (projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0);
+  }, 0);
+  const otherProjectBudgetRawTotal = otherProjects.reduce((s, p) => {
+    return s + (p.projectId != null ? (nodeById.get(`project-budget-${p.projectId}`)?.value ?? 0) : 0);
   }, 0);
 
   const totalWindowSpending = windowRecipients.reduce((s, [, v]) => s + v, 0);
@@ -163,45 +183,56 @@ export function filterTopN(
   // 7. Ministry budget totals (sum of project-budget values per ministry — for node heights)
   // Exclude effectively hidden projects (had spending but lost window flow at current offset)
   const ministryBudgetValue = new Map<string, number>();
+  const ministryBudgetRawValue = new Map<string, number>();
   for (const n of allNodes) {
     if (n.type === 'project-budget' && n.ministry) {
       if (effectivelyHiddenBudgetIds.has(n.id)) continue;
       if (zeroSpendingBudgetIds.has(n.id)) continue;
-      ministryBudgetValue.set(n.ministry, (ministryBudgetValue.get(n.ministry) || 0) + n.value);
+      const adjValue = projectAdjustedBudget.get(n.id) ?? n.value;
+      ministryBudgetValue.set(n.ministry, (ministryBudgetValue.get(n.ministry) || 0) + adjValue);
+      ministryBudgetRawValue.set(n.ministry, (ministryBudgetRawValue.get(n.ministry) || 0) + n.value);
     }
   }
   const totalBudget = Array.from(ministryBudgetValue.values()).reduce((s, v) => s + v, 0);
+  const totalBudgetRaw = Array.from(ministryBudgetRawValue.values()).reduce((s, v) => s + v, 0);
   const otherMinistryBudgetValue = otherMinistries.reduce((s, n) => s + (ministryBudgetValue.get(n.name) || 0), 0);
+  const otherMinistryBudgetRawValue = otherMinistries.reduce((s, n) => s + (ministryBudgetRawValue.get(n.name) || 0), 0);
 
   // ── Build nodes ──
   const nodes: RawNode[] = [];
   const totalNode = allNodes.find(n => n.type === 'total');
-  if (totalNode) nodes.push({ ...totalNode, value: totalBudget, skipLinkOverride: true });
+  if (totalNode) {
+    nodes.push({ ...totalNode, value: totalBudget, rawValue: totalBudgetRaw, isScaled: totalBudget < totalBudgetRaw, skipLinkOverride: true });
+  }
 
   for (const n of topMinistryNodes) {
     const bv = ministryBudgetValue.get(n.name) || 0;
-    if (bv > 0) nodes.push({ ...n, value: bv, skipLinkOverride: true });
+    const rawBv = ministryBudgetRawValue.get(n.name) || 0;
+    if (bv > 0) nodes.push({ ...n, value: bv, rawValue: rawBv, isScaled: bv < rawBv, skipLinkOverride: true });
   }
   if (otherMinistryBudgetValue > 0) {
-    nodes.push({ id: '__agg-ministry', name: `${otherMinistries.length.toLocaleString()}省庁`, type: 'ministry', value: otherMinistryBudgetValue, skipLinkOverride: true, aggregated: true });
+    nodes.push({ id: '__agg-ministry', name: `${otherMinistries.length.toLocaleString()}省庁`, type: 'ministry', value: otherMinistryBudgetValue, rawValue: otherMinistryBudgetRawValue, isScaled: otherMinistryBudgetValue < otherMinistryBudgetRawValue, skipLinkOverride: true, aggregated: true });
   }
 
   for (const n of topProjectNodes) {
-    const wv = projectWindowValue.get(n.id) || 0;
     const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
-    // Budget height = original budget amount (budget-column basis).
-    // skipLinkOverride prevents layout engine from overriding with edge-sum (which is window spending).
-    if (budgetNode) nodes.push({ ...budgetNode, skipLinkOverride: true });
+    // Budget height = adjusted budget (scaled by visible spending fraction when scaleBudgetToVisible).
+    // rawValue preserves original budget for label display.
+    if (budgetNode) {
+      const adjBv = projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value;
+      nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, skipLinkOverride: true });
+    }
     // spending node height = window spending only (agg hidden) or total minus above-window (normal).
     const spendingValue = !showAggRecipient
       ? (projectWindowValue.get(n.id) || 0)
       : n.value - (projectAboveWindowSpending.get(n.id) || 0);
-    nodes.push({ ...n, value: spendingValue, skipLinkOverride: true });
+    const spendingTrimmed = spendingValue < n.value;
+    nodes.push({ ...n, value: spendingValue, rawValue: spendingTrimmed ? n.value : undefined, isScaled: spendingTrimmed, skipLinkOverride: true });
   }
   // Create __agg-project-budget when aggregated projects have budget (otherProjectBudgetTotal > 0).
   // This can happen even when flow is zero (budget-only projects with no spending edges).
   if (otherProjectBudgetTotal > 0) {
-    nodes.push({ id: '__agg-project-budget', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-budget', value: otherProjectBudgetTotal, skipLinkOverride: true, aggregated: true });
+    nodes.push({ id: '__agg-project-budget', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-budget', value: otherProjectBudgetTotal, rawValue: otherProjectBudgetRawTotal, isScaled: otherProjectBudgetTotal < otherProjectBudgetRawTotal, skipLinkOverride: true, aggregated: true });
   }
   // Create __agg-project-spending whenever there is flow through it.
   // In range mode: window flow only (no __agg-recipient, so tail-only nodes have no outgoing edge).
@@ -211,7 +242,9 @@ export function filterTopN(
     const otherProjectSpendingTotal = !showAggRecipient
       ? otherProjectWindowTotal
       : otherProjects.reduce((s, p) => s + p.value - (projectAboveWindowSpending.get(p.id) || 0), 0);
-    nodes.push({ id: '__agg-project-spending', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-spending', value: otherProjectSpendingTotal, skipLinkOverride: true, aggregated: true });
+    const otherProjectSpendingRawTotal = otherProjects.reduce((s, p) => s + p.value, 0);
+    const aggSpendingTrimmed = otherProjectSpendingTotal < otherProjectSpendingRawTotal;
+    nodes.push({ id: '__agg-project-spending', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-spending', value: otherProjectSpendingTotal, rawValue: aggSpendingTrimmed ? otherProjectSpendingRawTotal : undefined, isScaled: aggSpendingTrimmed, skipLinkOverride: true, aggregated: true });
   }
 
   for (const [rid] of windowRecipients) {
@@ -251,31 +284,37 @@ export function filterTopN(
     edges.push({ source: 'total', target: '__agg-ministry', value: otherMinistryBudgetValue });
   }
 
-  // ministry → project-budget (budget-based)
+  // ministry → project-budget (adjusted budget-based)
   for (const n of topProjectNodes) {
-    const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
-    const bv = budgetNode?.value ?? 0;
+    const budgetId = `project-budget-${n.projectId}`;
+    const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
     const ministrySource = topMinistryNames.has(n.ministry || '') ? `ministry-${n.ministry}` : '__agg-ministry';
-    if (bv > 0) edges.push({ source: ministrySource, target: `project-budget-${n.projectId}`, value: bv });
+    if (bv > 0) edges.push({ source: ministrySource, target: budgetId, value: bv });
   }
   if (otherProjectBudgetTotal > 0) {
     for (const mn of topMinistryNodes) {
       const v = otherProjects
         .filter(p => p.ministry === mn.name && p.projectId != null)
-        .reduce((s, p) => s + (nodeById.get(`project-budget-${p.projectId}`)?.value ?? 0), 0);
+        .reduce((s, p) => {
+          const budgetId = `project-budget-${p.projectId}`;
+          return s + (projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0);
+        }, 0);
       if (v > 0) edges.push({ source: mn.id, target: '__agg-project-budget', value: v });
     }
     const otherMinRemain = otherProjects
       .filter(p => !topMinistryNames.has(p.ministry || '') && p.projectId != null)
-      .reduce((s, p) => s + (nodeById.get(`project-budget-${p.projectId}`)?.value ?? 0), 0);
+      .reduce((s, p) => {
+        const budgetId = `project-budget-${p.projectId}`;
+        return s + (projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0);
+      }, 0);
     if (otherMinRemain > 0) edges.push({ source: '__agg-ministry', target: '__agg-project-budget', value: otherMinRemain });
   }
 
-  // project-budget → project-spending (budget-based)
+  // project-budget → project-spending (adjusted budget-based)
   for (const n of topProjectNodes) {
-    const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
-    const bv = budgetNode?.value ?? 0;
-    if (bv > 0) edges.push({ source: `project-budget-${n.projectId}`, target: n.id, value: bv });
+    const budgetId = `project-budget-${n.projectId}`;
+    const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
+    if (bv > 0) edges.push({ source: budgetId, target: n.id, value: bv });
   }
   if (otherProjectBudgetTotal > 0 && aggProjectSpendingNeeded) {
     edges.push({ source: '__agg-project-budget', target: '__agg-project-spending', value: otherProjectBudgetTotal });

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -27,6 +27,7 @@ export default function RealDataSankeyPage() {
   const [showLabels, setShowLabels] = useState(true);
   const [includeZeroSpending, setIncludeZeroSpending] = useState(false);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
+  const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
   const [zoomInputValue, setZoomInputValue] = useState('');
@@ -189,8 +190,8 @@ export default function RealDataSankeyPage() {
     if (!graphData) return null;
     const maxOffset = Math.max(0, (graphData.nodes.filter(n => n.type === 'recipient').length) - topRecipient);
     const clampedOffset = Math.min(recipientOffset, maxOffset);
-    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient);
-  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient]);
+    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible);
+  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible]);
 
   const minNodeGap = showLabels ? 12 / zoom : undefined;
 
@@ -229,7 +230,7 @@ export default function RealDataSankeyPage() {
 
   // Per-ministry project stats — for total/ministry node side panel
   type ProjectStat = { pid: number; name: string; budgetId: string; spendingId: string; budgetValue: number; spendingValue: number };
-  type MinistryStat = { total: number; budgetTotal: number; budgetOnly: number; spendingOnly: number; neither: number; projects: ProjectStat[] };
+  type MinistryStat = { total: number; budgetTotal: number; spendingTotal: number; budgetOnly: number; spendingOnly: number; neither: number; projects: ProjectStat[] };
   const ministryProjectStats = useMemo(() => {
     if (!graphData) return new Map<string, MinistryStat>();
     const spendingByPid = new Map(
@@ -244,10 +245,11 @@ export default function RealDataSankeyPage() {
       const b = n.value;
       const s = sn?.value ?? 0;
       const m = n.ministry;
-      if (!stats.has(m)) stats.set(m, { total: 0, budgetTotal: 0, budgetOnly: 0, spendingOnly: 0, neither: 0, projects: [] });
+      if (!stats.has(m)) stats.set(m, { total: 0, budgetTotal: 0, spendingTotal: 0, budgetOnly: 0, spendingOnly: 0, neither: 0, projects: [] });
       const st = stats.get(m)!;
       st.total++;
       st.budgetTotal += b;
+      st.spendingTotal += s;
       if (b === 0 && s === 0) st.neither++;
       else if (b === 0) st.spendingOnly++;
       else if (s === 0) st.budgetOnly++;
@@ -634,7 +636,7 @@ export default function RealDataSankeyPage() {
                 {/* Column labels with totals */}
                 {(() => {
                   const maxCol = layout.maxCol || 1;
-                  const amt = (n: LayoutNode) => n.rawValue ?? n.value;
+                  const amt = (n: LayoutNode) => n.value;
                   const colNodeTypes = ['total', 'ministry', 'project-budget', 'project-spending', 'recipient'] as const;
                   const colNodes = colNodeTypes.map(t =>
                     t === 'total'
@@ -767,7 +769,7 @@ export default function RealDataSankeyPage() {
                             style={{ userSelect: 'none', pointerEvents: 'none' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
                           >
-                            {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.rawValue ?? node.value)})
+                            {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#aaa"> 元: {formatYen(node.rawValue)}</tspan>)}
                           </text>
                         )}
                       </g>
@@ -815,13 +817,16 @@ export default function RealDataSankeyPage() {
           {hoveredNode && (
             <div style={{ position: 'absolute', left: mousePos.x + 12, top: mousePos.y - 10, background: 'rgba(0,0,0,0.78)', color: '#fff', padding: '5px 9px', borderRadius: 4, fontSize: 12, lineHeight: 1.4, pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 20 }}>
               <div style={{ fontWeight: 500 }}>{hoveredNode.name}</div>
-              <div style={{ color: '#7df', fontSize: 11 }}>{formatYen(hoveredNode.rawValue ?? hoveredNode.value)}</div>
-              <div style={{ color: '#aaa', fontSize: 10 }}>{(hoveredNode.rawValue ?? hoveredNode.value).toLocaleString()}円</div>
+              <div style={{ color: '#7df', fontSize: 11 }}>{formatYen(hoveredNode.value)}</div>
+              <div style={{ color: '#aaa', fontSize: 10 }}>{hoveredNode.value.toLocaleString()}円</div>
+              {hoveredNode.isScaled && hoveredNode.rawValue != null && (
+                <div style={{ color: '#888', fontSize: 10 }}>元: {formatYen(hoveredNode.rawValue)}</div>
+              )}
             </div>
           )}
           {/* DOM tooltip — column label hover */}
           {hoveredColIndex !== null && layout && (() => {
-            const amt = (n: LayoutNode) => n.rawValue ?? n.value;
+            const amt = (n: LayoutNode) => n.value;
             const colNodeTypes = ['total', 'ministry', 'project-budget', 'project-spending', 'recipient'] as const;
             const nodes = hoveredColIndex === 0
               ? layout.nodes.filter(n => n.type === 'total')
@@ -908,21 +913,61 @@ export default function RealDataSankeyPage() {
                     <div style={{ fontWeight: 700, fontSize: 13, color: '#111', wordBreak: 'break-all', lineHeight: 1.4 }}>
                       {selectedNode.name}
                     </div>
-                    <div style={{ fontSize: 15, fontWeight: 600, color: '#222', marginTop: 3 }}>
-                      {(selectedNode.type === 'total' || selectedNode.type === 'ministry') ? (() => {
-                        const bt = selectedNode.type === 'total'
-                          ? Array.from(ministryProjectStats.values()).reduce((s, v) => s + v.budgetTotal, 0)
-                          : ministryProjectStats.get(selectedNode.name)?.budgetTotal ?? 0;
-                        return formatYen(bt);
-                      })() : formatYen(selectedNode.rawValue ?? selectedNode.value)}
-                    </div>
-                    <div style={{ fontSize: 11, color: '#999', marginTop: 1 }}>
-                      {((selectedNode.type === 'total' || selectedNode.type === 'ministry') ? (() => {
-                        return selectedNode.type === 'total'
-                          ? Array.from(ministryProjectStats.values()).reduce((s, v) => s + v.budgetTotal, 0)
-                          : ministryProjectStats.get(selectedNode.name)?.budgetTotal ?? 0;
-                      })() : (selectedNode.rawValue ?? selectedNode.value)).toLocaleString()}円
-                    </div>
+                    {(() => {
+                      // Main value (予算額 for budget types, 支出額 for spending type)
+                      let mainValue = 0;
+                      let mainLabel = '';
+                      let subValue: number | null = null;
+                      let subLabel = '';
+                      if (selectedNode.type === 'total' || selectedNode.type === 'ministry') {
+                        const stats = selectedNode.type === 'total'
+                          ? Array.from(ministryProjectStats.values())
+                          : (ministryProjectStats.has(selectedNode.name) ? [ministryProjectStats.get(selectedNode.name)!] : []);
+                        mainValue = selectedNode.value;
+                        mainLabel = '予算額';
+                        subValue = stats.reduce((s, v) => s + v.spendingTotal, 0);
+                        subLabel = '支出額';
+                      } else if (selectedNode.type === 'project-budget') {
+                        mainValue = selectedNode.value;
+                        mainLabel = '予算額';
+                        if (selectedNode.projectId != null) {
+                          const sn = filtered?.nodes.find(n => n.type === 'project-spending' && n.projectId === selectedNode.projectId);
+                          if (sn) { subValue = sn.value; subLabel = '支出額'; }
+                        }
+                      } else if (selectedNode.type === 'project-spending') {
+                        mainValue = selectedNode.value;
+                        mainLabel = '支出額';
+                        if (selectedNode.projectId != null) {
+                          const bn = filtered?.nodes.find(n => n.type === 'project-budget' && n.projectId === selectedNode.projectId);
+                          if (bn) { subValue = bn.value; subLabel = '予算額'; }
+                        }
+                      } else {
+                        mainValue = selectedNode.value;
+                      }
+                      const rawMain = selectedNode.isScaled && selectedNode.rawValue != null ? selectedNode.rawValue : null;
+                      const rawMainLabel = mainLabel ? `元の${mainLabel}` : '元の値';
+                      return (<>
+                        <div style={{ fontSize: 15, fontWeight: 600, color: '#222', marginTop: 3 }}>
+                          {mainLabel && <span style={{ fontSize: 10, color: '#aaa', fontWeight: 400, marginRight: 4 }}>{mainLabel}</span>}
+                          {formatYen(mainValue)}
+                        </div>
+                        <div style={{ fontSize: 11, color: '#999', marginTop: 1 }}>{mainValue.toLocaleString()}円</div>
+                        {rawMain !== null && (
+                          <div style={{ fontSize: 11, color: '#bbb', marginTop: 1 }}>
+                            <span style={{ fontSize: 10, color: '#ccc', marginRight: 4 }}>{rawMainLabel}</span>
+                            {formatYen(rawMain)}
+                            <span style={{ fontSize: 10, color: '#ccc', marginLeft: 4 }}>{rawMain.toLocaleString()}円</span>
+                          </div>
+                        )}
+                        {subValue !== null && (
+                          <div style={{ fontSize: 12, color: '#777', marginTop: 4 }}>
+                            <span style={{ fontSize: 10, color: '#aaa', marginRight: 4 }}>{subLabel}</span>
+                            {formatYen(subValue)}
+                            <span style={{ fontSize: 10, color: '#bbb', marginLeft: 4 }}>{subValue.toLocaleString()}円</span>
+                          </div>
+                        )}
+                      </>);
+                    })()}
                   </div>
                   <button
                     onClick={() => selectNode(null)}
@@ -1318,6 +1363,10 @@ export default function RealDataSankeyPage() {
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showAggRecipient} onChange={e => setShowAggRecipient(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>支出先の集約ノードを表示</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={scaleBudgetToVisible} onChange={e => setScaleBudgetToVisible(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>事業の予算額を支出額に合わせて調整</span>
               </label>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showLabels} onChange={e => setShowLabels(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />

--- a/docs/tasks/20260412_0657_事業予算ノード高さスケーリング設計.md
+++ b/docs/tasks/20260412_0657_事業予算ノード高さスケーリング設計.md
@@ -1,0 +1,191 @@
+# 事業(予算)ノード高さのスケーリング実装
+
+## 目的
+
+支出先オフセットによってウィンドウ内に現れる支出が少ない大型事業について、
+事業(予算)ノードの高さが事業(支出)に対して極端に大きくなる視覚的アンバランスを解消する。
+
+---
+
+## 背景・現状（Issue #130）
+
+### 問題
+
+支出先オフセット 4877 付近で「失業等給付費等」が事業に表示されたとき：
+
+- 事業(支出): **3,304万円**（ウィンドウ内支出のみ）
+- 事業(予算): **2.03兆円**（予算額ベース）
+
+予算ノードと支出ノードの高さが約6,000倍のアンバランスになり、
+予算→支出のリボンが支出ノード側で極端に細くなる。
+
+---
+
+## 実装方針
+
+「表示中の支出」に占める「ウィンドウ内の支出」の割合を **visible fraction** として算出し、
+その割合で事業(予算)ノードの高さを擬似的に縮小する。
+
+```
+visibleFraction = spendingValue / n.value
+adjustedBudgetValue = budgetNode.value × visibleFraction
+```
+
+- `spendingValue`: 現在の事業(支出)ノードに設定される値（通常モード = `n.value - aboveWindowSpending`）
+- `n.value`: 事業の総支出額
+- `visibleFraction` のクランプ: `[0, 1]`（n.value = 0 の場合は 1）
+- `scaleBudgetToVisible = false` のとき調整なし（全予算額を使用）
+
+### 効果
+
+| 状態 | visibleFraction | 事業(予算)高さ |
+|------|----------------|---------------|
+| オフセット = 0（上位支出先がすべて見える） | ≈ 1.0 | ≈ 全予算額（変化なし） |
+| オフセット中位（失業等給付費等の例） | ≈ 0.016% | ≈ 全予算の0.016%（支出と釣り合う） |
+| 集約非表示モード（showAggRecipient=false）| windowValue / n.value | さらに縮小 |
+
+---
+
+## 実装内容
+
+### `types/sankey-svg.ts`
+
+`RawNode` に以下のフィールドを追加:
+
+| フィールド | 型 | 意味 |
+|-----------|-----|------|
+| `rawValue` | `number?` | 元の値（調整前の予算額 or 総支出額） |
+| `isScaled` | `boolean?` | 表示値が元の値より小さいとき `true` |
+
+`isScaled` は予算ノード（visibleFraction < 1）と支出ノード（ウィンドウ調整で削減済み）の両方に設定される。
+
+---
+
+### `app/lib/sankey-svg-filter.ts`
+
+#### シグネチャ変更
+
+```
+filterTopN(..., scaleBudgetToVisible: boolean = true)
+```
+
+デフォルト `true`。`false` のとき調整なし。
+
+#### `projectAdjustedBudget` Map の構築（step 3b）
+
+全 `project-spending` ノードに対して `project-budget` の調整後の値を事前計算する。
+
+```
+fraction = scaleBudgetToVisible && n.value > 0
+  ? clamp(spendingValue / n.value, 0, 1) : 1
+adjustedBudget(budgetId) = budgetNode.value × fraction
+```
+
+#### `ministryBudgetValue` / `ministryBudgetRawValue` の並行管理（step 7）
+
+- `ministryBudgetValue`: 調整済み予算の省庁別合計（ノード高さ・エッジ幅の根拠）
+- `ministryBudgetRawValue`: 元の予算の省庁別合計（ラベル表示用）
+- 同様に `totalBudget` / `totalBudgetRaw`、`otherMinistryBudgetValue` / `otherMinistryBudgetRawValue` を並行管理
+
+#### ノード出力
+
+| ノード | value | rawValue | isScaled |
+|--------|-------|----------|---------|
+| `total` | `totalBudget`（調整済み合計） | `totalBudgetRaw` | `totalBudget < totalBudgetRaw` |
+| `ministry` / `__agg-ministry` | 調整済み省庁別合計 | 元の省庁別合計 | value < rawValue |
+| `project-budget` | `adjustedBudgetValue` | `budgetNode.value` | adjBv < budgetNode.value |
+| `__agg-project-budget` | `otherProjectBudgetTotal`（調整済み） | `otherProjectBudgetRawTotal` | total < rawTotal |
+| `project-spending` | `spendingValue`（ウィンドウ内） | `n.value`（総支出） | spendingValue < n.value |
+| `__agg-project-spending` | ウィンドウ内集約支出 | 集約事業の総支出合計 | value < rawValue |
+
+#### エッジ出力
+
+`ministry → project-budget`、`__agg-project-budget` のフロー、`project-budget → project-spending` の全エッジは
+`projectAdjustedBudget` から調整済み予算値を参照してエッジ幅を決定する。
+
+---
+
+### `app/sankey-svg/page.tsx`
+
+#### 設定オプション追加
+
+```tsx
+const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
+```
+
+設定パネルに「事業の予算額を支出額に合わせて調整」チェックボックスを追加（デフォルト ON）。
+
+#### SVG ノードラベル
+
+`isScaled === true` のとき元の値を灰色 `<tspan>` で付記する:
+
+```
+{node.name} ({formatYen(node.value)}) 元: {formatYen(node.rawValue)}
+```
+
+#### ホバーツールチップ
+
+`isScaled === true` のとき「元: {formatYen(node.rawValue)}」行を追加。
+
+#### サイドパネル ヘッダー
+
+- メイン表示: `node.value`（調整後）
+- `isScaled === true` のとき「元の予算額 / 元の支出額」を淡い色で補足表示
+- `project-budget` 選択時: サブ行に `filtered.nodes` から取得した支出額を表示
+- `project-spending` 選択時: サブ行に `filtered.nodes` から取得した予算額（調整後）を表示
+- `total` / `ministry` 選択時: メインは `selectedNode.value`（調整済み）、サブに `ministryProjectStats` の支出合計
+
+#### `filterTopN` 呼び出し・依存配列
+
+`scaleBudgetToVisible` を第10引数として渡し、`useMemo` deps にも追加。
+
+---
+
+## 影響範囲
+
+| 箇所 | 変更内容 |
+|------|---------|
+| 事業(予算)ノード高さ | 調整後の値（支出との釣り合いを改善） |
+| 省庁ノード高さ | 傘下の調整済み予算合計ベースに変更 |
+| 総計ノード高さ | 調整済み予算合計ベースに変更 |
+| 事業(予算)集約ノード高さ | 調整済み予算合計に変更 |
+| エッジ幅 | 上記ノード値の変化に追従 |
+| SVG ラベル | `isScaled` ノードに元の値を灰色テキストで付記 |
+| ホバーツールチップ | `isScaled` ノードに元の値行を追加 |
+| サイドパネル ヘッダー | 調整後の値を主表示、元の値を補足表示 |
+| 設定パネル | 「事業の予算額を支出額に合わせて調整」チェックボックス |
+
+---
+
+## 未実装（設計段階のみで見送り）
+
+- `filterTopN` 戻り値への `effectivelyHiddenIds` 追加
+- サイドパネル接続リストの可視状態バッジ（表示中/集約/非表示）
+
+---
+
+## トレードオフ
+
+### 変わること
+- 事業(予算)の高さが「全予算額」でなく「現在のビューで意味のある予算の割合」になる
+- オフセットをスクロールするにつれて予算・支出ノードの高さも動的に変化する
+- `isScaled` なノードには元の値が補足表示される
+
+### 変わらないこと
+- `rawValue` に元の値を保持するため、正確な予算額・支出額はいつでも確認できる
+- オフセット = 0 のデフォルト状態では `visibleFraction ≈ 1` のため `isScaled = false`、表示は従来と変わらない
+- `scaleBudgetToVisible = false` で従来の全予算額表示に戻せる
+
+### 意味論の変化
+現在の「予算列 = 全予算額」から「予算列 = 現在のビューに対応する予算の割合」へ変わる。
+「Sankey図で見える支出先への予算配分はどれくらいか」を表す列として解釈できる。
+
+---
+
+## 整合性チェック
+
+| ルール | 確認 |
+|-------|------|
+| `scripts/` にUIロジックなし | 変更なし ✅ |
+| `app/lib/` にHTTP・Reactなし | `filterTopN` は pure 関数のまま ✅ |
+| `client/components/` に直接APIコールなし | 変更なし ✅ |

--- a/docs/tasks/20260412_0657_事業予算ノード高さスケーリング設計.md
+++ b/docs/tasks/20260412_0657_事業予算ノード高さスケーリング設計.md
@@ -26,7 +26,7 @@
 「表示中の支出」に占める「ウィンドウ内の支出」の割合を **visible fraction** として算出し、
 その割合で事業(予算)ノードの高さを擬似的に縮小する。
 
-```
+```text
 visibleFraction = spendingValue / n.value
 adjustedBudgetValue = budgetNode.value × visibleFraction
 ```
@@ -65,7 +65,7 @@ adjustedBudgetValue = budgetNode.value × visibleFraction
 
 #### シグネチャ変更
 
-```
+```text
 filterTopN(..., scaleBudgetToVisible: boolean = true)
 ```
 
@@ -75,7 +75,7 @@ filterTopN(..., scaleBudgetToVisible: boolean = true)
 
 全 `project-spending` ノードに対して `project-budget` の調整後の値を事前計算する。
 
-```
+```text
 fraction = scaleBudgetToVisible && n.value > 0
   ? clamp(spendingValue / n.value, 0, 1) : 1
 adjustedBudget(budgetId) = budgetNode.value × fraction
@@ -119,7 +119,7 @@ const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
 
 `isScaled === true` のとき元の値を灰色 `<tspan>` で付記する:
 
-```
+```text
 {node.name} ({formatYen(node.value)}) 元: {formatYen(node.rawValue)}
 ```
 

--- a/types/sankey-svg.ts
+++ b/types/sankey-svg.ts
@@ -5,6 +5,8 @@ export interface RawNode {
   value: number;
   /** Actual value preserved when layout height is capped (used for tooltip display) */
   rawValue?: number;
+  /** True when a budget node's height has been scaled by visible spending fraction */
+  isScaled?: boolean;
   /** If set, layout engine caps node height to this value after computing link-sum */
   layoutCap?: number;
   /** If true, layout engine skips the link-sum override so node.value stays as initialized */


### PR DESCRIPTION
## 目的

支出先オフセットで大型事業のウィンドウ内支出が少ないとき、事業(予算)ノードが極端に大きくなり Sankey 図が見づらくなる問題を解消する。

## 変更内容

### `app/lib/sankey-svg-filter.ts`
- `filterTopN` に `scaleBudgetToVisible: boolean = true` パラメータを追加
- ON 時: `visibleFraction = spendingValue / totalSpending` で事業(予算)ノード高さを調整
- 全予算ノード（project-budget / __agg-project-budget / ministry / total）に `rawValue`（元の予算額）と `isScaled` フラグを追加
- 支出ノード（project-spending / __agg-project-spending）もウィンドウ調整後の値が元の総支出より小さい場合に `rawValue` / `isScaled` を付与
- エッジ幅を調整済み予算値ベースに統一（ministry → project-budget, project-budget → project-spending など）

### `types/sankey-svg.ts`
- `RawNode` に `isScaled?: boolean` フィールドを追加

### `app/sankey-svg/page.tsx`
- 設定パネルに「事業の予算額を支出額に合わせて調整」チェックボックスを追加（デフォルト ON）
- SVG ラベル: `isScaled` ノードに元の値を灰色 `<tspan>` で付記（例: `○○事業 (3,300万) 元: 2.03兆`）
- ホバーツールチップ: `isScaled` ノードに「元: xxx」行を追加
- サイドパネルヘッダー: 調整後の値を主表示、`isScaled` 時に「元の予算額 / 元の支出額」を補足表示
- サイドパネル: `filtered.nodes` から予算・支出のクロス参照値を取得するよう変更（調整済み値を使用）

## テスト方法

```bash
npm run dev
# localhost:3002/sankey-svg を開く
```

1. 支出先オフセットを 4877 付近に設定し「失業等給付費等」が表示されることを確認
2. 事業(予算)ノードの高さが事業(支出)と釣り合っていることを確認
3. SVG ラベルに「元: 2.03兆」が表示されることを確認
4. 設定パネルの「事業の予算額を支出額に合わせて調整」を OFF にすると全予算額表示に戻ることを確認
5. オフセット = 0 のデフォルト状態で見た目が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggleable budget-scaling option that adjusts displayed budget values to the portion of spending currently visible.
  * Labels and tooltips now show scaled values with the original amount presented alongside when scaling is applied.

* **Improvements**
  * Ministry and total panels now include explicit spending totals alongside budget figures for clearer comparisons.

* **Documentation**
  * Added design notes describing the scaling behavior and UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->