### PR TITLE
feat: /sankey-svg 選択ノードの関連ノードフォーカスモードとBFSハイライト

### DIFF
--- a/app/lib/sankey-svg-constants.ts
+++ b/app/lib/sankey-svg-constants.ts
@@ -77,7 +77,8 @@ export function ribbonPath(link: LayoutLink): string {
 
 export function formatYen(value: number): string {
   if (value >= 1e12) return `${(value / 1e12).toFixed(2)}兆円`;
-  if (value >= 1e8) return `${Math.round(value / 1e8).toLocaleString()}億円`;
+  if (value >= 1e10) return `${Math.round(value / 1e8).toLocaleString()}億円`;
+  if (value >= 1e8) return `${(value / 1e8).toFixed(2)}億円`;
   if (value >= 1e4) return `${Math.round(value / 1e4).toLocaleString()}万円`;
-  return `${value.toLocaleString()}円`;
+  return `${Math.round(value).toLocaleString()}円`;
 }

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -16,6 +16,9 @@ export function filterTopN(
   includeZeroSpending: boolean = true,
   showAggRecipient: boolean = true,
   scaleBudgetToVisible: boolean = true,
+  focusRelated: boolean = false,
+  pinnedRecipientId: string | null = null,
+  pinnedMinistryName: string | null = null,
 ): { nodes: RawNode[]; edges: RawEdge[]; totalRecipientCount: number; aggNodeMembers: Map<string, AggMember[]>; topProjectIds: Set<string> } {
   // Build O(1) lookup map
   const nodeById = new Map(allNodes.map(n => [n.id, n]));
@@ -32,12 +35,26 @@ export function filterTopN(
     }
   }
 
+  // Focus modes (mutually exclusive; priority: recipient > ministry > project)
+  const recipientFocusMode = focusRelated && pinnedRecipientId != null;
+  const ministryFocusMode = focusRelated && pinnedMinistryName != null && !recipientFocusMode;
+  const projectRecipientsMode = focusRelated && pinnedProjectId != null && !recipientFocusMode && !ministryFocusMode;
+
   // 1. TopN ministries by total value (stable ranking)
   const ministries = allNodes.filter(n => n.type === 'ministry').sort((a, b) => b.value - a.value);
-  const topMinistryNodes = ministries.slice(0, topMinistry);
+  let topMinistryNodes = ministries.slice(0, topMinistry);
+  if (ministryFocusMode && pinnedMinistryName) {
+    const pinned = ministries.find(n => n.name === pinnedMinistryName);
+    topMinistryNodes = pinned ? [pinned] : [];
+  }
+  let otherMinistries = ministryFocusMode ? [] : ministries.slice(topMinistry);
+  // Single-element aggregation: promote lone ministry to a regular node
+  if (otherMinistries.length === 1) {
+    topMinistryNodes = [...topMinistryNodes, otherMinistries[0]];
+    otherMinistries = [];
+  }
   const topMinistryIds = new Set(topMinistryNodes.map(n => n.id));
   const topMinistryNames = new Set(topMinistryNodes.map(n => n.name));
-  const otherMinistries = ministries.slice(topMinistry);
 
   // 2. Recipient window — ranked by total amount across ALL edges (stable ranking)
   const allRecipientAmounts = new Map<string, number>();
@@ -47,10 +64,49 @@ export function filterTopN(
     }
   }
   const allSortedRecipients = Array.from(allRecipientAmounts.entries()).sort((a, b) => b[1] - a[1]);
-  const totalRecipientCount = allSortedRecipients.length;
-  const windowRecipients = allSortedRecipients.slice(recipientOffset, recipientOffset + topRecipient);
+  let totalRecipientCount = allSortedRecipients.length;
+
+  let windowRecipients: [string, number][];
+  let tailRecipients: [string, number][];
+  let ministrySpecificSortedRecipients: [string, number][] = [];
+  if (recipientFocusMode && pinnedRecipientId) {
+    // Show only the one pinned recipient; no tail (projects are restricted in step 4)
+    const totalFlow = allEdges.reduce((s, e) => e.target === pinnedRecipientId ? s + e.value : s, 0);
+    windowRecipients = totalFlow > 0 ? [[pinnedRecipientId, totalFlow]] : [];
+    tailRecipients = [];
+  } else if (ministryFocusMode && pinnedMinistryName) {
+    // Recipient window based on ministry-specific flows (supports offset scrolling)
+    const ministryRecipientAmounts = new Map<string, number>();
+    for (const e of allEdges) {
+      const srcNode = nodeById.get(e.source);
+      if (srcNode?.type === 'project-spending' && srcNode.ministry === pinnedMinistryName && e.target.startsWith('r-')) {
+        ministryRecipientAmounts.set(e.target, (ministryRecipientAmounts.get(e.target) || 0) + e.value);
+      }
+    }
+    ministrySpecificSortedRecipients = Array.from(ministryRecipientAmounts.entries()).sort((a, b) => b[1] - a[1]);
+    totalRecipientCount = ministrySpecificSortedRecipients.length;
+    windowRecipients = ministrySpecificSortedRecipients.slice(recipientOffset, recipientOffset + topRecipient);
+    tailRecipients = ministrySpecificSortedRecipients.slice(recipientOffset + topRecipient);
+  } else if (projectRecipientsMode) {
+    const projectRecipientAmounts = new Map<string, number>();
+    for (const e of allEdges) {
+      if (e.source === pinnedProjectId && e.target.startsWith('r-')) {
+        projectRecipientAmounts.set(e.target, (projectRecipientAmounts.get(e.target) || 0) + e.value);
+      }
+    }
+    const sortedProjectRecipients = Array.from(projectRecipientAmounts.entries()).sort((a, b) => b[1] - a[1]);
+    windowRecipients = sortedProjectRecipients.slice(0, topRecipient);
+    tailRecipients = sortedProjectRecipients.slice(topRecipient);
+  } else {
+    windowRecipients = allSortedRecipients.slice(recipientOffset, recipientOffset + topRecipient);
+    tailRecipients = allSortedRecipients.slice(recipientOffset + topRecipient);
+  }
+  // Single-element tail: promote lone recipient to window
+  if (tailRecipients.length === 1) {
+    windowRecipients = [...windowRecipients, tailRecipients[0]];
+    tailRecipients = [];
+  }
   const windowRecipientIds = new Set(windowRecipients.map(([id]) => id));
-  const tailRecipients = allSortedRecipients.slice(recipientOffset + topRecipient);
   const tailRecipientIds = new Set(tailRecipients.map(([id]) => id));
 
   // 3. Per-project and per-recipient window/tail spending (all projects, used for re-ranking)
@@ -68,9 +124,15 @@ export function filterTopN(
 
   // Recipients before the window (rank 0..offset-1) are neither in window nor tail — their flow is hidden.
   // Compute per-project spending to these hidden recipients so we can subtract from node heights.
-  const aboveWindowRecipientIds = new Set(allSortedRecipients.slice(0, recipientOffset).map(([id]) => id));
+  // In projectRecipientsMode or recipientFocusMode, there is no offset concept — aboveWindow is always empty.
+  // In ministryFocusMode, aboveWindow is computed from ministry-specific sorted recipients.
+  const aboveWindowRecipientIds = (projectRecipientsMode || recipientFocusMode)
+    ? new Set<string>()
+    : ministryFocusMode
+      ? new Set(ministrySpecificSortedRecipients.slice(0, recipientOffset).map(([id]) => id))
+      : new Set(allSortedRecipients.slice(0, recipientOffset).map(([id]) => id));
   const projectAboveWindowSpending = new Map<string, number>();
-  if (recipientOffset > 0) {
+  if (!(projectRecipientsMode || recipientFocusMode) && recipientOffset > 0) {
     for (const e of allEdges) {
       if (aboveWindowRecipientIds.has(e.target)) {
         projectAboveWindowSpending.set(e.source, (projectAboveWindowSpending.get(e.source) || 0) + e.value);
@@ -86,7 +148,7 @@ export function filterTopN(
     if (n.type !== 'project-spending' || n.projectId == null) continue;
     const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
     if (!budgetNode) continue;
-    const sv = !showAggRecipient
+    const sv = (recipientFocusMode || !showAggRecipient)
       ? (projectWindowValue.get(n.id) || 0)
       : n.value - (projectAboveWindowSpending.get(n.id) || 0);
     const fraction = (scaleBudgetToVisible && n.value > 0) ? Math.max(0, Math.min(1, sv / n.value)) : 1;
@@ -110,6 +172,25 @@ export function filterTopN(
     if (pinned && (includeZeroSpending || !zeroSpendingProjectIds.has(pinned.id)) && !topProjectNodes.some(n => n.id === pinnedProjectId)) {
       topProjectNodes.push(pinned);
     }
+  }
+  // In projectRecipientsMode: restrict to the pinned project only
+  if (projectRecipientsMode && pinnedProjectId) {
+    topProjectNodes.splice(0, topProjectNodes.length, ...topProjectNodes.filter(n => n.id === pinnedProjectId));
+  }
+  // In recipientFocusMode: show projects (any ministry) that have flow to the pinned recipient, with TopN aggregation
+  let recipientFocusOtherProjects: RawNode[] = [];
+  if (recipientFocusMode && pinnedRecipientId) {
+    const flowToRecipient = new Map<string, number>();
+    for (const e of allEdges) {
+      if (e.target === pinnedRecipientId) {
+        flowToRecipient.set(e.source, (flowToRecipient.get(e.source) || 0) + e.value);
+      }
+    }
+    const allRecipientProjects = allNodes
+      .filter(n => n.type === 'project-spending' && flowToRecipient.has(n.id))
+      .sort((a, b) => (flowToRecipient.get(b.id) || 0) - (flowToRecipient.get(a.id) || 0));
+    topProjectNodes.splice(0, topProjectNodes.length, ...allRecipientProjects.slice(0, topProject));
+    recipientFocusOtherProjects = allRecipientProjects.slice(topProject);
   }
   const topProjectIds = new Set(topProjectNodes.map(n => n.id));
 
@@ -136,10 +217,18 @@ export function filterTopN(
   const otherMinistryProjects = allNodes.filter(
     n => n.type === 'project-spending' && !topMinistryNames.has(n.ministry || '') && !topProjectIds.has(n.id) && !effectivelyHiddenIds.has(n.id) && !zeroSpendingProjectIds.has(n.id)
   );
-  const otherProjects = [
+  let otherProjects: RawNode[] = recipientFocusMode ? recipientFocusOtherProjects
+    : ministryFocusMode ? topMinistryAllProjects.filter(n => !topProjectIds.has(n.id) && !effectivelyHiddenIds.has(n.id))
+    : projectRecipientsMode ? [] : [
     ...topMinistryAllProjects.filter(n => !topProjectIds.has(n.id) && !effectivelyHiddenIds.has(n.id)),
     ...otherMinistryProjects,
   ];
+  // Single-element aggregation: promote lone project to a regular node
+  if (otherProjects.length === 1) {
+    topProjectNodes.push(otherProjects[0]);
+    topProjectIds.add(otherProjects[0].id);
+    otherProjects = [];
+  }
   const otherProjectSpendingIds = new Set(otherProjects.map(n => n.id));
 
   // 5. Aggregated values
@@ -182,10 +271,25 @@ export function filterTopN(
 
   // 7. Ministry budget totals (sum of project-budget values per ministry — for node heights)
   // Exclude effectively hidden projects (had spending but lost window flow at current offset)
+  // In projectRecipientsMode: only count the pinned project's budget.
+  // In recipientFocusMode: only count budgets for projects flowing to the pinned recipient.
+  const pinnedBudgetId = projectRecipientsMode && pinnedProjectId
+    ? `project-budget-${allNodes.find(n => n.id === pinnedProjectId)?.projectId}`
+    : null;
+  // Include both topProjectNodes and otherProjects (aggregated) so that ministry/total budget is complete.
+  const recipientFocusProjectBudgetIds = recipientFocusMode
+    ? new Set([
+        ...topProjectNodes.filter(n => n.projectId != null).map(n => `project-budget-${n.projectId}`),
+        ...otherProjects.filter(n => n.projectId != null).map(n => `project-budget-${n.projectId}`),
+      ])
+    : null;
   const ministryBudgetValue = new Map<string, number>();
   const ministryBudgetRawValue = new Map<string, number>();
   for (const n of allNodes) {
     if (n.type === 'project-budget' && n.ministry) {
+      if (projectRecipientsMode && n.id !== pinnedBudgetId) continue;
+      if (recipientFocusMode && !recipientFocusProjectBudgetIds?.has(n.id)) continue;
+      if (ministryFocusMode && n.ministry !== pinnedMinistryName) continue;
       if (effectivelyHiddenBudgetIds.has(n.id)) continue;
       if (zeroSpendingBudgetIds.has(n.id)) continue;
       const adjValue = projectAdjustedBudget.get(n.id) ?? n.value;
@@ -205,12 +309,14 @@ export function filterTopN(
     nodes.push({ ...totalNode, value: totalBudget, rawValue: totalBudgetRaw, isScaled: totalBudget < totalBudgetRaw, skipLinkOverride: true });
   }
 
-  for (const n of topMinistryNodes) {
+  // In recipientFocusMode, iterate all ministries so non-top ministries with relevant projects appear.
+  const ministryNodesToShow = recipientFocusMode ? ministries : topMinistryNodes;
+  for (const n of ministryNodesToShow) {
     const bv = ministryBudgetValue.get(n.name) || 0;
     const rawBv = ministryBudgetRawValue.get(n.name) || 0;
     if (bv > 0) nodes.push({ ...n, value: bv, rawValue: rawBv, isScaled: bv < rawBv, skipLinkOverride: true });
   }
-  if (otherMinistryBudgetValue > 0) {
+  if (!recipientFocusMode && otherMinistryBudgetValue > 0) {
     nodes.push({ id: '__agg-ministry', name: `${otherMinistries.length.toLocaleString()}省庁`, type: 'ministry', value: otherMinistryBudgetValue, rawValue: otherMinistryBudgetRawValue, isScaled: otherMinistryBudgetValue < otherMinistryBudgetRawValue, skipLinkOverride: true, aggregated: true });
   }
 
@@ -223,7 +329,7 @@ export function filterTopN(
       nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, skipLinkOverride: true });
     }
     // spending node height = window spending only (agg hidden) or total minus above-window (normal).
-    const spendingValue = !showAggRecipient
+    const spendingValue = (recipientFocusMode || !showAggRecipient)
       ? (projectWindowValue.get(n.id) || 0)
       : n.value - (projectAboveWindowSpending.get(n.id) || 0);
     const spendingTrimmed = spendingValue < n.value;
@@ -239,7 +345,7 @@ export function filterTopN(
   // In normal mode: window OR tail flow (tail goes to __agg-recipient).
   const aggProjectSpendingNeeded = !showAggRecipient ? otherProjectWindowTotal > 0 : (otherProjectWindowTotal > 0 || otherProjectTailTotal > 0);
   if (aggProjectSpendingNeeded) {
-    const otherProjectSpendingTotal = !showAggRecipient
+    const otherProjectSpendingTotal = (recipientFocusMode || !showAggRecipient)
       ? otherProjectWindowTotal
       : otherProjects.reduce((s, p) => s + p.value - (projectAboveWindowSpending.get(p.id) || 0), 0);
     const otherProjectSpendingRawTotal = otherProjects.reduce((s, p) => s + p.value, 0);
@@ -247,9 +353,12 @@ export function filterTopN(
     nodes.push({ id: '__agg-project-spending', name: `${otherProjects.length.toLocaleString()}事業`, type: 'project-spending', value: otherProjectSpendingTotal, rawValue: aggSpendingTrimmed ? otherProjectSpendingRawTotal : undefined, isScaled: aggSpendingTrimmed, skipLinkOverride: true, aggregated: true });
   }
 
-  for (const [rid] of windowRecipients) {
+  for (const [rid, pinnedAmt] of windowRecipients) {
     const rNode = nodeById.get(rid);
-    if (rNode) nodes.push({ ...rNode, value: recipientWindowValue.get(rid) || 0, skipLinkOverride: true });
+    if (rNode) {
+      const val = (projectRecipientsMode || ministryFocusMode) ? pinnedAmt : (recipientWindowValue.get(rid) || 0);
+      nodes.push({ ...rNode, value: val, skipLinkOverride: true });
+    }
   }
   // tailValue = total inflow to rank (offset+topRecipient)+ recipients from ALL projects.
   // otherProjectTailTotal is a subset of tailValue (aggregated projects' tail flow),
@@ -276,19 +385,24 @@ export function filterTopN(
   const edges: RawEdge[] = [];
 
   // total → ministry (budget-based)
-  for (const mn of topMinistryNodes) {
+  // In recipientFocusMode, use ministryNodesToShow (all ministries) instead of topMinistryNodes only
+  for (const mn of ministryNodesToShow) {
     const bv = ministryBudgetValue.get(mn.name) || 0;
     if (bv > 0) edges.push({ source: 'total', target: mn.id, value: bv });
   }
-  if (otherMinistryBudgetValue > 0) {
+  if (!recipientFocusMode && otherMinistryBudgetValue > 0) {
     edges.push({ source: 'total', target: '__agg-ministry', value: otherMinistryBudgetValue });
   }
 
   // ministry → project-budget (adjusted budget-based)
+  // In recipientFocusMode, non-top-ministry projects map to their own ministry node (not __agg-ministry)
+  const visibleMinistryNames = recipientFocusMode
+    ? new Set(topProjectNodes.map(n => n.ministry).filter(Boolean) as string[])
+    : topMinistryNames;
   for (const n of topProjectNodes) {
     const budgetId = `project-budget-${n.projectId}`;
     const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
-    const ministrySource = topMinistryNames.has(n.ministry || '') ? `ministry-${n.ministry}` : '__agg-ministry';
+    const ministrySource = visibleMinistryNames.has(n.ministry || '') ? `ministry-${n.ministry}` : '__agg-ministry';
     if (bv > 0) edges.push({ source: ministrySource, target: budgetId, value: bv });
   }
   if (otherProjectBudgetTotal > 0) {

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -15,10 +15,12 @@ export default function RealDataSankeyPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [topMinistry, setTopMinistry] = useState(37);
-  const [topProject, setTopProject] = useState(20);
-  const [topRecipient, setTopRecipient] = useState(20);
+  const [topProject, setTopProject] = useState(40);
+  const [topRecipient, setTopRecipient] = useState(40);
   const [recipientOffset, setRecipientOffset] = useState(0);
   const [pinnedProjectId, setPinnedProjectId] = useState<string | null>(null);
+  const [pinnedRecipientId, setPinnedRecipientId] = useState<string | null>(null);
+  const [pinnedMinistryName, setPinnedMinistryName] = useState<string | null>(null);
   const [hoveredLink, setHoveredLink] = useState<LayoutLink | null>(null);
   const [hoveredNode, setHoveredNode] = useState<LayoutNode | null>(null);
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
@@ -28,6 +30,7 @@ export default function RealDataSankeyPage() {
   const [includeZeroSpending, setIncludeZeroSpending] = useState(false);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
   const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
+  const [focusRelated, setFocusRelated] = useState(true);
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
   const [zoomInputValue, setZoomInputValue] = useState('');
@@ -190,10 +193,10 @@ export default function RealDataSankeyPage() {
     if (!graphData) return null;
     const maxOffset = Math.max(0, (graphData.nodes.filter(n => n.type === 'recipient').length) - topRecipient);
     const clampedOffset = Math.min(recipientOffset, maxOffset);
-    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible);
-  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible]);
+    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName);
+  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName]);
 
-  const minNodeGap = showLabels ? 12 / zoom : undefined;
+  const minNodeGap = showLabels ? 14 / zoom : undefined;
 
   const layout = useMemo(() => {
     if (!filtered) return null;
@@ -214,19 +217,37 @@ export default function RealDataSankeyPage() {
     return { ...rawNode, x0: 0, x1: 0, y0: 0, y1: 0, sourceLinks: [], targetLinks: [] } as LayoutNode;
   }, [selectedNodeId, layout, graphData]);
 
-  // True only when the node exists in the current layout (for highlight/dim)
+  // The selected node in the current layout (null if not in layout)
   const selectedNodeInLayout = useMemo(
-    () => selectedNodeId !== null && (layout?.nodes.some(n => n.id === selectedNodeId) ?? false),
+    () => (selectedNodeId !== null ? (layout?.nodes.find(n => n.id === selectedNodeId) ?? null) : null),
     [selectedNodeId, layout],
   );
 
   const connectedNodeIds = useMemo(() => {
-    if (!selectedNode || !selectedNodeInLayout) return null;
-    const ids = new Set<string>([selectedNode.id]);
-    for (const l of selectedNode.sourceLinks) ids.add(l.target.id);
-    for (const l of selectedNode.targetLinks) ids.add(l.source.id);
+    if (!selectedNodeInLayout) return null;
+    const ids = new Set<string>();
+    // BFS upstream (follow targetLinks → source recursively) — separate visited set
+    const uVisited = new Set<string>();
+    const uQueue = [selectedNodeInLayout];
+    while (uQueue.length) {
+      const n = uQueue.shift()!;
+      if (uVisited.has(n.id)) continue;
+      uVisited.add(n.id);
+      ids.add(n.id);
+      for (const l of n.targetLinks) if (!uVisited.has(l.source.id)) uQueue.push(l.source);
+    }
+    // BFS downstream (follow sourceLinks → target recursively) — separate visited set
+    const dVisited = new Set<string>();
+    const dQueue = [selectedNodeInLayout];
+    while (dQueue.length) {
+      const n = dQueue.shift()!;
+      if (dVisited.has(n.id)) continue;
+      dVisited.add(n.id);
+      ids.add(n.id);
+      for (const l of n.sourceLinks) if (!dVisited.has(l.target.id)) dQueue.push(l.target);
+    }
     return ids;
-  }, [selectedNode, selectedNodeInLayout]);
+  }, [selectedNodeInLayout]);
 
   // Per-ministry project stats — for total/ministry node side panel
   type ProjectStat = { pid: number; name: string; budgetId: string; spendingId: string; budgetValue: number; spendingValue: number };
@@ -267,6 +288,16 @@ export default function RealDataSankeyPage() {
     }
     const sorted = Array.from(amounts.entries()).sort((a, b) => b[1] - a[1]);
     return new Map(sorted.map(([id], i) => [id, i]));
+  }, [graphData]);
+
+  // Recipient count per project-spending node (from raw graphData)
+  const projectRecipientCount = useMemo(() => {
+    if (!graphData) return new Map<string, number>();
+    const countMap = new Map<string, number>();
+    for (const e of graphData.edges) {
+      if (e.target.startsWith('r-')) countMap.set(e.source, (countMap.get(e.source) || 0) + 1);
+    }
+    return countMap;
   }, [graphData]);
 
   // Full connection list from raw graphData (bypasses TopN aggregation)
@@ -332,8 +363,8 @@ export default function RealDataSankeyPage() {
   const selectNode = useCallback((id: string | null) => {
     setSelectedNodeId(id);
     if (id !== null) setIsPanelCollapsed(false);
-    else setPinnedProjectId(null);
-  }, []);
+    else { setPinnedProjectId(null); setPinnedRecipientId(null); setPinnedMinistryName(null); }
+  }, [setPinnedRecipientId, setPinnedMinistryName]);
 
   // Auto-clear stale selection when node no longer exists in graphData at all
   useEffect(() => {
@@ -390,6 +421,22 @@ export default function RealDataSankeyPage() {
     // If already in layout, select and focus directly (no effect needed)
     const inLayoutNode = layout?.nodes.find(n => n.id === nodeId);
     if (inLayoutNode) {
+      if (focusRelated && nodeId.startsWith('r-') && !inLayoutNode.aggregated) {
+        setPinnedRecipientId(nodeId);
+        setPinnedProjectId(null);
+        setPinnedMinistryName(null);
+        selectNode(nodeId);
+        focusOnNeighborhood(inLayoutNode);
+        return;
+      }
+      if (focusRelated && inLayoutNode.type === 'ministry' && !inLayoutNode.aggregated) {
+        setPinnedMinistryName(inLayoutNode.name);
+        setPinnedProjectId(null);
+        setPinnedRecipientId(null);
+        selectNode(nodeId);
+        focusOnNeighborhood(inLayoutNode);
+        return;
+      }
       // Preserve pin if the clicked node belongs to the same pinned project
       const derivedPinnedId = nodeId.startsWith('project-budget-')
         ? nodeId.replace('project-budget-', 'project-spending-')
@@ -397,9 +444,12 @@ export default function RealDataSankeyPage() {
           ? nodeId
           : null;
       const nextPinnedProjectId =
-        derivedPinnedId !== null && derivedPinnedId === pinnedProjectId
-          ? pinnedProjectId
-          : null;
+        focusRelated && derivedPinnedId !== null
+          ? derivedPinnedId
+          : derivedPinnedId !== null && derivedPinnedId === pinnedProjectId
+            ? pinnedProjectId
+            : null;
+      if (focusRelated && derivedPinnedId !== null) { setPinnedRecipientId(null); setPinnedMinistryName(null); }
       const needsDeferredFocus = nextPinnedProjectId !== pinnedProjectId || isPanelCollapsed;
       setPinnedProjectId(nextPinnedProjectId);
       if (needsDeferredFocus) pendingFocusId.current = nodeId;
@@ -443,13 +493,37 @@ export default function RealDataSankeyPage() {
     // Out-of-layout node: focus via effect once it appears in layout after pin/offset jump
     pendingFocusId.current = nodeId;
     selectNode(nodeId);
-  }, [layout, filtered, allRecipientRanks, topRecipient, selectNode, graphData, focusOnNeighborhood, pinnedProjectId, isPanelCollapsed]);
+  }, [layout, filtered, allRecipientRanks, topRecipient, selectNode, graphData, focusOnNeighborhood, pinnedProjectId, isPanelCollapsed, focusRelated, setPinnedRecipientId, setPinnedMinistryName]);
 
   const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
     e.stopPropagation();
     if (didPanRef.current) return;
-    selectNode(selectedNodeId === node.id ? null : node.id);
-  }, [selectedNodeId, selectNode]);
+    const newId = selectedNodeId === node.id ? null : node.id;
+    if (focusRelated && newId !== null && !node.aggregated) {
+      if (node.type === 'recipient') {
+        setPinnedRecipientId(node.id);
+        setPinnedProjectId(null);
+        setPinnedMinistryName(null);
+      } else if (node.type === 'ministry') {
+        setPinnedMinistryName(node.name);
+        setPinnedProjectId(null);
+        setPinnedRecipientId(null);
+      } else {
+        const spendingId = node.type === 'project-budget'
+          ? node.id.replace('project-budget-', 'project-spending-')
+          : node.type === 'project-spending'
+            ? node.id
+            : null;
+        setPinnedProjectId(spendingId);
+        setPinnedRecipientId(null);
+        setPinnedMinistryName(null);
+      }
+    } else if (!focusRelated || newId === null) {
+      setPinnedRecipientId(null);
+      setPinnedMinistryName(null);
+    }
+    selectNode(newId);
+  }, [selectedNodeId, selectNode, focusRelated]);
 
   // ── Search ──
 
@@ -618,6 +692,10 @@ export default function RealDataSankeyPage() {
 
       {layout && (
         <>
+            <style>{`
+              @keyframes snk-fade-in { from { opacity: 0 } to { opacity: 1 } }
+              .snk-node { animation: snk-fade-in 0.25s ease forwards; }
+            `}</style>
             <svg
               ref={svgRef}
               width={svgWidth}
@@ -655,8 +733,8 @@ export default function RealDataSankeyPage() {
                     return (
                       <text
                         key={i}
-                        x={x + NODE_W / 2} y={-10}
-                        textAnchor="middle" fontSize={11} fill="#999"
+                        x={x + NODE_W / 2} y={-13}
+                        textAnchor="middle" fontSize={15} fill="#999"
                         style={{ cursor: 'default', userSelect: 'none' }}
                         onMouseEnter={(e) => {
                           const rect = containerRef.current?.getBoundingClientRect();
@@ -676,15 +754,14 @@ export default function RealDataSankeyPage() {
                 })()}
 
                 {/* Links */}
-                {layout.links.map((link, i) => (
+                {layout.links.map((link) => (
                   <path
-                    key={i}
-                    d={ribbonPath(link)}
+                    key={`${link.source.id}→${link.target.id}`}
                     fill={getLinkColor(link)}
                     fillOpacity={
-                      selectedNode
-                        ? (link.source.id === selectedNode.id || link.target.id === selectedNode.id)
-                          ? (hoveredLink === link ? 0.6 : 0.5)
+                      connectedNodeIds
+                        ? (connectedNodeIds.has(link.source.id) && connectedNodeIds.has(link.target.id))
+                          ? (hoveredLink === link ? 0.45 : 0.35)
                           : 0.05
                         : hoveredLink === link ? 0.6
                           : hoveredNode && (link.source === hoveredNode || link.target === hoveredNode) ? 0.5
@@ -704,7 +781,7 @@ export default function RealDataSankeyPage() {
                     }}
                     onMouseLeave={() => setHoveredLink(null)}
                     onClick={(e) => e.stopPropagation()}
-                    style={{ cursor: 'grab', transition: 'fill-opacity 0.2s ease' }}
+                    style={{ cursor: 'grab', transition: 'fill-opacity 0.2s ease, d 0.3s ease', d: `path("${ribbonPath(link)}")` } as React.CSSProperties}
                   />
                 ))}
 
@@ -733,20 +810,21 @@ export default function RealDataSankeyPage() {
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
                     return (
-                      <g key={node.id}>
+                      <g key={node.id} className="snk-node" style={{ transform: `translateY(${node.y0}px)`, transition: 'transform 0.3s ease' }}>
                         <rect
                           x={node.x0}
-                          y={node.y0}
+                          y={0}
                           width={NODE_W}
-                          height={Math.max(1, h)}
                           fill={getNodeColor(node)}
-                          opacity={
-                            connectedNodeIds
-                              ? (connectedNodeIds.has(node.id) ? 1 : 0.3)
-                              : (hoveredNode && hoveredNode !== node ? 0.4 : 1)
-                          }
                           rx={1}
-                          style={{ cursor: 'pointer', transition: 'opacity 0.2s ease' }}
+                          style={{
+                            height: Math.max(1, h),
+                            opacity: connectedNodeIds
+                              ? (connectedNodeIds.has(node.id) ? 1 : 0.3)
+                              : (hoveredNode && hoveredNode !== node ? 0.4 : 1),
+                            cursor: 'pointer',
+                            transition: 'opacity 0.2s ease, height 0.3s ease',
+                          }}
                           onMouseEnter={(e) => {
                             const rect = containerRef.current?.getBoundingClientRect();
                             if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
@@ -762,14 +840,14 @@ export default function RealDataSankeyPage() {
                         {labelVisible && (
                           <text
                             x={node.x1 + 3}
-                            y={node.y0 + h / 2}
-                            fontSize={9 / zoom}
+                            y={h / 2}
+                            fontSize={11 / zoom}
                             dominantBaseline="middle"
                             fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : '#333'}
                             style={{ userSelect: 'none', pointerEvents: 'none' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
                           >
-                            {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#aaa"> 元: {formatYen(node.rawValue)}</tspan>)}
+                            {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                           </text>
                         )}
                       </g>
@@ -810,7 +888,7 @@ export default function RealDataSankeyPage() {
             <div style={{ position: 'absolute', left: mousePos.x + 12, top: mousePos.y - 10, background: 'rgba(0,0,0,0.85)', color: '#fff', padding: '6px 10px', borderRadius: 4, fontSize: 12, lineHeight: 1.4, pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 20 }}>
               <div>{hoveredLink.source.name} → {hoveredLink.target.name}</div>
               <div style={{ color: '#adf' }}>{formatYen(hoveredLink.value)}</div>
-              <div style={{ color: '#aaa', fontSize: 11 }}>{hoveredLink.value.toLocaleString()}円</div>
+              <div style={{ color: '#aaa', fontSize: 11 }}>{Math.round(hoveredLink.value).toLocaleString()}円</div>
             </div>
           )}
           {/* DOM tooltip — node hover (mini: name + amount only) */}
@@ -818,9 +896,9 @@ export default function RealDataSankeyPage() {
             <div style={{ position: 'absolute', left: mousePos.x + 12, top: mousePos.y - 10, background: 'rgba(0,0,0,0.78)', color: '#fff', padding: '5px 9px', borderRadius: 4, fontSize: 12, lineHeight: 1.4, pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 20 }}>
               <div style={{ fontWeight: 500 }}>{hoveredNode.name}</div>
               <div style={{ color: '#7df', fontSize: 11 }}>{formatYen(hoveredNode.value)}</div>
-              <div style={{ color: '#aaa', fontSize: 10 }}>{hoveredNode.value.toLocaleString()}円</div>
+              <div style={{ color: '#aaa', fontSize: 10 }}>{Math.round(hoveredNode.value).toLocaleString()}円</div>
               {hoveredNode.isScaled && hoveredNode.rawValue != null && (
-                <div style={{ color: '#888', fontSize: 10 }}>元: {formatYen(hoveredNode.rawValue)}</div>
+                <div style={{ color: '#888', fontSize: 10 }}>/ {formatYen(hoveredNode.rawValue)}</div>
               )}
             </div>
           )}
@@ -847,7 +925,7 @@ export default function RealDataSankeyPage() {
                 <div style={{ fontWeight: 'bold', marginBottom: 2 }}>{COL_LABELS[hoveredColIndex]}</div>
                 {count != null && <div style={{ color: '#aaa', fontSize: 11 }}>{count.toLocaleString()}件</div>}
                 <div style={{ color: '#7df' }}>{formatYen(total)}</div>
-                <div style={{ color: '#aaa', fontSize: 11 }}>{total.toLocaleString()}円</div>
+                <div style={{ color: '#aaa', fontSize: 11 }}>{Math.round(total).toLocaleString()}円</div>
                 <div style={{ color: '#888', fontSize: 10, marginTop: 4 }}>{colDescs[hoveredColIndex]}</div>
               </div>
             );
@@ -951,19 +1029,19 @@ export default function RealDataSankeyPage() {
                           {mainLabel && <span style={{ fontSize: 10, color: '#aaa', fontWeight: 400, marginRight: 4 }}>{mainLabel}</span>}
                           {formatYen(mainValue)}
                         </div>
-                        <div style={{ fontSize: 11, color: '#999', marginTop: 1 }}>{mainValue.toLocaleString()}円</div>
+                        <div style={{ fontSize: 11, color: '#999', marginTop: 1 }}>{Math.round(mainValue).toLocaleString()}円</div>
                         {rawMain !== null && (
                           <div style={{ fontSize: 11, color: '#bbb', marginTop: 1 }}>
                             <span style={{ fontSize: 10, color: '#ccc', marginRight: 4 }}>{rawMainLabel}</span>
                             {formatYen(rawMain)}
-                            <span style={{ fontSize: 10, color: '#ccc', marginLeft: 4 }}>{rawMain.toLocaleString()}円</span>
+                            <span style={{ fontSize: 10, color: '#ccc', marginLeft: 4 }}>{Math.round(rawMain).toLocaleString()}円</span>
                           </div>
                         )}
                         {subValue !== null && (
                           <div style={{ fontSize: 12, color: '#777', marginTop: 4 }}>
                             <span style={{ fontSize: 10, color: '#aaa', marginRight: 4 }}>{subLabel}</span>
                             {formatYen(subValue)}
-                            <span style={{ fontSize: 10, color: '#bbb', marginLeft: 4 }}>{subValue.toLocaleString()}円</span>
+                            <span style={{ fontSize: 10, color: '#bbb', marginLeft: 4 }}>{Math.round(subValue).toLocaleString()}円</span>
                           </div>
                         )}
                       </>);
@@ -1040,14 +1118,21 @@ export default function RealDataSankeyPage() {
                           <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>{items.length}件 {formatYen(total)}</span>
                         </button>
                         {!isCollapsed && (<>
-                          {items.slice(0, displayCount).map((item, i) => (
-                            <button key={i} type="button" disabled={item.aggregated} onClick={() => handleConnectionClick(item.id)}
-                              style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '4px 6px', borderBottom: '1px solid #f5f5f5', width: '100%', background: 'transparent', border: 'none', cursor: item.aggregated ? 'default' : 'pointer', gap: 6, textAlign: 'left' }}
-                            >
-                              <span title={item.name} style={{ flex: 1, fontSize: 12, color: item.aggregated ? '#999' : '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</span>
-                              <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(item.value)}</span>
-                            </button>
-                          ))}
+                          {items.slice(0, displayCount).map((item, i) => {
+                            const spId = item.id.startsWith('project-budget-') ? item.id.replace('project-budget-', 'project-spending-') : item.id;
+                            const rCount = projectRecipientCount.get(spId);
+                            return (
+                              <button key={i} type="button" disabled={item.aggregated} onClick={() => handleConnectionClick(item.id)}
+                                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '4px 6px', borderBottom: '1px solid #f5f5f5', width: '100%', background: 'transparent', border: 'none', cursor: item.aggregated ? 'default' : 'pointer', gap: 6, textAlign: 'left' }}
+                              >
+                                <span title={item.name} style={{ flex: 1, fontSize: 12, color: item.aggregated ? '#999' : '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</span>
+                                <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                                  {rCount != null && <span style={{ fontSize: 10, color: '#bbb', marginRight: 4 }}>{rCount.toLocaleString()}先</span>}
+                                  {formatYen(item.value)}
+                                </span>
+                              </button>
+                            );
+                          })}
                           <div style={{ display: 'flex', gap: 0, padding: '2px 4px', alignItems: 'center', justifyContent: 'flex-end' }}>
                             {remaining > 0 && <>
                               <button onClick={() => setMinistryDisplayCounts(prev => new Map(prev).set(ministry, displayCount + 10))} style={btnStyle}>さらに{Math.min(10, remaining)}件（残{remaining}）</button>
@@ -1127,16 +1212,23 @@ export default function RealDataSankeyPage() {
                                   )
                                 : selectedNodeAllConnections.inEdges;
                               return (<>
-                                {expandedInEdges.slice(0, inDisplayCount).map((item, i) => (
-                                  <button key={i} type="button" onClick={() => handleConnectionClick(item.id)}
-                                    style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '5px 0', borderBottom: '1px solid #f5f5f5', width: '100%', background: 'transparent', border: 'none', cursor: 'pointer', gap: 6, textAlign: 'left' }}
-                                  >
-                                    <span title={item.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                      {item.name}
-                                    </span>
-                                    <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(item.value)}</span>
-                                  </button>
-                                ))}
+                                {expandedInEdges.slice(0, inDisplayCount).map((item, i) => {
+                                  const spId = item.id.startsWith('project-budget-') ? item.id.replace('project-budget-', 'project-spending-') : item.id;
+                                  const rCount = projectRecipientCount.get(spId);
+                                  return (
+                                    <button key={i} type="button" onClick={() => handleConnectionClick(item.id)}
+                                      style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '5px 0', borderBottom: '1px solid #f5f5f5', width: '100%', background: 'transparent', border: 'none', cursor: 'pointer', gap: 6, textAlign: 'left' }}
+                                    >
+                                      <span title={item.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                        {item.name}
+                                      </span>
+                                      <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                                        {rCount != null && <span style={{ fontSize: 10, color: '#bbb', marginRight: 4 }}>{rCount.toLocaleString()}先</span>}
+                                        {formatYen(item.value)}
+                                      </span>
+                                    </button>
+                                  );
+                                })}
                                 {(() => { const rem = expandedInEdges.length - inDisplayCount; return (
                                   <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center', justifyContent: 'flex-end' }}>
                                     {rem > 0 && <>
@@ -1168,14 +1260,21 @@ export default function RealDataSankeyPage() {
                         return (<>
                           {useGrouped && <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>{renderGroupToggle(aggMembers)}</div>}
                           {useGrouped ? renderGrouped(aggMembers) : (<>
-                            {expandedOutEdges.slice(0, outDisplayCount).map((item, i) => (
-                              <button key={i} type="button" onClick={() => handleConnectionClick(item.id)}
-                                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '5px 0', width: '100%', background: 'transparent', border: 'none', borderBottom: '1px solid #f5f5f5', cursor: 'pointer', gap: 6, textAlign: 'left' }}
-                              >
-                                <span title={item.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</span>
-                                <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(item.value)}</span>
-                              </button>
-                            ))}
+                            {expandedOutEdges.slice(0, outDisplayCount).map((item, i) => {
+                              const spId = item.id.startsWith('project-budget-') ? item.id.replace('project-budget-', 'project-spending-') : item.id;
+                              const rCount = projectRecipientCount.get(spId);
+                              return (
+                                <button key={i} type="button" onClick={() => handleConnectionClick(item.id)}
+                                  style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '5px 0', width: '100%', background: 'transparent', border: 'none', borderBottom: '1px solid #f5f5f5', cursor: 'pointer', gap: 6, textAlign: 'left' }}
+                                >
+                                  <span title={item.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</span>
+                                  <span style={{ fontSize: 11, color: '#777', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                                    {rCount != null && <span style={{ fontSize: 10, color: '#bbb', marginRight: 4 }}>{rCount.toLocaleString()}先</span>}
+                                    {formatYen(item.value)}
+                                  </span>
+                                </button>
+                              );
+                            })}
                             {(() => { const rem = expandedOutEdges.length - outDisplayCount; return (
                               <div style={{ display: 'flex', gap: 0, padding: '2px 0', alignItems: 'center', justifyContent: 'flex-end' }}>
                                 {rem > 0 && <>
@@ -1343,7 +1442,7 @@ export default function RealDataSankeyPage() {
         {showSettings && (
           <>
             <div style={{ position: 'fixed', inset: 0, zIndex: 18 }} onMouseDown={() => setShowSettings(false)} />
-            <div id="sankey-topn-settings" role="dialog" aria-label="TopN 設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: 12, minWidth: 240, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div id="sankey-topn-settings" role="dialog" aria-label="TopN 設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: 12, minWidth: 240, display: 'flex', flexDirection: 'column', gap: 10, colorScheme: 'light', color: '#333' }}>
               <div style={{ fontWeight: 'bold', color: '#333', marginBottom: 2 }}>TopN 設定</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <span style={{ width: 48, color: '#555' }}>省庁:</span>
@@ -1361,6 +1460,14 @@ export default function RealDataSankeyPage() {
                 <input type="range" min={1} max={100} value={topRecipient} onChange={e => setTopRecipient(Number(e.target.value))} style={{ flex: 1 }} />
               </label>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={showLabels} onChange={e => setShowLabels(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={includeZeroSpending} onChange={e => setIncludeZeroSpending(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>支出が0円の事業を対象にする</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showAggRecipient} onChange={e => setShowAggRecipient(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>支出先の集約ノードを表示</span>
               </label>
@@ -1369,12 +1476,8 @@ export default function RealDataSankeyPage() {
                 <span style={{ color: '#555' }}>事業の予算額を支出額に合わせて調整</span>
               </label>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-                <input type="checkbox" checked={showLabels} onChange={e => setShowLabels(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
-                <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>
-              </label>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-                <input type="checkbox" checked={includeZeroSpending} onChange={e => setIncludeZeroSpending(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
-                <span style={{ color: '#555' }}>支出が0円の事業を対象にする</span>
+                <input type="checkbox" checked={focusRelated} onChange={e => setFocusRelated(e.target.checked)} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>選択ノードの関連ノードのみ表示</span>
               </label>
             </div>
           </>

--- a/docs/tasks/20260412_1226_選択事業の支出先全表示オプション設計.md
+++ b/docs/tasks/20260412_1226_選択事業の支出先全表示オプション設計.md
@@ -1,0 +1,108 @@
+# 選択した事業に関連する支出先を全表示するオプション設計
+
+## 目的
+
+特定の事業に注目したユーザーが、その事業が支出する支出先の全体像を TopN / オフセットの制約なしに一覧できるようにする。
+
+---
+
+## 背景・現状
+
+### 現行の支出先表示
+
+`filterTopN` は全エッジの支出合計で支出先をランキングし、`recipientOffset` から始まる `topRecipient` 件をウィンドウとして表示する。
+特定事業のみに注目したい場合でも、支出先の選択はこのグローバルランキングに依存しており、事業固有の支出先を網羅的に確認できない。
+
+### `pinnedProjectId` の既存機能
+
+事業ノードをクリックすると `pinnedProjectId` が設定され、TopN に入っていない事業でも強制表示（TopN+1）される。
+また `recipientOffset` が自動ジャンプして、その事業の最大支出先が見えるよう調整される。
+
+---
+
+## 設計方針
+
+「選択した事業に関連する支出先のみ表示」オプション（`showProjectRecipients`）を追加する。
+
+| 状態 | 挙動 |
+|------|------|
+| OFF（デフォルト） | 現行と同じ（グローバルランキングによる TopN ウィンドウ） |
+| ON + 事業ノード選択中 | 選択事業の全支出先をランキング順に表示し、それ以外の支出先は非表示 |
+| ON + 選択解除 | OFF と同じ挙動に戻る（TopN ウィンドウへ復帰） |
+| ON + 事業以外のノード選択中 | OFF と同じ挙動（グローバル TopN を維持） |
+
+---
+
+## 変更スコープ
+
+### 変更ファイル: `app/lib/sankey-svg-filter.ts`
+
+#### シグネチャ変更
+
+```text
+filterTopN(..., showProjectRecipients: boolean = false)
+```
+
+#### 受取先ウィンドウの上書きロジック
+
+条件 `showProjectRecipients && pinnedProjectId != null` のとき、step 2 の受取先ウィンドウ計算を以下で置換する:
+
+1. `pinnedProjectId` から出る全エッジ（`e.source === pinnedProjectId && e.target.startsWith('r-')`）を収集
+2. 収集したエッジを支出額降順でソートし、**全件**を `windowRecipients` とする
+3. `tailRecipients` / `tailRecipientIds` は空集合にする（テールなし）
+4. `aboveWindowRecipientIds` は空集合にする（オフセットなし）
+
+#### 事業ノードのオフセットジャンプ無効化
+
+通常モードでは事業ノードクリック時に `recipientOffset` を自動ジャンプさせているが、
+`showProjectRecipients` が ON の場合は `recipientOffset` を参照しないため、ジャンプロジック自体は動作しても表示に影響しない（副作用なし）。
+
+#### `__agg-recipient` の扱い
+
+`showProjectRecipients` ON のとき:
+- `windowRecipients` が当該事業の全支出先であるため、テール行き支出は原則ゼロ
+- 他の事業が上記ウィンドウ受取先に送る支出は通常どおりエッジとして表示される
+- 他の事業の残余支出（ウィンドウ外受取先行き）は `__agg-recipient` に集約される
+
+---
+
+### 変更ファイル: `app/sankey-svg/page.tsx`
+
+#### state 追加
+
+```text
+showProjectRecipients: boolean  (デフォルト false)
+```
+
+#### `filterTopN` 呼び出し・依存配列
+
+`showProjectRecipients` を第11引数として渡し、`useMemo` の deps に追加。
+
+#### 設定パネル
+
+「支出先の集約ノードを表示」チェックボックスの下に「選択した事業に関連する支出先のみ表示」チェックボックスを追加。
+
+---
+
+## 表示の変化
+
+| 条件 | 支出先列 | 受取先オフセット |
+|------|---------|----------------|
+| OFF | TopN ウィンドウ（現行） | 有効 |
+| ON + 事業選択なし | TopN ウィンドウ（現行） | 有効 |
+| ON + 事業選択中 | 選択事業の全支出先 | 無視される |
+
+オプション ON + 事業選択中は:
+- 支出先列に選択事業の支出先が全件表示される（100件超になる場合もある）
+- 選択事業以外の事業も、上記の支出先に流れるエッジがあれば表示される
+- 選択事業を解除すると元の TopN ウィンドウに即座に戻る
+
+---
+
+## 整合性チェック
+
+| ルール | 確認 |
+|-------|------|
+| `scripts/` にUIロジックなし | 変更なし ✅ |
+| `app/lib/` にHTTP・Reactなし | `filterTopN` は pure 関数のまま ✅ |
+| `client/components/` に直接APIコールなし | 変更なし ✅ |


### PR DESCRIPTION
## 目的

ユーザーが特定のノード（事業・支出先・府省庁）に注目したとき、関係のないノードを非表示にしてフロー全体を把握しやすくするため。

## 変更内容

### フォーカスモード (`focusRelated` オプション)

設定パネルに「選択ノードの関連ノードのみ表示」チェックボックスを追加。ON のときノードをクリックすると関連ノードのみ表示する。

| モード | 発動条件 | 挙動 |
|--------|---------|------|
| `projectRecipientsMode` | 事業ノードをクリック | 選択事業の全支出先を TopN 集約付きで表示 |
| `ministryFocusMode` | 府省庁ノードをクリック | 配下の事業・支出先のみ表示（オフセットスクロール対応） |
| `recipientFocusMode` | 支出先ノードをクリック | 流入元の事業・府省庁のみを TopN 集約付きで表示 |

### BFS 上流・下流ハイライト

ノードクリック時に上流（予算源）・下流（支出先）を BFS で辿り、関連ノードとエッジをハイライト。関係のないノード・エッジは透明度を下げて表示。

### 集約ノードの単一要素展開

`__agg-ministry` / `__agg-project-budget` / `__agg-project-spending` / `__agg-recipient` の集約対象が1件のみの場合、集約ノードを作らず通常ノードとして表示する。

### その他

- `formatYen`: 100億未満は小数2桁表示（例: 52.34億円）、1円未満端数を除去
- 設定パネルのダークモード時文字色修正
- 列合計フォント・ノードラベルフォント・行間の微調整

## テスト方法

```bash
npm run dev
# → localhost:3002/sankey-svg で動作確認

# 確認ポイント:
# 1. 設定パネル「選択ノードの関連ノードのみ表示」を ON
# 2. 支出先ノードをクリック → 流入元事業・府省庁のみ表示されること
# 3. 府省庁ノードをクリック → 配下事業・支出先のみ表示されること
# 4. 事業ノードをクリック → 全支出先が表示されること
# 5. ON/OFF に関わらずノードクリックで上流・下流ハイライトされること
# 6. 集約ノードが1件のとき通常ノードで表示されること
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node pinning and focus modes to filter visualizations to related data only
  * Added recipient count display for project nodes
  * Enhanced node selection with improved visual feedback

* **Improvements**
  * Refined currency value formatting precision
  * Updated settings UI with new filtering toggles
  * Added smooth animations for better visual experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->