### PR TITLE
feat: /sankey-svg 検索・サイドパネルにPID表示・数値1文字検索対応

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -936,10 +936,9 @@ export default function RealDataSankeyPage() {
 
   const searchResults = useMemo(() => {
     const q = debouncedQuery.trim();
-    if (!graphData || q.length < 2) return [];
-    const results: { id: string; name: string; type: string; value: number }[] = [];
-    // PID search: pure numeric query matches project-spending nodes by projectId
     const pidQuery = /^\d+$/.test(q) ? Number(q) : null;
+    if (!graphData || (pidQuery !== null ? q.length < 1 : q.length < 2)) return [];
+    const results: { id: string; name: string; type: string; value: number; projectId?: number }[] = [];
     let matcher: (name: string) => boolean;
     if (pidQuery !== null) {
       matcher = () => false;
@@ -953,9 +952,9 @@ export default function RealDataSankeyPage() {
     }
     for (const n of graphData.nodes) {
       if (pidQuery !== null) {
-        if (n.type === 'project-spending' && n.projectId === pidQuery) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
+        if (n.type === 'project-spending' && n.projectId === pidQuery) results.push({ id: n.id, name: n.name, type: n.type, value: n.value, projectId: n.projectId });
       } else {
-        if (matcher(n.name)) results.push({ id: n.id, name: n.name, type: n.type, value: n.value });
+        if (matcher(n.name)) results.push({ id: n.id, name: n.name, type: n.type, value: n.value, projectId: n.projectId });
       }
     }
     return results.sort((a, b) => b.value - a.value);
@@ -1647,6 +1646,9 @@ export default function RealDataSankeyPage() {
                   {selectedNode.aggregated && (
                     <span style={{ background: '#999', color: '#fff', padding: '2px 7px', borderRadius: 10, fontSize: 11, fontWeight: 500 }}>集約</span>
                   )}
+                  {selectedNode.projectId != null && (
+                    <span style={{ fontSize: 11, color: '#aaa' }}>PID:{selectedNode.projectId}</span>
+                  )}
                   {selectedNode.ministry && selectedNode.type !== 'ministry' && (
                     <span style={{ fontSize: 11, color: '#666' }}>{selectedNode.ministry}</span>
                   )}
@@ -1837,7 +1839,7 @@ export default function RealDataSankeyPage() {
             type="text"
             value={searchQuery}
             onChange={e => { setSearchQuery(e.target.value); setShowSearchResults(true); setSearchCursorIndex(-1); }}
-            onFocus={() => { if (debouncedQuery.trim().length >= 2) setShowSearchResults(true); }}
+            onFocus={() => { const q = debouncedQuery.trim(); if (/^\d+$/.test(q) ? q.length >= 1 : q.length >= 2) setShowSearchResults(true); }}
             onKeyDown={e => {
               if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
               if (!showSearchResults || searchPagedResults.length === 0) return;
@@ -1918,6 +1920,7 @@ export default function RealDataSankeyPage() {
                 >
                   <span style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: getNodeColor(node) }} />
                   <span title={node.name} style={{ flex: 1, fontSize: 12, color: '#333', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{node.name}</span>
+                  {node.projectId != null && <span style={{ fontSize: 10, color: '#bbb', whiteSpace: 'nowrap', flexShrink: 0 }}>PID:{node.projectId}</span>}
                   <span style={{ fontSize: 11, color: '#999', whiteSpace: 'nowrap', flexShrink: 0 }}>{formatYen(node.value)}</span>
                 </button>
               ))}
@@ -1934,7 +1937,7 @@ export default function RealDataSankeyPage() {
           </div>
         )}
         {/* No results */}
-        {showSearchResults && debouncedQuery.trim().length >= 2 && searchResults.length === 0 && (
+        {showSearchResults && (() => { const q = debouncedQuery.trim(); return /^\d+$/.test(q) ? q.length >= 1 : q.length >= 2; })() && searchResults.length === 0 && (
           <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', padding: '10px 12px', fontSize: 12, color: '#999', zIndex: 20 }}>
             該当なし
           </div>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -129,6 +129,8 @@ export default function RealDataSankeyPage() {
   const [searchCursorIndex, setSearchCursorIndex] = useState(-1);
   const [searchUseRegex, setSearchUseRegex] = useState(false);
   const [searchPage, setSearchPage] = useState(0);
+  const isPidQuery = (q: string) => /^\d+$/.test(q);
+  const meetsSearchMinLength = (q: string) => isPidQuery(q) ? q.length >= 1 : q.length >= 2;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchDropdownRef = useRef<HTMLDivElement>(null);
   const [zeroSpendingAlert, setZeroSpendingAlert] = useState(false);
@@ -936,8 +938,8 @@ export default function RealDataSankeyPage() {
 
   const searchResults = useMemo(() => {
     const q = debouncedQuery.trim();
-    const pidQuery = /^\d+$/.test(q) ? Number(q) : null;
-    if (!graphData || (pidQuery !== null ? q.length < 1 : q.length < 2)) return [];
+    const pidQuery = isPidQuery(q) ? Number(q) : null;
+    if (!graphData || !meetsSearchMinLength(q)) return [];
     const results: { id: string; name: string; type: string; value: number; projectId?: number }[] = [];
     let matcher: (name: string) => boolean;
     if (pidQuery !== null) {
@@ -1839,7 +1841,7 @@ export default function RealDataSankeyPage() {
             type="text"
             value={searchQuery}
             onChange={e => { setSearchQuery(e.target.value); setShowSearchResults(true); setSearchCursorIndex(-1); }}
-            onFocus={() => { const q = debouncedQuery.trim(); if (/^\d+$/.test(q) ? q.length >= 1 : q.length >= 2) setShowSearchResults(true); }}
+            onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
             onKeyDown={e => {
               if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
               if (!showSearchResults || searchPagedResults.length === 0) return;
@@ -1865,7 +1867,7 @@ export default function RealDataSankeyPage() {
                 }
               }
             }}
-            placeholder="ノード検索（2文字以上）"
+            placeholder="ノード検索（2文字以上／PIDは1文字〜）"
             style={{
               width: '100%', boxSizing: 'border-box',
               paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
@@ -1937,7 +1939,7 @@ export default function RealDataSankeyPage() {
           </div>
         )}
         {/* No results */}
-        {showSearchResults && (() => { const q = debouncedQuery.trim(); return /^\d+$/.test(q) ? q.length >= 1 : q.length >= 2; })() && searchResults.length === 0 && (
+        {showSearchResults && meetsSearchMinLength(debouncedQuery.trim()) && searchResults.length === 0 && (
           <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', padding: '10px 12px', fontSize: 12, color: '#999', zIndex: 20 }}>
             該当なし
           </div>


### PR DESCRIPTION
## 目的

サンキー図の探索者が事業ID（PID）で素早く特定の事業を見つけられるようにするため。

## 変更内容

- **検索結果にPID表示**: `project-spending` ノードの検索結果にPID（事業ID）をグレーで表示
- **サイドパネルにPID表示**: 事業ノード選択時のサイドパネルサブ情報にPIDを表示
- **数値1文字検索対応**: 数値のみのクエリ（PID検索）は1文字から検索を開始（通常は2文字以上）

## テスト方法

1. `npm run dev` で起動し `localhost:3002/sankey-svg` を開く
2. 検索ボックスに数値（例: `1`）を1文字入力 → 検索結果が表示されることを確認
3. 検索結果の事業ノードにPID番号が表示されることを確認
4. 事業ノードをクリック → サイドパネルにPIDが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project IDs now display in search results, search dropdown items, and the selected node details panel.
  * Optimized search responsiveness for numeric Project ID queries, enabling results with a single character instead of requiring two.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->