### PR TITLE
feat: /sankey-svg ノードラベルクリックでノード選択を有効化

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1108,7 +1108,8 @@ export default function RealDataSankeyPage() {
                             {labelVisible && (
                               <text x={node.x1 + 3} y={bH / 2} fontSize={11 / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : '#333'}
-                                style={{ userSelect: 'none', pointerEvents: 'none' }} clipPath={`url(#clip-col-${getColumn(node)})`}>
+                                style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
+                                onClick={(e) => handleNodeClick(node, e)}>
                                 {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                               </text>
                             )}
@@ -1130,13 +1131,15 @@ export default function RealDataSankeyPage() {
                             {/* Left label: budget amount */}
                             <text x={node.x0 - 3} y={bH / 2} fontSize={11 / zoom} dominantBaseline="middle" textAnchor="end"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : '#333'}
-                              style={{ userSelect: 'none', pointerEvents: 'none' }}>
+                              style={{ userSelect: 'none', cursor: 'pointer' }}
+                              onClick={(e) => handleNodeClick(node, e)}>
                               {formatYen(node.value)}{node.isScaled && node.rawValue != null && <tspan fill="#888"> / {formatYen(node.rawValue)}</tspan>}
                             </text>
                             {/* Right label: project name + spending amount */}
                             <text x={spendingNode.x1 + 3} y={sH / 2} fontSize={11 / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : '#333'}
-                              style={{ userSelect: 'none', pointerEvents: 'none' }} clipPath={`url(#clip-col-${getColumn(node)})`}>
+                              style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
+                              onClick={(e) => handleNodeClick(node, e)}>
                               {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
                             </text>
                           </>)}
@@ -1184,8 +1187,9 @@ export default function RealDataSankeyPage() {
                             fontSize={11 / zoom}
                             dominantBaseline="middle"
                             fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : '#333'}
-                            style={{ userSelect: 'none', pointerEvents: 'none' }}
+                            style={{ userSelect: 'none', cursor: 'pointer' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
+                            onClick={(e) => handleNodeClick(node, e)}
                           >
                             {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                           </text>


### PR DESCRIPTION
## 目的

ノードの rect をクリックしたときと同じ挙動をラベルテキストからも行えるようにするため。ラベルをクリックしてもノードが選択・フォーカスされるようになります。

## 変更内容

`app/sankey-svg/page.tsx` の SVG テキストラベル 4 箇所を修正:

| ノード種別 | ラベル位置 | 変更内容 |
|-----------|----------|---------|
| 予算のみノード（spending ペアなし） | 右ラベル | `pointerEvents: 'none'` 削除 + `onClick` 追加 |
| 統合プロジェクトノード | 左ラベル（予算額） | 同上 |
| 統合プロジェクトノード | 右ラベル（事業名+支出額） | 同上 |
| 通常ノード（total/府省庁/支出先） | 右ラベル | 同上 |

すべて `handleNodeClick(node, e)` を呼び出すため、既存のフォーカスモード・サイドパネル・URL状態管理の挙動をそのまま引き継ぎます。

## テスト方法

```bash
npm run dev
# → http://localhost:3002/sankey-svg でノードラベルのテキスト部分をクリック
# → ノード rect クリックと同じ挙動（選択・サイドパネル表示）になることを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sankey diagram labels are now interactive and clickable, including both merged project labels and regular node labels. Visual cursor feedback indicates interaction points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->