### PR TITLE
/sankey-svg 検索UX改善・パネル折りたたみボタン強化

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -46,6 +46,26 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   return result;
 }
 
+/** ノードID → フォーカスピン状態を導出する純粋ヘルパー */
+function computeFocusPins(
+  nodeId: string,
+  nodes: Array<{ id: string; name: string }> | undefined,
+): { pinnedProjectId: string | null; pinnedRecipientId: string | null; pinnedMinistryName: string | null } {
+  if (nodeId.startsWith('r-')) {
+    return { pinnedProjectId: null, pinnedRecipientId: nodeId, pinnedMinistryName: null };
+  }
+  if (nodeId.startsWith('project-budget-') || nodeId.startsWith('project-spending-')) {
+    const spendingId = nodeId.startsWith('project-budget-')
+      ? nodeId.replace('project-budget-', 'project-spending-')
+      : nodeId;
+    return { pinnedProjectId: spendingId, pinnedRecipientId: null, pinnedMinistryName: null };
+  }
+  if (nodeId.startsWith('ministry-')) {
+    return { pinnedProjectId: null, pinnedRecipientId: null, pinnedMinistryName: nodes?.find(n => n.id === nodeId)?.name ?? null };
+  }
+  return { pinnedProjectId: null, pinnedRecipientId: null, pinnedMinistryName: null };
+}
+
 export default function RealDataSankeyPage() {
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -531,18 +551,9 @@ export default function RealDataSankeyPage() {
     // If already in layout, select and focus directly (no effect needed)
     const inLayoutNode = layout?.nodes.find(n => n.id === nodeId);
     if (inLayoutNode) {
-      if (focusRelated && nodeId.startsWith('r-') && !inLayoutNode.aggregated) {
-        setPinnedRecipientId(nodeId);
-        setPinnedProjectId(null);
-        setPinnedMinistryName(null);
-        selectNode(nodeId);
-        focusOnNeighborhood(inLayoutNode);
-        return;
-      }
-      if (focusRelated && inLayoutNode.type === 'ministry' && !inLayoutNode.aggregated) {
-        setPinnedMinistryName(inLayoutNode.name);
-        setPinnedProjectId(null);
-        setPinnedRecipientId(null);
+      if (focusRelated && (nodeId.startsWith('r-') || inLayoutNode.type === 'ministry') && !inLayoutNode.aggregated) {
+        const pins = computeFocusPins(nodeId, graphData?.nodes);
+        setPinnedProjectId(pins.pinnedProjectId); setPinnedRecipientId(pins.pinnedRecipientId); setPinnedMinistryName(pins.pinnedMinistryName);
         selectNode(nodeId);
         focusOnNeighborhood(inLayoutNode);
         return;
@@ -576,19 +587,8 @@ export default function RealDataSankeyPage() {
 
     if (focusRelated) {
       // focusRelated ON: 現在のフォーカスコンテキストをクリアして新しいノードに切り替える
-      if (nodeId.startsWith('r-')) {
-        setPinnedRecipientId(nodeId); setPinnedProjectId(null); setPinnedMinistryName(null);
-      } else if (nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-')) {
-        const spendingId = nodeId.startsWith('project-budget-')
-          ? nodeId.replace('project-budget-', 'project-spending-')
-          : nodeId;
-        setPinnedProjectId(spendingId); setPinnedRecipientId(null); setPinnedMinistryName(null);
-      } else if (nodeId.startsWith('ministry-')) {
-        const ministryNode = graphData?.nodes.find(n => n.id === nodeId);
-        if (ministryNode) { setPinnedMinistryName(ministryNode.name); setPinnedProjectId(null); setPinnedRecipientId(null); }
-      } else {
-        setPinnedProjectId(null); setPinnedRecipientId(null); setPinnedMinistryName(null);
-      }
+      const pins = computeFocusPins(nodeId, graphData?.nodes);
+      setPinnedProjectId(pins.pinnedProjectId); setPinnedRecipientId(pins.pinnedRecipientId); setPinnedMinistryName(pins.pinnedMinistryName);
     } else if (nodeId.startsWith('r-') && filtered) {
       // Recipient outside window: jump offset so it's visible
       const rank = allRecipientRanks.get(nodeId);
@@ -625,30 +625,14 @@ export default function RealDataSankeyPage() {
     if (didPanRef.current) return;
     const newId = selectedNodeId === node.id ? null : node.id;
     if (focusRelated && newId !== null && !node.aggregated) {
-      if (node.type === 'recipient') {
-        setPinnedRecipientId(node.id);
-        setPinnedProjectId(null);
-        setPinnedMinistryName(null);
-      } else if (node.type === 'ministry') {
-        setPinnedMinistryName(node.name);
-        setPinnedProjectId(null);
-        setPinnedRecipientId(null);
-      } else {
-        const spendingId = node.type === 'project-budget'
-          ? node.id.replace('project-budget-', 'project-spending-')
-          : node.type === 'project-spending'
-            ? node.id
-            : null;
-        setPinnedProjectId(spendingId);
-        setPinnedRecipientId(null);
-        setPinnedMinistryName(null);
-      }
+      const pins = computeFocusPins(node.id, graphData?.nodes);
+      setPinnedProjectId(pins.pinnedProjectId); setPinnedRecipientId(pins.pinnedRecipientId); setPinnedMinistryName(pins.pinnedMinistryName);
     } else if (!focusRelated || newId === null) {
       setPinnedRecipientId(null);
       setPinnedMinistryName(null);
     }
     selectNode(newId);
-  }, [selectedNodeId, selectNode, focusRelated]);
+  }, [selectedNodeId, selectNode, focusRelated, graphData]);
 
   // ── Search ──
 

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -77,7 +77,9 @@ export default function RealDataSankeyPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [showSearchResults, setShowSearchResults] = useState(false);
+  const [searchCursorIndex, setSearchCursorIndex] = useState(-1);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchDropdownRef = useRef<HTMLDivElement>(null);
   // Tracks whether the next URL update should push (navigation) or replace (slider/toggle)
   const pendingHistoryAction = useRef<'push' | 'replace' | null>(null);
   const pendingFocusId = useRef<string | null>(null);
@@ -1076,8 +1078,8 @@ export default function RealDataSankeyPage() {
           <div
             data-pan-disabled="true"
             style={{
-              position: 'absolute', right: -18, top: '50%', transform: 'translateY(-50%)',
-              width: 18,
+              position: 'absolute', right: -25, top: '50%', transform: 'translateY(-50%)',
+              width: 25,
               background: '#fff', border: '1px solid #e0e0e0', borderLeft: 'none',
               borderRadius: '0 6px 6px 0',
               boxShadow: '2px 0 4px rgba(0,0,0,0.08)',
@@ -1090,16 +1092,16 @@ export default function RealDataSankeyPage() {
               onClick={() => setIsPanelCollapsed(c => !c)}
               title={isPanelCollapsed ? 'パネルを展開' : 'パネルを折りたたむ'}
               style={{
-                width: 18, height: 48,
+                width: 25, height: 56,
                 background: 'transparent', border: 'none',
                 cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
                 padding: 0, borderRadius: '0 6px 6px 0',
               }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#aaa">
+              <svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 24 24" fill="none" stroke="#888" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 {isPanelCollapsed
-                  ? <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
-                  : <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>}
+                  ? <polyline points="9 6 15 12 9 18"/>
+                  : <polyline points="15 6 9 12 15 18"/>}
               </svg>
             </button>
           </div>
@@ -1422,7 +1424,7 @@ export default function RealDataSankeyPage() {
       {/* Search box — top left */}
       <div
         data-pan-disabled="true"
-        style={{ position: 'absolute', top: 12, left: 12, zIndex: 15, width: 260 }}
+        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? 292 : 12, zIndex: 100, width: 260, transition: 'left 0.2s ease' }}
       >
         <div style={{ position: 'relative' }}>
           {/* Search icon */}
@@ -1434,9 +1436,33 @@ export default function RealDataSankeyPage() {
             ref={searchInputRef}
             type="text"
             value={searchQuery}
-            onChange={e => { setSearchQuery(e.target.value); setShowSearchResults(true); }}
+            onChange={e => { setSearchQuery(e.target.value); setShowSearchResults(true); setSearchCursorIndex(-1); }}
             onFocus={() => { if (debouncedQuery.trim().length >= 2) setShowSearchResults(true); }}
-            onKeyDown={e => { if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); } }}
+            onKeyDown={e => {
+              if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
+              if (!showSearchResults || searchResults.length === 0) return;
+              if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setSearchCursorIndex(i => {
+                  const next = Math.min(i + 1, searchResults.length - 1);
+                  setTimeout(() => searchDropdownRef.current?.children[next]?.scrollIntoView({ block: 'nearest' }), 0);
+                  return next;
+                });
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setSearchCursorIndex(i => {
+                  const next = Math.max(i - 1, 0);
+                  setTimeout(() => searchDropdownRef.current?.children[next]?.scrollIntoView({ block: 'nearest' }), 0);
+                  return next;
+                });
+              } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (searchCursorIndex >= 0 && searchCursorIndex < searchResults.length) {
+                  handleSearchSelect(searchResults[searchCursorIndex].id);
+                  setSearchCursorIndex(-1);
+                }
+              }
+            }}
             placeholder="ノード検索（2文字以上）"
             style={{
               width: '100%', boxSizing: 'border-box',
@@ -1456,18 +1482,18 @@ export default function RealDataSankeyPage() {
         </div>
         {/* Dropdown */}
         {showSearchResults && searchResults.length > 0 && (
-          <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 280, overflowY: 'auto', zIndex: 20 }}>
-            {searchResults.map(node => (
+          <div ref={searchDropdownRef} style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 280, overflowY: 'auto', zIndex: 20 }}>
+            {searchResults.map((node, i) => (
               <button
                 key={node.id}
                 type="button"
-                onClick={() => handleSearchSelect(node.id)}
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', background: 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left' }}
-                onMouseEnter={e => (e.currentTarget.style.background = '#f5f5f5')}
-                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                onClick={() => { handleSearchSelect(node.id); setSearchCursorIndex(-1); }}
+                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', background: i === searchCursorIndex ? '#e8f0fe' : 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                onMouseEnter={e => { if (i !== searchCursorIndex) e.currentTarget.style.background = '#f5f5f5'; }}
+                onMouseLeave={e => { e.currentTarget.style.background = i === searchCursorIndex ? '#e8f0fe' : 'transparent'; }}
               >
                 <span style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: getNodeColor(node) }} />
-                <span style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{node.name}</span>
+                <span title={node.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{node.name}</span>
                 <span style={{ fontSize: 11, color: '#999', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(node.value)}</span>
               </button>
             ))}


### PR DESCRIPTION
## 目的

ユーザーが検索ボックスをキーボードだけで操作できるようにし、サイドパネルとの視覚的な干渉をなくすため。

## 変更内容

### パネル折りたたみボタン
- アイコンを `fill` ベースの小さなパスから `stroke` ベースの chevron（20×20）に変更し、視認性を向上
- コンテナ・ボタン幅を 18px → 25px に拡大

### 検索ボックス
- サイドパネル展開中は `left: 12px` → `left: 292px` にスライド（0.2s トランジション）、パネルと重ならないよう調整
- `zIndex` を 15 → 100 に引き上げ、最前面に表示

### 検索キーボードナビゲーション
- **↓ / ↑ キー**: 候補リストをカーソル移動（画面外の候補は自動スクロール）
- **Enter キー**: カーソル位置の候補を選択
- **Escape キー**: 検索クリア（既存動作）
- カーソル行を青背景（`#e8f0fe`）でハイライト表示

### 検索結果ツールチップ
- 名前が省略（`text-overflow: ellipsis`）されている候補にホバーするとフルネームをツールチップ表示

## テスト方法

```
npm run dev
# localhost:3002/sankey-svg を開く
# 1. ノードを選択 → サイドパネルが開き、検索ボックスが右にスライドすることを確認
# 2. 検索ボックスに2文字以上入力 → ↓↑キーで候補移動、Enterで選択
# 3. 折りたたみボタンのアイコンが太く大きくなっていることを確認
```

> **Note**: このPRは PR #140 (`fix/sankey-svg-focus-search-context`) を base にしています。#140 のマージ後に base を `main` に変更してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)