### PR TITLE
fix: /sankey-svg focusRelated ON 時に検索から別ノードを選択しても画面が切り替わらないバグを修正

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -572,7 +572,22 @@ export default function RealDataSankeyPage() {
       setRecipientOffset(newOffset);
     };
 
-    if (nodeId.startsWith('r-') && filtered) {
+    if (focusRelated) {
+      // focusRelated ON: 現在のフォーカスコンテキストをクリアして新しいノードに切り替える
+      if (nodeId.startsWith('r-')) {
+        setPinnedRecipientId(nodeId); setPinnedProjectId(null); setPinnedMinistryName(null);
+      } else if (nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-')) {
+        const spendingId = nodeId.startsWith('project-budget-')
+          ? nodeId.replace('project-budget-', 'project-spending-')
+          : nodeId;
+        setPinnedProjectId(spendingId); setPinnedRecipientId(null); setPinnedMinistryName(null);
+      } else if (nodeId.startsWith('ministry-')) {
+        const ministryNode = graphData?.nodes.find(n => n.id === nodeId);
+        if (ministryNode) { setPinnedMinistryName(ministryNode.name); setPinnedProjectId(null); setPinnedRecipientId(null); }
+      } else {
+        setPinnedProjectId(null); setPinnedRecipientId(null); setPinnedMinistryName(null);
+      }
+    } else if (nodeId.startsWith('r-') && filtered) {
       // Recipient outside window: jump offset so it's visible
       const rank = allRecipientRanks.get(nodeId);
       if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);


### PR DESCRIPTION
## 目的

「選択ノードの関連ノードのみ表示」ON 時に、ノードを選択済みの状態で検索から別のノードを選択しても表示が切り替わらない問題を解消するため。

## 原因

`handleConnectionClick` のアウトレイアウト処理（ノードが現在のレイアウトに存在しない場合）で、`focusRelated` ON 時に既存の `pinnedMinistryName` / `pinnedRecipientId` をクリアしていなかった。
これにより、例えば府省庁 A にフォーカスした状態で府省庁 B のノードを検索選択しても、古い `pinnedMinistryName = A` が維持されたままレイアウトが更新されなかった。

## 変更内容

`handleConnectionClick` のアウトレイアウト処理に `focusRelated` ON 専用の分岐を追加。

| ノード種別 | 新しいピン設定 |
|-----------|--------------|
| `r-*`（支出先） | `pinnedRecipientId` をセット、他をクリア |
| `project-*`（事業） | `pinnedProjectId` をセット、他をクリア |
| `ministry-*`（府省庁） | `pinnedMinistryName` をセット、他をクリア |
| その他 | すべてクリア |

`focusRelated` OFF の場合は既存のオフセットジャンプ・ピン留めロジックをそのまま維持。

## テスト方法

```bash
npm run dev
# → localhost:3002/sankey-svg

# 確認ポイント:
# 1. 「選択ノードの関連ノードのみ表示」を ON にする
# 2. 事業ノードをクリックして選択する（事業のフォーカス表示になる）
# 3. 検索ボックスで別の支出先・事業・府省庁を検索して選択する
# 4. 選択したノードのフォーカス表示に切り替わることを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced node selection behavior in the Sankey diagram to better highlight related recipients, spending data, and ministry information when interacting with nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->