### PR TITLE
feat: sankey-svg 選択時自動フォーカス・projectOffset修正

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -999,8 +999,14 @@ export default function RealDataSankeyPage() {
       }
     } else if (projectOffsetModeActive && nodeId.startsWith('r-') && graphData) {
       // Recipient in project offset mode: resolve parent project and jump offset to it.
-      // Prefer pinnedContextProjectId (the project the user was exploring) over max-flow fallback.
-      let parentSpendingId: string | null = pinnedContextProjectId.current;
+      // Prefer pinnedContextProjectId (the project the user was exploring), but only if it
+      // actually parents this recipient (guards against stale ref from a different flow).
+      let parentSpendingId: string | null = null;
+      const ctxId = pinnedContextProjectId.current;
+      pinnedContextProjectId.current = null;
+      if (ctxId && graphData.edges.some(e => e.target === nodeId && e.source === ctxId)) {
+        parentSpendingId = ctxId;
+      }
       if (!parentSpendingId) {
         let bestEdgeValue = -1;
         for (const e of graphData.edges) {
@@ -1010,7 +1016,6 @@ export default function RealDataSankeyPage() {
           }
         }
       }
-      pinnedContextProjectId.current = null;
       if (parentSpendingId !== null) {
         const rank = allProjectRanks.get(parentSpendingId);
         if (rank !== undefined) jumpToProjectRank(rank);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -30,6 +30,7 @@ interface SankeyUrlState {
   projectSortBy: 'budget' | 'spending';
   scaleBudgetToVisible: boolean;
   focusRelated: boolean;
+  autoFocusRelated: boolean;
   year: '2024' | '2025';
   zoom?: number;
 }
@@ -54,6 +55,7 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const ps = p.get('ps'); if (ps === 's') result.projectSortBy = 'spending';
   const sb = p.get('sb'); if (sb !== null) result.scaleBudgetToVisible = sb !== '0';
   const fr = p.get('fr'); if (fr !== null) result.focusRelated = fr === '1';
+  const afr = p.get('afr'); if (afr !== null) result.autoFocusRelated = afr === '1';
   const yr = p.get('yr'); if (yr === '2024' || yr === '2025') result.year = yr;
   const z = p.get('z'); if (z !== null) { const n = parseFloat(z); if (!isNaN(n) && n >= 0.1 && n <= 10) result.zoom = n; }
   return result;
@@ -115,6 +117,7 @@ export default function RealDataSankeyPage() {
   const [projectSortBy, setProjectSortBy] = useState<'budget' | 'spending'>('budget');
   const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
   const [focusRelated, setFocusRelated] = useState(false);
+  const [autoFocusRelated, setAutoFocusRelated] = useState(true);
   const [year, setYear] = useState<'2024' | '2025'>('2025');
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
@@ -147,6 +150,7 @@ export default function RealDataSankeyPage() {
   const pendingHistoryAction = useRef<'push' | 'replace' | null>(null);
   const pendingFocusId = useRef<string | null>(null);
   const pendingResetViewport = useRef<boolean>(false);
+  const pendingConnectionNodeId = useRef<string | null>(null);
   // Zoom URL state
   const urlRestoredZoomRef = useRef<number | null>(null); // zoom to restore on first layout (no sel= case)
   const zoomRef = useRef(1);                              // always-current zoom for debounce callbacks
@@ -229,6 +233,7 @@ export default function RealDataSankeyPage() {
       setProjectSortBy(parsed.projectSortBy ?? 'budget');
       setScaleBudgetToVisible(parsed.scaleBudgetToVisible ?? true);
       setFocusRelated(parsed.focusRelated ?? false);
+      setAutoFocusRelated(parsed.autoFocusRelated ?? false);
       if (parsed.year !== undefined) setYear(parsed.year);
       if (parsed.selectedNodeId) pendingResetViewport.current = true;
     };
@@ -259,6 +264,7 @@ export default function RealDataSankeyPage() {
     if (projectSortBy === 'spending') p.set('ps', 's');
     if (!scaleBudgetToVisible) p.set('sb', '0');
     if (focusRelated) p.set('fr', '1');
+    if (autoFocusRelated) p.set('afr', '1');
     if (year !== '2025') p.set('yr', year);
     const qs = p.toString();
     const url = qs ? `?${qs}` : window.location.pathname;
@@ -267,7 +273,7 @@ export default function RealDataSankeyPage() {
     } else {
       window.history.replaceState(null, '', url);
     }
-  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, year]);
+  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -621,6 +627,25 @@ export default function RealDataSankeyPage() {
     return new Map(sorted.map(([id], i) => [id, i]));
   }, [graphData]);
 
+  // Global project rank (0-indexed) — for projectOffset jump
+  const allProjectRanks = useMemo(() => {
+    if (!graphData) return new Map<string, number>();
+    const budgetValues = new Map<string | undefined, number>(
+      graphData.nodes.filter(n => n.type === 'project-budget').map(n => [`project-spending-${n.projectId}`, n.value] as const)
+    );
+    const ranked = graphData.nodes
+      .filter(n => n.type === 'project-spending' && n.value > 0)
+      .sort((a, b) => {
+        if (projectSortBy === 'budget') {
+          const ba = budgetValues.get(a.id) ?? 0;
+          const bb = budgetValues.get(b.id) ?? 0;
+          if (bb !== ba) return bb - ba;
+        }
+        return b.value - a.value;
+      });
+    return new Map(ranked.map((n, i) => [n.id, i]));
+  }, [graphData, projectSortBy]);
+
   // Recipient count per project-spending node (from raw graphData)
   const projectRecipientCount = useMemo(() => {
     if (!graphData) return new Map<string, number>();
@@ -932,6 +957,11 @@ export default function RealDataSankeyPage() {
     };
 
     const projectOffsetModeActive = offsetTarget === 'project';
+    const jumpToProjectRank = (rank: number) => {
+      const maxOffset = Math.max(0, allProjectRanks.size - topProject);
+      const newOffset = Math.max(0, Math.min(rank - Math.floor(topProject / 2), maxOffset));
+      setProjectOffset(newOffset);
+    };
     if (focusRelated) {
       // focusRelated ON: 現在のフォーカスコンテキストをクリアして新しいノードに切り替える
       const pins = computeFocusPins(nodeId, graphData?.nodes);
@@ -959,22 +989,31 @@ export default function RealDataSankeyPage() {
         const rank = allRecipientRanks.get(bestRecipientId);
         if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);
       }
+    } else if (projectOffsetModeActive && (nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-'))) {
+      // Project offset mode: jump projectOffset window so the target project is visible
+      const spendingId = nodeId.startsWith('project-budget-')
+        ? nodeId.replace('project-budget-', 'project-spending-')
+        : nodeId;
+      const rank = allProjectRanks.get(spendingId);
+      if (rank !== undefined) jumpToProjectRank(rank);
+      setPinnedProjectId(null);
     } else {
       setPinnedProjectId(null);
     }
     // Out-of-layout node: focus via effect once it appears in layout after pin/offset jump
     pendingFocusId.current = nodeId;
     selectNode(nodeId);
-  }, [layout, filtered, allRecipientRanks, topRecipient, selectNode, graphData, focusOnNeighborhood, pinnedProjectId, isPanelCollapsed, focusRelated, setPinnedRecipientId, setPinnedMinistryName, includeZeroSpending, offsetTarget]);
+  }, [layout, filtered, allRecipientRanks, allProjectRanks, topRecipient, topProject, selectNode, graphData, focusOnNeighborhood, pinnedProjectId, isPanelCollapsed, focusRelated, setPinnedRecipientId, setPinnedMinistryName, includeZeroSpending, offsetTarget, setProjectOffset]);
 
   // Step2 → Step1 遷移: 選択ノード (selectedNodeId) は維持し、
   // focusRelated と pinnedProject/Recipient/Ministry (Step2 用のフォーカスピン) のみ解除
-  const exitFocusRelated = useCallback(() => {
+  const exitFocusRelated = useCallback((nodeId?: string) => {
     pendingHistoryAction.current = 'push';
     setPinnedProjectId(null);
     setPinnedRecipientId(null);
     setPinnedMinistryName(null);
     setFocusRelated(false);
+    if (nodeId) pendingConnectionNodeId.current = nodeId;
   }, [setPinnedRecipientId, setPinnedMinistryName]);
 
   const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
@@ -983,18 +1022,45 @@ export default function RealDataSankeyPage() {
     const newId = selectedNodeId === node.id ? null : node.id;
     if (newId === null && focusRelated) {
       // Pin中ノードを再クリック → フィルターのみOFF（Pin解除しない）
-      exitFocusRelated();
+      exitFocusRelated(selectedNodeId ?? undefined);
       return;
     }
     if (newId !== null) {
-      // 新規選択は常に Step1（Pin状態のみ）: フィルター・ピンをリセット
-      if (focusRelated) setFocusRelated(false);
+      if (autoFocusRelated) {
+        // 自動focusRelated: ピンを新ノードに切り替えてStep2へ直行
+        const pins = computeFocusPins(newId, graphData?.nodes);
+        setPinnedProjectId(pins.pinnedProjectId);
+        setPinnedRecipientId(pins.pinnedRecipientId);
+        setPinnedMinistryName(pins.pinnedMinistryName);
+        setFocusRelated(true);
+        pendingResetViewport.current = true;
+        selectNode(newId);
+        return;
+      }
+      if (focusRelated) {
+        // focusRelated=ON 中の新規選択: ピン・フィルターをリセットし、
+        // レイアウト更新後に handleConnectionClick でオフセット調整
+        setFocusRelated(false);
+        setPinnedProjectId(null);
+        setPinnedRecipientId(null);
+        setPinnedMinistryName(null);
+        pendingConnectionNodeId.current = newId;
+        return;
+      }
       setPinnedProjectId(null);
       setPinnedRecipientId(null);
       setPinnedMinistryName(null);
     }
     selectNode(newId);
-  }, [selectedNodeId, selectNode, focusRelated, exitFocusRelated]);
+  }, [selectedNodeId, selectNode, focusRelated, autoFocusRelated, exitFocusRelated, graphData]);
+
+  // focusRelated=ON 中に別ノードをクリックした後、フルレイアウト更新後にオフセット調整
+  useEffect(() => {
+    if (!pendingConnectionNodeId.current || !layout) return;
+    const id = pendingConnectionNodeId.current;
+    pendingConnectionNodeId.current = null;
+    handleConnectionClick(id);
+  }, [layout, handleConnectionClick]);
 
   // ── Search ──
 
@@ -1196,7 +1262,7 @@ export default function RealDataSankeyPage() {
   // Escape key: focusRelated ON → フィルターのみOFF、OFF → 選択解除
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { if (focusRelated) exitFocusRelated(); else selectNode(null); }
+      if (e.key === 'Escape') { if (focusRelated) exitFocusRelated(selectedNodeId ?? undefined); else selectNode(null); }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
@@ -1277,7 +1343,7 @@ export default function RealDataSankeyPage() {
               <rect
                 x={0} y={0} width={svgWidth} height={svgHeight}
                 fill="transparent"
-                onClick={() => { if (!didPanRef.current) { if (focusRelated) exitFocusRelated(); else selectNode(null); } }}
+                onClick={() => { if (!didPanRef.current) { if (focusRelated) exitFocusRelated(selectedNodeId ?? undefined); else selectNode(null); } }}
               />
               <g transform={`translate(${pan.x},${pan.y}) scale(${zoom})`}>
               <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
@@ -2417,6 +2483,10 @@ export default function RealDataSankeyPage() {
                 <input type="checkbox" checked={scaleBudgetToVisible} onChange={e => { pendingHistoryAction.current = 'replace'; setScaleBudgetToVisible(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>事業の予算額を支出額に合わせて調整</span>
               </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={autoFocusRelated} onChange={e => { pendingHistoryAction.current = 'replace'; setAutoFocusRelated(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>選択時に関連ノードのみ表示</span>
+              </label>
             </div>
           </>
         )}
@@ -2507,6 +2577,8 @@ export default function RealDataSankeyPage() {
                   setPinnedProjectId(null);
                   setPinnedRecipientId(null);
                   setPinnedMinistryName(null);
+                  // 選択ノードがある場合はレイアウト更新後にオフセット調整
+                  if (selectedNode) pendingConnectionNodeId.current = selectedNode.id;
                 }
                 setFocusRelated(next);
               }}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -989,6 +989,21 @@ export default function RealDataSankeyPage() {
         const rank = allRecipientRanks.get(bestRecipientId);
         if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);
       }
+    } else if (projectOffsetModeActive && nodeId.startsWith('r-') && graphData) {
+      // Recipient in project offset mode: find parent project and jump offset so the project (and recipient) become visible
+      let parentSpendingId: string | null = null;
+      let bestEdgeValue = -1;
+      for (const e of graphData.edges) {
+        if (e.target === nodeId && e.source.startsWith('project-spending-') && e.value > bestEdgeValue) {
+          bestEdgeValue = e.value;
+          parentSpendingId = e.source;
+        }
+      }
+      if (parentSpendingId !== null) {
+        const rank = allProjectRanks.get(parentSpendingId);
+        if (rank !== undefined) jumpToProjectRank(rank);
+      }
+      setPinnedProjectId(null);
     } else if (projectOffsetModeActive && (nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-'))) {
       // Project offset mode: jump projectOffset window so the target project is visible
       const spendingId = nodeId.startsWith('project-budget-')

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -151,6 +151,9 @@ export default function RealDataSankeyPage() {
   const pendingFocusId = useRef<string | null>(null);
   const pendingResetViewport = useRef<boolean>(false);
   const pendingConnectionNodeId = useRef<string | null>(null);
+  // focusRelated ON中に事業をピンしたときのコンテキスト事業ID
+  // projectOffsetMode + r-* 選択後にfocusRelated=OFFしたとき、親事業の特定に使う
+  const pinnedContextProjectId = useRef<string | null>(null);
   // Zoom URL state
   const urlRestoredZoomRef = useRef<number | null>(null); // zoom to restore on first layout (no sel= case)
   const zoomRef = useRef(1);                              // always-current zoom for debounce callbacks
@@ -942,6 +945,7 @@ export default function RealDataSankeyPage() {
             ? pinnedProjectId
             : null;
       if (focusRelated && derivedPinnedId !== null) { setPinnedRecipientId(null); setPinnedMinistryName(null); }
+      if (focusRelated && nextPinnedProjectId) pinnedContextProjectId.current = nextPinnedProjectId;
       const needsDeferredFocus = nextPinnedProjectId !== pinnedProjectId || isPanelCollapsed;
       setPinnedProjectId(nextPinnedProjectId);
       if (needsDeferredFocus) pendingFocusId.current = nodeId;
@@ -966,6 +970,7 @@ export default function RealDataSankeyPage() {
       // focusRelated ON: 現在のフォーカスコンテキストをクリアして新しいノードに切り替える
       const pins = computeFocusPins(nodeId, graphData?.nodes);
       setPinnedProjectId(pins.pinnedProjectId); setPinnedRecipientId(pins.pinnedRecipientId); setPinnedMinistryName(pins.pinnedMinistryName);
+      if (pins.pinnedProjectId) pinnedContextProjectId.current = pins.pinnedProjectId;
     } else if (!projectOffsetModeActive && nodeId.startsWith('r-') && filtered) {
       // Recipient outside window: jump offset so it's visible (disabled in project offset mode)
       const rank = allRecipientRanks.get(nodeId);
@@ -990,18 +995,26 @@ export default function RealDataSankeyPage() {
         if (rank !== undefined) jumpToRecipientRank(rank, filtered.totalRecipientCount);
       }
     } else if (projectOffsetModeActive && nodeId.startsWith('r-') && graphData) {
-      // Recipient in project offset mode: find parent project and jump offset so the project (and recipient) become visible
-      let parentSpendingId: string | null = null;
-      let bestEdgeValue = -1;
-      for (const e of graphData.edges) {
-        if (e.target === nodeId && e.source.startsWith('project-spending-') && e.value > bestEdgeValue) {
-          bestEdgeValue = e.value;
-          parentSpendingId = e.source;
+      // Recipient in project offset mode: resolve parent project and jump offset to it.
+      // Prefer pinnedContextProjectId (the project the user was exploring) over max-flow fallback.
+      let parentSpendingId: string | null = pinnedContextProjectId.current;
+      if (!parentSpendingId) {
+        let bestEdgeValue = -1;
+        for (const e of graphData.edges) {
+          if (e.target === nodeId && e.source.startsWith('project-spending-') && e.value > bestEdgeValue) {
+            bestEdgeValue = e.value;
+            parentSpendingId = e.source;
+          }
         }
       }
+      pinnedContextProjectId.current = null;
       if (parentSpendingId !== null) {
         const rank = allProjectRanks.get(parentSpendingId);
         if (rank !== undefined) jumpToProjectRank(rank);
+        setPinnedProjectId(null);
+        pendingFocusId.current = parentSpendingId;
+        selectNode(parentSpendingId);
+        return;
       }
       setPinnedProjectId(null);
     } else if (projectOffsetModeActive && (nodeId.startsWith('project-spending-') || nodeId.startsWith('project-budget-'))) {
@@ -1047,6 +1060,7 @@ export default function RealDataSankeyPage() {
         setPinnedProjectId(pins.pinnedProjectId);
         setPinnedRecipientId(pins.pinnedRecipientId);
         setPinnedMinistryName(pins.pinnedMinistryName);
+        if (pins.pinnedProjectId) pinnedContextProjectId.current = pins.pinnedProjectId;
         setFocusRelated(true);
         pendingResetViewport.current = true;
         selectNode(newId);
@@ -2587,6 +2601,7 @@ export default function RealDataSankeyPage() {
                   setPinnedProjectId(pins.pinnedProjectId);
                   setPinnedRecipientId(pins.pinnedRecipientId);
                   setPinnedMinistryName(pins.pinnedMinistryName);
+                  if (pins.pinnedProjectId) pinnedContextProjectId.current = pins.pinnedProjectId;
                   pendingResetViewport.current = true;
                 } else if (!next) {
                   setPinnedProjectId(null);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -203,6 +203,7 @@ export default function RealDataSankeyPage() {
     if (parsed.projectSortBy !== undefined) setProjectSortBy(parsed.projectSortBy);
     if (parsed.scaleBudgetToVisible !== undefined) setScaleBudgetToVisible(parsed.scaleBudgetToVisible);
     if (parsed.focusRelated !== undefined) setFocusRelated(parsed.focusRelated);
+    if (parsed.autoFocusRelated !== undefined) setAutoFocusRelated(parsed.autoFocusRelated);
     if (parsed.year !== undefined) setYear(parsed.year);
     // Restore zoom only when no sel= (focusOnNeighborhood will handle zoom for sel= case)
     if (parsed.zoom !== undefined && parsed.selectedNodeId === undefined) {
@@ -236,7 +237,7 @@ export default function RealDataSankeyPage() {
       setProjectSortBy(parsed.projectSortBy ?? 'budget');
       setScaleBudgetToVisible(parsed.scaleBudgetToVisible ?? true);
       setFocusRelated(parsed.focusRelated ?? false);
-      setAutoFocusRelated(parsed.autoFocusRelated ?? false);
+      setAutoFocusRelated(parsed.autoFocusRelated ?? true);
       if (parsed.year !== undefined) setYear(parsed.year);
       if (parsed.selectedNodeId) pendingResetViewport.current = true;
     };
@@ -267,7 +268,7 @@ export default function RealDataSankeyPage() {
     if (projectSortBy === 'spending') p.set('ps', 's');
     if (!scaleBudgetToVisible) p.set('sb', '0');
     if (focusRelated) p.set('fr', '1');
-    if (autoFocusRelated) p.set('afr', '1');
+    if (!autoFocusRelated) p.set('afr', '0');
     if (year !== '2025') p.set('yr', year);
     const qs = p.toString();
     const url = qs ? `?${qs}` : window.location.pathname;
@@ -633,11 +634,13 @@ export default function RealDataSankeyPage() {
   // Global project rank (0-indexed) — for projectOffset jump
   const allProjectRanks = useMemo(() => {
     if (!graphData) return new Map<string, number>();
-    const budgetValues = new Map<string | undefined, number>(
-      graphData.nodes.filter(n => n.type === 'project-budget').map(n => [`project-spending-${n.projectId}`, n.value] as const)
+    const budgetValues = new Map<string, number>(
+      graphData.nodes
+        .filter(n => n.type === 'project-budget' && n.projectId != null)
+        .map(n => [`project-spending-${n.projectId}`, n.value] as const)
     );
     const ranked = graphData.nodes
-      .filter(n => n.type === 'project-spending' && n.value > 0)
+      .filter(n => n.type === 'project-spending' && (includeZeroSpending || n.value > 0))
       .sort((a, b) => {
         if (projectSortBy === 'budget') {
           const ba = budgetValues.get(a.id) ?? 0;
@@ -647,7 +650,7 @@ export default function RealDataSankeyPage() {
         return b.value - a.value;
       });
     return new Map(ranked.map((n, i) => [n.id, i]));
-  }, [graphData, projectSortBy]);
+  }, [graphData, projectSortBy, includeZeroSpending]);
 
   // Recipient count per project-spending node (from raw graphData)
   const projectRecipientCount = useMemo(() => {

--- a/docs/tasks/20260425_1045_事業オフセットモードfocusRelated解除時の支出先消失問題.md
+++ b/docs/tasks/20260425_1045_事業オフセットモードfocusRelated解除時の支出先消失問題.md
@@ -1,0 +1,77 @@
+# 事業オフセットモード + focusRelated 解除時の支出先消失問題
+
+## 問題の概要
+
+`offsetTarget='project'`（事業オフセットモード）で `focusRelated`（関連ノードのみ表示）をOFFにしたとき、直前に選択していた支出先ノードが画面に表示されない。
+
+## 再現手順
+
+1. オフセット対象を「事業」に設定
+2. 事業ノード（例: 電気・ガス価格激変緩和対策等事業）をクリック → autoFocusRelated により `focusRelated=ON`
+3. 関連ノードのみ表示の状態で支出先ノード（例: 北海道電力株式会社）をクリック
+4. 「関連ノードのみ表示」をOFF → 北海道電力株式会社が表示されない
+
+## 根本原因
+
+### 1. `projectOffsetMode` での支出先フィルタリング
+
+`sankey-svg-filter.ts` L132–144:
+
+```
+windowRecipients = 現在の事業ウィンドウ内の事業への流出だけで再ランキング → Top N
+```
+
+事業オフセットモードでは「現在の事業ウィンドウ内の事業への支出合計」で支出先を再ランキングするため、ウィンドウ外の事業からの支出は無視される。`topRecipient=3`（デフォルト）のような小さい値では、大規模事業の支出先のほとんどが上位N位に入らず非表示になる。
+
+### 2. focusRelated ON→OFF 遷移時のコンテキスト喪失
+
+`focusRelated=ON` で支出先をクリックすると `handleConnectionClick` が `computeFocusPins('r-...')` を呼び出し、`pinnedProjectId=null` / `pinnedRecipientId='r-...'` にリセットされる。このとき「どの事業から辿ってきたか」という情報が失われる。
+
+その後 `focusRelated=OFF` 時には `pinnedProjectId` がすでに null であり、`pendingConnectionNodeId='r-...'` だけが残る。`handleConnectionClick` は親事業を辿ろうとするが、「最大フロー親事業」が必ずしもユーザーが意図した事業とは限らない。
+
+### 3. 親事業が複数存在する場合の曖昧性
+
+支出先ノードは複数の事業から支出を受けている場合がある。現在の実装では `graphData.edges` を逆引きして `e.value` が最大の親事業を選ぶが、ユーザーが辿ってきた事業（クリック元）と異なる可能性がある。
+
+## 解決策
+
+### `pinnedContextProjectId` ref の導入
+
+`focusRelated=ON` で事業を Pin した瞬間に「コンテキスト事業ID」を別 ref に保存しておく。
+
+```tsx
+const pinnedContextProjectId = useRef<string | null>(null);
+```
+
+**保存タイミング**: `setFocusRelated(true)` と同時に `pinnedProjectId` が設定されるとき（autoFocusRelated による自動起動 + 手動のフィルターボタンON）
+
+**参照タイミング**: `focusRelated=OFF` 遷移時に `pendingConnectionNodeId` の代わりに `pinnedContextProjectId.current` を使用
+
+### handleConnectionClick の修正
+
+`projectOffsetModeActive=true && r-*` ブランチ:
+
+```
+1. pinnedContextProjectId.current が存在する → そのIDを使ってプロジェクトオフセットジャンプ + 選択
+2. 存在しない（fallback）→ 最大フロー親事業でジャンプ + 選択
+3. どちらでもジャンプ後 selectNode(parentSpendingId) で事業ノードを選択
+```
+
+選択を **支出先 → 親事業** に切り替えることで、「事業オフセットモード = 事業を閲覧するモード」という一貫したUXを維持する。
+
+### 保存・クリアのライフサイクル
+
+| タイミング | 操作 |
+|-----------|------|
+| `setFocusRelated(true)` 時 | `pinnedContextProjectId.current = pinnedProjectId` |
+| `exitFocusRelated()` 後 | 参照後にクリア |
+| `setFocusRelated(false)` でフィルターボタンOFF | 参照後にクリア |
+| 別ノードをクリックして `focusRelated` が再起動 | 新しい `pinnedProjectId` で上書き |
+
+## 影響範囲
+
+- `app/sankey-svg/page.tsx` のみ
+- `handleNodeClick`（autoFocusRelated 起動時に保存）
+- フィルターボタン onClick（手動ON時に保存）
+- `handleConnectionClick`（参照・クリア）
+- `exitFocusRelated`（参照・クリア）


### PR DESCRIPTION
## 目的

ユーザーがノードをPin状態にしたとき、手動で「関連ノードのみ表示」ボタンを押す手間を省き、自動的に関連ノードのみ表示へ遷移できるようにする。また、事業オフセットモードで「関連ノードのみ表示」をOFFにしたとき選択ノードが画面外になってしまうバグを修正する。

## 変更内容

### 新機能: `autoFocusRelated`（デフォルトON）
- ノードをクリックしてPin状態になると同時に「関連ノードのみ表示」が自動起動
- 設定パネルからOFF可能（OFF時は従来の2ステップ操作）
- URL param `afr=1` で状態を保存・履歴対応

### バグ修正: `focusRelated` OFF時のオフセット調整
- `focusRelated` をOFFにした後、`pendingConnectionNodeId` 経由で `handleConnectionClick` を遅延発火し、選択ノードが画面内に来るようオフセットを調整
- `projectOffsetモード` で事業ノードのオフセットジャンプが機能しなかった問題を修正（`allProjectRanks` useMemoを追加して事業ランクを計算）

### UX改善
- Pin状態（`selectedNode` あり）のとき、他ノードへのホバーハイライトを抑制（ポップアップのみ表示）
- `focusRelated` ON/OFF遷移をブラウザ履歴に追加

## テスト方法

```bash
npm run dev
```

1. `localhost:3002/sankey-svg` を開く
2. 事業ノードをクリック → 自動的に関連ノードのみ表示に切り替わることを確認
3. 「関連ノードのみ表示」OFFボタンを押す → 選択ノードが画面内に表示されることを確認
4. オフセット対象を「事業」に切り替え → 事業ノードをクリックしてOFFにしても選択事業が表示されることを確認
5. 設定パネルで `選択時に関連ノードのみ表示` をOFFにして従来の2ステップ動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Auto Focus Related" toggle that immediately derives and focuses related nodes when a node is selected.
  * Improved project-offset navigation to jump to the correct project rank and center it in view when navigating between nodes.

* **Bug Fixes**
  * Fixed an issue where toggling focus-related off during project-offset mode could make a selected recipient disappear by preserving the originating project context.

* **Documentation**
  * Added a spec describing the project-offset/focus-related defect and the remediation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->