### PR TITLE
fix: /sankey-svg 支出先オフセット増加時にウィンドウ外支出先の事業が残り続けるバグを修正

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -494,6 +494,7 @@ export function filterTopN(
   }
 
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
     // Budget height = adjusted budget (scaled by visible spending fraction when scaleBudgetToVisible).
     // rawValue preserves original budget for label display.
@@ -585,6 +586,7 @@ export function filterTopN(
     ? new Set(topProjectNodes.map(n => n.ministry).filter(Boolean) as string[])
     : topMinistryNames;
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetId = `project-budget-${n.projectId}`;
     const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
     const ministrySource = visibleMinistryNames.has(n.ministry || '') ? `ministry-${n.ministry}` : '__agg-ministry';
@@ -615,6 +617,7 @@ export function filterTopN(
 
   // project-budget → project-spending (adjusted budget-based; 0-value edges emitted for hierarchy)
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetId = `project-budget-${n.projectId}`;
     const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
     edges.push({ source: budgetId, target: n.id, value: bv });
@@ -624,7 +627,7 @@ export function filterTopN(
   }
 
   // project-spending → window recipients
-  const topProjectSpendingIds = new Set(topProjectNodes.map(n => n.id));
+  const topProjectSpendingIds = new Set(topProjectNodes.filter(n => !effectivelyHiddenIds.has(n.id)).map(n => n.id));
   for (const e of allEdges) {
     if (topProjectSpendingIds.has(e.source) && windowRecipientIds.has(e.target)) edges.push(e);
   }

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -315,7 +315,7 @@ export function filterTopN(
   const effectivelyHiddenIds = new Set(
     allNodes
       .filter(n => n.type === 'project-spending' && n.value > 0
-        && !topProjectIds.has(n.id)  // pinned projects are in topProjectIds — do not hide them
+        && n.id !== pinnedProjectId  // only exempt the pinned project; top-N alone is not enough
         && !aboveWindowSpendingIds.has(n.id)  // above-window projects excluded via their own path
         // In projectOffsetMode, aggregate projects are always shown via the aggregate node
         // regardless of recipient overlap with the window — never treat them as effectively hidden.


### PR DESCRIPTION
## 目的

ユーザーが支出先オフセットを増やしたとき、ウィンドウ外になった支出先にのみ流れる事業が表示され続ける（ゴースト事業）問題を解消するため。

## 変更内容

**`app/lib/sankey-svg-filter.ts`**

`effectivelyHiddenIds` の計算ロジックを修正。

- **Before**: `!topProjectIds.has(n.id)` — TopN事業全体を非表示対象から除外していた
- **After**: `n.id !== pinnedProjectId` — ピン留め事業のみ保護し、TopN判定は除外

### 問題の根本原因

TopN事業（予算額でランク上位の事業）は `effectivelyHiddenIds` から除外されていた。しかし「予算額でTopN」と「現在のウィンドウ内の支出先に流れを持つ」は別の条件。支出先オフセットが増えるとウィンドウが後方にシフトするため、TopN事業であっても現在のウィンドウ外の支出先にのみ流れを持つ場合がある。

この修正により、ピン留め以外のTopN事業も `projectWindowValue === 0` かつ `projectTailValue === 0`（showAggRecipient時）の条件を満たす場合は正しく非表示になる。

## テスト方法

1. `npm run dev` → `localhost:3002/sankey-svg`
2. オフセット対象を「支出先」に切り替える
3. 支出先オフセットを増加させる
4. オフセットによってウィンドウから外れた支出先にのみ紐づく事業が、ウィンドウ外に出た後に消えることを確認