### PR TITLE
fix: /sankey-svg 支出先オフセット時に全支出先がウィンドウ外になった事業ノードが0円で残り続けるバグを修正

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -234,16 +234,20 @@ export function filterTopN(
   );
   topMinistryAllProjects.sort((a, b) => {
     if (projectSortBy === 'budget') {
-      const ba = nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
-      const bb = nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
+      // Use adjusted budget (scaled by visible spending fraction) so ranking reacts to recipient offset.
+      const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
+      const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
-      return b.value - a.value;
+      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
     return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
   });
+  // Filter before slice so that projects with no visible flow don't consume TopN slots.
   const topProjectNodes = topMinistryAllProjects
-    .slice(0, topProject)
-    .filter(n => includeZeroSpending || projectSortBy === 'budget' || (projectWindowValue.get(n.id) || 0) > 0);
+    .filter(n => n.id === pinnedProjectId || includeZeroSpending
+      || (projectWindowValue.get(n.id) || 0) > 0
+      || (showAggRecipient && (projectTailValue.get(n.id) || 0) > 0))
+    .slice(0, topProject);
   // Pin: force-include the pinned project (TopN+1) if not already present
   if (pinnedProjectId) {
     const pinned = allNodes.find(n => n.id === pinnedProjectId && n.type === 'project-spending');

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -238,13 +238,9 @@ export function filterTopN(
       const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
+      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
-    const wa = projectWindowValue.get(a.id) || 0;
-    const wb = projectWindowValue.get(b.id) || 0;
-    if (wb !== wa) return wb - wa;
-    // Tiebreaker: tail spending — at high offset where window spending is 0, order by tail flow
-    // so projects sort by visible contribution rather than preserving original data order.
-    return (projectTailValue.get(b.id) || 0) - (projectTailValue.get(a.id) || 0);
+    return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
   });
   // Filter before slice so that projects with no visible flow don't consume TopN slots.
   const topProjectNodes = topMinistryAllProjects

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -242,7 +242,10 @@ export function filterTopN(
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
     }
-    return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
+    // Use window + tail (= visible spending) so the aggregate recipient's contribution is included.
+    const va = (projectWindowValue.get(a.id) || 0) + (showAggRecipient ? (projectTailValue.get(a.id) || 0) : 0);
+    const vb = (projectWindowValue.get(b.id) || 0) + (showAggRecipient ? (projectTailValue.get(b.id) || 0) : 0);
+    return vb - va;
   });
   // Filter before slice so that projects with no visible flow don't consume TopN slots.
   const topProjectNodes = topMinistryAllProjects
@@ -501,27 +504,26 @@ export function filterTopN(
 
   for (const n of topProjectNodes) {
     if (effectivelyHiddenIds.has(n.id)) continue;
-    const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
-    // Budget height = adjusted budget (scaled by visible spending fraction when scaleBudgetToVisible).
-    // rawValue preserves original budget for label display.
-    if (budgetNode) {
-      const adjBv = projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value;
-      // layoutSortValue: determines vertical position — must match topMinistryAllProjects sort key.
-      // project-offset + budget sort → adjusted budget; otherwise → window spending.
-      const layoutSortBase = (projectSortBy === 'budget' && projectOffsetMode)
-        ? (projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value)
-        : (projectWindowValue.get(n.id) || 0);
-      nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, layoutSortValue: layoutSortBase, skipLinkOverride: true });
-    }
     // spending node height = window spending only (agg hidden) or total minus above-window (normal).
     const spendingValue = (recipientFocusMode || !showAggRecipient)
       ? (projectWindowValue.get(n.id) || 0)
       : n.value - (projectAboveWindowSpending.get(n.id) || 0);
     const spendingTrimmed = spendingValue < n.value;
-    const spendingLayoutSortValue = (projectSortBy === 'budget' && projectOffsetMode)
+    // layoutSortValue: determines vertical position — must match topMinistryAllProjects sort key.
+    // project-offset + budget sort → adjusted budget; otherwise → visible spending (window + tail).
+    // Use spendingValue (= window + tail) rather than windowValue alone so the aggregate
+    // recipient's contribution is included in the sort, matching the displayed node height.
+    const layoutSortBase = (projectSortBy === 'budget' && projectOffsetMode)
       ? (projectAdjustedBudget.get(`project-budget-${n.projectId}`) ?? nodeById.get(`project-budget-${n.projectId}`)?.value ?? n.value)
-      : (projectWindowValue.get(n.id) || 0);
-    nodes.push({ ...n, value: spendingValue, rawValue: spendingTrimmed ? n.value : undefined, isScaled: spendingTrimmed, layoutSortValue: spendingLayoutSortValue, skipLinkOverride: true });
+      : spendingValue;
+    const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
+    // Budget height = adjusted budget (scaled by visible spending fraction when scaleBudgetToVisible).
+    // rawValue preserves original budget for label display.
+    if (budgetNode) {
+      const adjBv = projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value;
+      nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, layoutSortValue: layoutSortBase, skipLinkOverride: true });
+    }
+    nodes.push({ ...n, value: spendingValue, rawValue: spendingTrimmed ? n.value : undefined, isScaled: spendingTrimmed, layoutSortValue: layoutSortBase, skipLinkOverride: true });
   }
   // Compute aggregate spending total independently of budget so zero-budget aggregate projects
   // still get a spending node (budget and spending gates are evaluated separately).

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -233,13 +233,12 @@ export function filterTopN(
     n => n.type === 'project-spending' && topMinistryNames.has(n.ministry || '') && !zeroSpendingProjectIds.has(n.id)
   );
   topMinistryAllProjects.sort((a, b) => {
-    // In project-offset mode with budget sort, rank by adjusted budget (scaled by visible fraction).
-    // In recipient-offset mode (or spending sort), always rank by window spending so TopN
-    // reflects the current offset window regardless of the sort setting.
-    if (projectSortBy === 'budget' && projectOffsetMode) {
+    if (projectSortBy === 'budget') {
+      // Use adjusted budget (scaled by visible spending fraction) so ranking reacts to recipient offset.
       const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
+      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
     return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
   });

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -506,21 +506,21 @@ export function filterTopN(
     // rawValue preserves original budget for label display.
     if (budgetNode) {
       const adjBv = projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value;
-      // layoutSortValue: align both columns to the same sort criterion.
-      // spending sort → budget column sorts by spending n.value
-      // budget sort   → budget column sorts by raw budgetNode.value (canonical, scale-independent)
-      const budgetLayoutSortValue = projectSortBy === 'spending' ? n.value : budgetNode.value;
-      nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, layoutSortValue: budgetLayoutSortValue, skipLinkOverride: true });
+      // layoutSortValue: determines vertical position — must match topMinistryAllProjects sort key.
+      // project-offset + budget sort → adjusted budget; otherwise → window spending.
+      const layoutSortBase = (projectSortBy === 'budget' && projectOffsetMode)
+        ? (projectAdjustedBudget.get(budgetNode.id) ?? budgetNode.value)
+        : (projectWindowValue.get(n.id) || 0);
+      nodes.push({ ...budgetNode, value: adjBv, rawValue: budgetNode.value, isScaled: adjBv < budgetNode.value, layoutSortValue: layoutSortBase, skipLinkOverride: true });
     }
     // spending node height = window spending only (agg hidden) or total minus above-window (normal).
     const spendingValue = (recipientFocusMode || !showAggRecipient)
       ? (projectWindowValue.get(n.id) || 0)
       : n.value - (projectAboveWindowSpending.get(n.id) || 0);
     const spendingTrimmed = spendingValue < n.value;
-    // budget sort → spending column sorts by raw budgetNode.value; spending sort → sort by n.value
-    const spendingLayoutSortValue = projectSortBy === 'budget'
-      ? (nodeById.get(`project-budget-${n.projectId}`)?.value ?? n.value)
-      : n.value;
+    const spendingLayoutSortValue = (projectSortBy === 'budget' && projectOffsetMode)
+      ? (projectAdjustedBudget.get(`project-budget-${n.projectId}`) ?? nodeById.get(`project-budget-${n.projectId}`)?.value ?? n.value)
+      : (projectWindowValue.get(n.id) || 0);
     nodes.push({ ...n, value: spendingValue, rawValue: spendingTrimmed ? n.value : undefined, isScaled: spendingTrimmed, layoutSortValue: spendingLayoutSortValue, skipLinkOverride: true });
   }
   // Compute aggregate spending total independently of budget so zero-budget aggregate projects

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -238,9 +238,13 @@ export function filterTopN(
       const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
-      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
-    return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
+    const wa = projectWindowValue.get(a.id) || 0;
+    const wb = projectWindowValue.get(b.id) || 0;
+    if (wb !== wa) return wb - wa;
+    // Tiebreaker: tail spending — at high offset where window spending is 0, order by tail flow
+    // so projects sort by visible contribution rather than preserving original data order.
+    return (projectTailValue.get(b.id) || 0) - (projectTailValue.get(a.id) || 0);
   });
   // Filter before slice so that projects with no visible flow don't consume TopN slots.
   const topProjectNodes = topMinistryAllProjects

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -233,12 +233,13 @@ export function filterTopN(
     n => n.type === 'project-spending' && topMinistryNames.has(n.ministry || '') && !zeroSpendingProjectIds.has(n.id)
   );
   topMinistryAllProjects.sort((a, b) => {
-    if (projectSortBy === 'budget') {
-      // Use adjusted budget (scaled by visible spending fraction) so ranking reacts to recipient offset.
+    // In project-offset mode with budget sort, rank by adjusted budget (scaled by visible fraction).
+    // In recipient-offset mode (or spending sort), always rank by window spending so TopN
+    // reflects the current offset window regardless of the sort setting.
+    if (projectSortBy === 'budget' && projectOffsetMode) {
       const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
-      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
     return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
   });

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -233,12 +233,14 @@ export function filterTopN(
     n => n.type === 'project-spending' && topMinistryNames.has(n.ministry || '') && !zeroSpendingProjectIds.has(n.id)
   );
   topMinistryAllProjects.sort((a, b) => {
-    if (projectSortBy === 'budget') {
-      // Use adjusted budget (scaled by visible spending fraction) so ranking reacts to recipient offset.
+    // projectSortBy='budget' is only meaningful in project-offset mode where there is no recipient
+    // offset and raw budget order is stable. In recipient-offset mode the adjusted budget
+    // (rawBudget × visible-fraction) still ranks large-budget projects above small-budget ones
+    // even when their window spending is far lower, so always sort by window spending instead.
+    if (projectSortBy === 'budget' && projectOffsetMode) {
       const ba = projectAdjustedBudget.get(`project-budget-${a.projectId}`) ?? nodeById.get(`project-budget-${a.projectId}`)?.value ?? 0;
       const bb = projectAdjustedBudget.get(`project-budget-${b.projectId}`) ?? nodeById.get(`project-budget-${b.projectId}`)?.value ?? 0;
       if (bb !== ba) return bb - ba;
-      return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
     }
     return (projectWindowValue.get(b.id) || 0) - (projectWindowValue.get(a.id) || 0);
   });

--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -315,7 +315,7 @@ export function filterTopN(
   const effectivelyHiddenIds = new Set(
     allNodes
       .filter(n => n.type === 'project-spending' && n.value > 0
-        && !topProjectIds.has(n.id)  // pinned projects are in topProjectIds — do not hide them
+        && n.id !== pinnedProjectId  // only the pinned project is exempt; top-N rank alone is not enough
         && !aboveWindowSpendingIds.has(n.id)  // above-window projects excluded via their own path
         // In projectOffsetMode, aggregate projects are always shown via the aggregate node
         // regardless of recipient overlap with the window — never treat them as effectively hidden.
@@ -494,6 +494,7 @@ export function filterTopN(
   }
 
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetNode = nodeById.get(`project-budget-${n.projectId}`);
     // Budget height = adjusted budget (scaled by visible spending fraction when scaleBudgetToVisible).
     // rawValue preserves original budget for label display.
@@ -585,6 +586,7 @@ export function filterTopN(
     ? new Set(topProjectNodes.map(n => n.ministry).filter(Boolean) as string[])
     : topMinistryNames;
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetId = `project-budget-${n.projectId}`;
     const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
     const ministrySource = visibleMinistryNames.has(n.ministry || '') ? `ministry-${n.ministry}` : '__agg-ministry';
@@ -615,6 +617,7 @@ export function filterTopN(
 
   // project-budget → project-spending (adjusted budget-based; 0-value edges emitted for hierarchy)
   for (const n of topProjectNodes) {
+    if (effectivelyHiddenIds.has(n.id)) continue;
     const budgetId = `project-budget-${n.projectId}`;
     const bv = projectAdjustedBudget.get(budgetId) ?? nodeById.get(budgetId)?.value ?? 0;
     edges.push({ source: budgetId, target: n.id, value: bv });
@@ -624,7 +627,7 @@ export function filterTopN(
   }
 
   // project-spending → window recipients
-  const topProjectSpendingIds = new Set(topProjectNodes.map(n => n.id));
+  const topProjectSpendingIds = new Set(topProjectNodes.filter(n => !effectivelyHiddenIds.has(n.id)).map(n => n.id));
   for (const e of allEdges) {
     if (topProjectSpendingIds.has(e.source) && windowRecipientIds.has(e.target)) edges.push(e);
   }

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -128,6 +128,7 @@ export default function RealDataSankeyPage() {
   const [showSearchResults, setShowSearchResults] = useState(false);
   const [searchCursorIndex, setSearchCursorIndex] = useState(-1);
   const [searchUseRegex, setSearchUseRegex] = useState(false);
+  const [searchPage, setSearchPage] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchDropdownRef = useRef<HTMLDivElement>(null);
   const [zeroSpendingAlert, setZeroSpendingAlert] = useState(false);
@@ -924,6 +925,8 @@ export default function RealDataSankeyPage() {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
+  useEffect(() => { setSearchPage(0); setSearchCursorIndex(-1); }, [debouncedQuery]);
+
   const searchRegexError = useMemo(() => {
     if (!searchUseRegex || debouncedQuery.trim().length < 2) return false;
     try { new RegExp(debouncedQuery.trim()); return false; } catch { return true; }
@@ -951,8 +954,15 @@ export default function RealDataSankeyPage() {
         if (matcher(n.name)) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
       }
     }
-    return results.sort((a, b) => b.value - a.value).slice(0, 20);
+    return results.sort((a, b) => b.value - a.value);
   }, [graphData, debouncedQuery, searchUseRegex]);
+
+  const SEARCH_PAGE_SIZE = 200;
+  const searchPagedResults = useMemo(
+    () => searchResults.slice(searchPage * SEARCH_PAGE_SIZE, (searchPage + 1) * SEARCH_PAGE_SIZE),
+    [searchResults, searchPage]
+  );
+  const searchTotalPages = Math.ceil(searchResults.length / SEARCH_PAGE_SIZE);
 
   const pendingSearchResetRef = useRef(false);
 
@@ -1826,25 +1836,25 @@ export default function RealDataSankeyPage() {
             onFocus={() => { if (debouncedQuery.trim().length >= 2) setShowSearchResults(true); }}
             onKeyDown={e => {
               if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
-              if (!showSearchResults || searchResults.length === 0) return;
+              if (!showSearchResults || searchPagedResults.length === 0) return;
               if (e.key === 'ArrowDown') {
                 e.preventDefault();
                 setSearchCursorIndex(i => {
-                  const next = Math.min(i + 1, searchResults.length - 1);
-                  setTimeout(() => searchDropdownRef.current?.children[next]?.scrollIntoView({ block: 'nearest' }), 0);
+                  const next = Math.min(i + 1, searchPagedResults.length - 1);
+                  setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
                   return next;
                 });
               } else if (e.key === 'ArrowUp') {
                 e.preventDefault();
                 setSearchCursorIndex(i => {
                   const next = Math.max(i - 1, 0);
-                  setTimeout(() => searchDropdownRef.current?.children[next]?.scrollIntoView({ block: 'nearest' }), 0);
+                  setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
                   return next;
                 });
               } else if (e.key === 'Enter') {
                 e.preventDefault();
-                if (searchCursorIndex >= 0 && searchCursorIndex < searchResults.length) {
-                  handleSearchSelect(searchResults[searchCursorIndex].id);
+                if (searchCursorIndex >= 0 && searchCursorIndex < searchPagedResults.length) {
+                  handleSearchSelect(searchPagedResults[searchCursorIndex].id);
                   setSearchCursorIndex(-1);
                 }
               }
@@ -1884,21 +1894,37 @@ export default function RealDataSankeyPage() {
         </div>
         {/* Dropdown */}
         {showSearchResults && searchResults.length > 0 && (
-          <div ref={searchDropdownRef} style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 280, overflowY: 'auto', zIndex: 20 }}>
-            {searchResults.map((node, i) => (
-              <button
-                key={node.id}
-                type="button"
-                onClick={() => { handleSearchSelect(node.id); setSearchCursorIndex(-1); }}
-                style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', background: i === searchCursorIndex ? '#e8f0fe' : 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left' }}
-                onMouseEnter={e => { if (i !== searchCursorIndex) e.currentTarget.style.background = '#f5f5f5'; }}
-                onMouseLeave={e => { e.currentTarget.style.background = i === searchCursorIndex ? '#e8f0fe' : 'transparent'; }}
-              >
-                <span style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: getNodeColor(node) }} />
-                <span title={node.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{node.name}</span>
-                <span style={{ fontSize: 11, color: '#999', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(node.value)}</span>
-              </button>
-            ))}
+          <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', zIndex: 20 }}>
+            {/* Count header */}
+            <div style={{ padding: '5px 10px', fontSize: 11, color: '#999', borderBottom: '1px solid #f0f0f0' }}>
+              {searchResults.length}件{searchTotalPages > 1 ? `（${searchPage + 1} / ${searchTotalPages} ページ）` : ''}
+            </div>
+            {/* Scrollable list */}
+            <div ref={searchDropdownRef} style={{ maxHeight: 280, overflowY: 'auto' }}>
+              {searchPagedResults.map((node, i) => (
+                <button
+                  key={node.id}
+                  type="button"
+                  onClick={() => { handleSearchSelect(node.id); setSearchCursorIndex(-1); }}
+                  style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', background: i === searchCursorIndex ? '#e8f0fe' : 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                  onMouseEnter={e => { if (i !== searchCursorIndex) e.currentTarget.style.background = '#f5f5f5'; }}
+                  onMouseLeave={e => { e.currentTarget.style.background = i === searchCursorIndex ? '#e8f0fe' : 'transparent'; }}
+                >
+                  <span style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: getNodeColor(node) }} />
+                  <span title={node.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{node.name}</span>
+                  <span style={{ fontSize: 11, color: '#999', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(node.value)}</span>
+                </button>
+              ))}
+            </div>
+            {/* Pagination footer */}
+            {searchTotalPages > 1 && (
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '5px 8px', borderTop: '1px solid #f0f0f0' }}>
+                <button type="button" onClick={() => { setSearchPage(p => Math.max(p - 1, 0)); setSearchCursorIndex(-1); }} disabled={searchPage === 0}
+                  style={{ fontSize: 11, padding: '2px 8px', border: '1px solid #e0e0e0', borderRadius: 4, background: 'transparent', cursor: searchPage === 0 ? 'default' : 'pointer', color: searchPage === 0 ? '#ccc' : '#555' }}>‹ 前へ</button>
+                <button type="button" onClick={() => { setSearchPage(p => Math.min(p + 1, searchTotalPages - 1)); setSearchCursorIndex(-1); }} disabled={searchPage === searchTotalPages - 1}
+                  style={{ fontSize: 11, padding: '2px 8px', border: '1px solid #e0e0e0', borderRadius: 4, background: 'transparent', cursor: searchPage === searchTotalPages - 1 ? 'default' : 'pointer', color: searchPage === searchTotalPages - 1 ? '#ccc' : '#555' }}>次へ ›</button>
+              </div>
+            )}
           </div>
         )}
         {/* No results */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -927,8 +927,10 @@ export default function RealDataSankeyPage() {
 
   useEffect(() => { setSearchPage(0); setSearchCursorIndex(-1); }, [debouncedQuery]);
 
+  const SEARCH_REGEX_MAX_LEN = 100;
   const searchRegexError = useMemo(() => {
     if (!searchUseRegex || debouncedQuery.trim().length < 2) return false;
+    if (debouncedQuery.trim().length > SEARCH_REGEX_MAX_LEN) return true;
     try { new RegExp(debouncedQuery.trim()); return false; } catch { return true; }
   }, [searchUseRegex, debouncedQuery]);
 
@@ -942,10 +944,12 @@ export default function RealDataSankeyPage() {
     if (pidQuery !== null) {
       matcher = () => false;
     } else if (searchUseRegex) {
+      if (q.length > SEARCH_REGEX_MAX_LEN) return [];
       try { const re = new RegExp(q, 'i'); matcher = name => re.test(name); }
       catch { return []; }  // invalid regex → no results
     } else {
-      matcher = name => name.includes(q);
+      const qLower = q.toLocaleLowerCase();
+      matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
     for (const n of graphData.nodes) {
       if (pidQuery !== null) {
@@ -1872,7 +1876,9 @@ export default function RealDataSankeyPage() {
           {/* .* regex toggle */}
           <button
             type="button"
-            title="正規表現で検索"
+            title={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+            aria-label={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+            aria-pressed={searchUseRegex}
             onClick={() => setSearchUseRegex(v => !v)}
             style={{
               position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -127,6 +127,7 @@ export default function RealDataSankeyPage() {
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [showSearchResults, setShowSearchResults] = useState(false);
   const [searchCursorIndex, setSearchCursorIndex] = useState(-1);
+  const [searchUseRegex, setSearchUseRegex] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchDropdownRef = useRef<HTMLDivElement>(null);
   const [zeroSpendingAlert, setZeroSpendingAlert] = useState(false);
@@ -923,21 +924,35 @@ export default function RealDataSankeyPage() {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
+  const searchRegexError = useMemo(() => {
+    if (!searchUseRegex || debouncedQuery.trim().length < 2) return false;
+    try { new RegExp(debouncedQuery.trim()); return false; } catch { return true; }
+  }, [searchUseRegex, debouncedQuery]);
+
   const searchResults = useMemo(() => {
     const q = debouncedQuery.trim();
     if (!graphData || q.length < 2) return [];
     const results: { id: string; name: string; type: string; value: number }[] = [];
     // PID search: pure numeric query matches project-spending nodes by projectId
     const pidQuery = /^\d+$/.test(q) ? Number(q) : null;
+    let matcher: (name: string) => boolean;
+    if (pidQuery !== null) {
+      matcher = () => false;
+    } else if (searchUseRegex) {
+      try { const re = new RegExp(q, 'i'); matcher = name => re.test(name); }
+      catch { return []; }  // invalid regex → no results
+    } else {
+      matcher = name => name.includes(q);
+    }
     for (const n of graphData.nodes) {
       if (pidQuery !== null) {
         if (n.type === 'project-spending' && n.projectId === pidQuery) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
       } else {
-        if (n.name.includes(q)) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
+        if (matcher(n.name)) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
       }
     }
     return results.sort((a, b) => b.value - a.value).slice(0, 20);
-  }, [graphData, debouncedQuery]);
+  }, [graphData, debouncedQuery, searchUseRegex]);
 
   const pendingSearchResetRef = useRef(false);
 
@@ -1837,12 +1852,28 @@ export default function RealDataSankeyPage() {
             placeholder="ノード検索（2文字以上）"
             style={{
               width: '100%', boxSizing: 'border-box',
-              paddingLeft: 30, paddingRight: searchQuery ? 28 : 10, paddingTop: 7, paddingBottom: 7,
-              fontSize: 13, border: '1px solid #e0e0e0', borderRadius: 8,
+              paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
+              fontSize: 13,
+              border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8,
               background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
               outline: 'none', color: '#333',
             }}
           />
+          {/* .* regex toggle */}
+          <button
+            type="button"
+            title="正規表現で検索"
+            onClick={() => setSearchUseRegex(v => !v)}
+            style={{
+              position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',
+              background: searchUseRegex ? '#1a73e8' : 'transparent',
+              border: 'none',
+              borderRadius: 4, cursor: 'pointer',
+              color: searchUseRegex ? '#fff' : '#888',
+              fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold',
+              lineHeight: 1, padding: '2px 4px',
+            }}
+          >.*</button>
           {searchQuery && (
             <button
               type="button"


### PR DESCRIPTION
## 目的

支出先オフセットを増やして事業の全支出先がウィンドウ外になったとき、事業ノードが 0 円で表示され続けるバグを解消するため。

## 再現手順

1. `/sankey-svg` を開く
2. オフセット対象を「支出先」に切り替える
3. 支出先オフセットを増やし、特定事業の唯一の支出先がウィンドウ外になる

**Before**: 事業ノード（例: `基礎年金給付に必要な経費`）が 0 円で残り続ける  
**After**: 事業ノードが非表示になる

## 変更内容

**`app/lib/sankey-svg-filter.ts`** の 2 箇所を修正:

### 1. `effectivelyHiddenIds` の判定条件
- **Before**: `!topProjectIds.has(n.id)` — TopN 事業全体を hidden 対象から除外
- **After**: `n.id !== pinnedProjectId` — ピン留め事業のみ除外

予算額 TopN にランクされていても、全支出先がウィンドウ外なら hidden になるべき。

### 2. `topProjectNodes` のノード/エッジ追加ループ
- ノード追加ループ、府省庁→予算エッジ、予算→支出エッジに `effectivelyHiddenIds` チェック（`continue`）を追加
- `topProjectSpendingIds` の構築にも hidden フィルターを追加

これにより `effectivelyHiddenIds` が正しく計算されていても、ループ内でノードが追加されてしまっていた問題を解消。

## テスト方法

```bash
npm run dev  # localhost:3002/sankey-svg
```

1. オフセット対象を「支出先」に設定
2. 支出先オフセットをスライドして特定事業の支出先をウィンドウ外に移動
3. その事業ノードが消えることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden projects and their recipient links are now consistently excluded from the diagram; pinned projects remain visible.
  * Project ordering/tie handling made more deterministic when window spending is zero and hidden nodes are skipped.

* **New Features**
  * Top project ranking now uses visible contribution (with budget-adjusted fallback where applicable) and includes tail-only contributors when aggregated recipients are shown.
  * Search gains a regex toggle with validation, plus PID-exact and case-insensitive matching modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->