### PR TITLE
feat: sankey-svg フィルタ機能（予算/支出レンジスライダー・フィルタトグル・TopNトグル）

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -78,6 +78,29 @@ function formatOkuYen(okuYen: number): string {
   return `${okuYen.toLocaleString()}億円`;
 }
 
+/** "1.26億", "4567万円", "1兆2000億", "100" (→億円) などを億円単位の数値に変換。解析失敗時 null */
+function parseAmountToOkuYen(s: string): number | null {
+  const t = s.trim().replace(/[,，\s]/g, '');
+  if (!t) return null;
+  // 兆 + 億 の複合 (例: "1兆2000億")
+  const comboMatch = t.match(/^([\d.]+)兆([\d.]+)億?$/);
+  if (comboMatch) {
+    const cho = parseFloat(comboMatch[1]);
+    const oku = parseFloat(comboMatch[2]);
+    if (!isNaN(cho) && !isNaN(oku)) return cho * 10000 + oku;
+  }
+  const m = t.match(/^([\d.]+)\s*(兆円?|億円?|万円?|円)?$/);
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  if (isNaN(n)) return null;
+  const unit = m[2] ?? '';
+  if (unit.startsWith('兆')) return n * 10000;
+  if (unit.startsWith('億')) return n;
+  if (unit.startsWith('万')) return n / 100;
+  if (unit === '円') return n / 1e8;
+  return n; // 単位なし → 億円
+}
+
 function computeFocusPins(
   nodeId: string,
   nodes: Array<{ id: string; name: string }> | undefined,
@@ -148,10 +171,11 @@ export default function RealDataSankeyPage() {
   // Filter feature
   const [filterActive, setFilterActive] = useState(false);
   const [showAmountSliders, setShowAmountSliders] = useState(false);
-  const [filterMinBudget, setFilterMinBudget] = useState(0);        // 億円; 0 = no min
-  const [filterMaxBudget, setFilterMaxBudget] = useState<number | null>(null); // null = no max
-  const [filterMinSpending, setFilterMinSpending] = useState(0);    // 億円; 0 = no min
-  const [filterMaxSpending, setFilterMaxSpending] = useState<number | null>(null);
+  const [filterTarget, setFilterTarget] = useState<'all' | 'project' | 'recipient'>('all');
+  const [filterMinBudgetText, setFilterMinBudgetText] = useState('');
+  const [filterMaxBudgetText, setFilterMaxBudgetText] = useState('');
+  const [filterMinSpendingText, setFilterMinSpendingText] = useState('');
+  const [filterMaxSpendingText, setFilterMaxSpendingText] = useState('');
   const isPidQuery = (q: string) => /^\d+$/.test(q);
   const meetsSearchMinLength = (q: string) => isPidQuery(q) ? q.length >= 1 : q.length >= 2;
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -519,19 +543,24 @@ export default function RealDataSankeyPage() {
   // Pre-filter exclusion set: built from filter conditions, applied before filterTopN
   const filterExcludedIds = useMemo(() => {
     if (!graphData) return null;
-    const hasBudget = filterMinBudget > 0 || filterMaxBudget !== null;
-    const hasSpending = filterMinSpending > 0 || filterMaxSpending !== null;
+    const minBudgetOku = parseAmountToOkuYen(filterMinBudgetText);
+    const maxBudgetOku = parseAmountToOkuYen(filterMaxBudgetText);
+    const minSpendingOku = parseAmountToOkuYen(filterMinSpendingText);
+    const maxSpendingOku = parseAmountToOkuYen(filterMaxSpendingText);
+    const hasBudget = minBudgetOku !== null || maxBudgetOku !== null;
+    const hasSpending = minSpendingOku !== null || maxSpendingOku !== null;
     const trimmedQuery = debouncedQuery.trim();
     const hasName = filterActive && trimmedQuery.length >= 2;
     if (!hasBudget && !hasSpending && !hasName) return null;
-    const minBudgetYen = filterMinBudget * 1e8;
-    const maxBudgetYen = filterMaxBudget !== null ? filterMaxBudget * 1e8 : Infinity;
-    const minSpendingYen = filterMinSpending * 1e8;
-    const maxSpendingYen = filterMaxSpending !== null ? filterMaxSpending * 1e8 : Infinity;
+    const minBudgetYen = (minBudgetOku ?? 0) * 1e8;
+    const maxBudgetYen = maxBudgetOku !== null ? maxBudgetOku * 1e8 : Infinity;
+    const minSpendingYen = (minSpendingOku ?? 0) * 1e8;
+    const maxSpendingYen = maxSpendingOku !== null ? maxSpendingOku * 1e8 : Infinity;
     let nameRegex: RegExp | null = null;
     if (hasName && searchUseRegex) {
-      try { nameRegex = new RegExp(trimmedQuery, 'i'); } catch { /* invalid regex — treat as no name filter */ }
+      try { nameRegex = new RegExp(trimmedQuery, 'i'); } catch { /* invalid regex */ }
     }
+    const matchesName = (name: string) => nameRegex ? nameRegex.test(name) : name.includes(trimmedQuery);
     const excluded = new Set<string>();
     const spendingByPid = new Map(
       graphData.nodes.filter(n => n.type === 'project-spending' && n.projectId != null).map(n => [n.projectId!, n])
@@ -542,15 +571,16 @@ export default function RealDataSankeyPage() {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudgetYen || n.value > maxBudgetYen);
         const failSpending = hasSpending && sn && (sn.value < minSpendingYen || sn.value > maxSpendingYen);
-        if (failBudget || failSpending) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
+        const failName = hasName && (filterTarget === 'project' || filterTarget === 'all') && !matchesName(n.name);
+        if (failBudget || failSpending || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpendingYen || n.value > maxSpendingYen);
-        const failName = hasName && (nameRegex ? !nameRegex.test(n.name) : !n.name.includes(trimmedQuery));
+        const failName = hasName && (filterTarget === 'recipient' || filterTarget === 'all') && !matchesName(n.name);
         if (failSpending || failName) excluded.add(n.id);
       }
     }
     return excluded.size > 0 ? excluded : null;
-  }, [graphData, filterActive, filterMinBudget, filterMaxBudget, filterMinSpending, filterMaxSpending, debouncedQuery, searchUseRegex]);
+  }, [graphData, filterActive, filterTarget, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery, searchUseRegex]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -2299,57 +2329,54 @@ export default function RealDataSankeyPage() {
 
             {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showAmountSliders && (
-              <div style={{ padding: '0 12px 10px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-                {[
-                  { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
-                  { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
-                ].map(({ label, min, max, dataMax, setMin, setMax }) => (
-                  <div key={label}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                      <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
-                      {(min > 0 || max !== null) && (
-                        <button type="button" onClick={() => { setMin(0); setMax(null); }}
-                          style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
-                      )}
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
-                      <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
-                      <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                        value={min}
-                        onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
-                        style={{ flex: 1, accentColor: '#1a73e8' }}
-                      />
-                      <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                        {min === 0 ? '制限なし' : formatOkuYen(min)}
-                      </span>
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                      <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
-                      <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                        value={max ?? dataMax}
-                        onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
-                        style={{ flex: 1, accentColor: '#1a73e8' }}
-                      />
-                      <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                        {max === null ? '制限なし' : formatOkuYen(max)}
-                      </span>
-                    </div>
+              <div style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {/* フィルター対象 */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ fontSize: 11, color: '#555', flexShrink: 0 }}>対象</span>
+                  <select value={filterTarget} onChange={e => setFilterTarget(e.target.value as 'all' | 'project' | 'recipient')}
+                    style={{ flex: 1, fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '2px 4px', background: '#fff', color: '#333', cursor: 'pointer' }}>
+                    <option value="all">すべて</option>
+                    <option value="project">事業</option>
+                    <option value="recipient">支出先</option>
+                  </select>
+                </div>
+                {/* 予算・支出 テキスト入力 */}
+                {([
+                  { label: '予算', minText: filterMinBudgetText, maxText: filterMaxBudgetText, setMin: setFilterMinBudgetText, setMax: setFilterMaxBudgetText },
+                  { label: '支出', minText: filterMinSpendingText, maxText: filterMaxSpendingText, setMin: setFilterMinSpendingText, setMax: setFilterMaxSpendingText },
+                ] as const).map(({ label, minText, maxText, setMin, setMax }) => (
+                  <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>{label}</span>
+                    <input type="text" value={minText} onChange={e => setMin(e.target.value)}
+                      placeholder="下限"
+                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToOkuYen(minText) !== null || !minText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                    />
+                    <span style={{ fontSize: 11, color: '#aaa', flexShrink: 0 }}>〜</span>
+                    <input type="text" value={maxText} onChange={e => setMax(e.target.value)}
+                      placeholder="上限"
+                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToOkuYen(maxText) !== null || !maxText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                    />
+                    {(minText || maxText) && (
+                      <button type="button" onClick={() => { setMin(''); setMax(''); }}
+                        style={{ fontSize: 10, color: '#aaa', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px', flexShrink: 0 }}>×</button>
+                    )}
                   </div>
                 ))}
+                <div style={{ fontSize: 10, color: '#bbb' }}>例: 1.26億 / 4567万円 / 1兆2000億</div>
               </div>
             )}
           </div>{/* end card */}
 
           {/* トグルボタン（card外・下部 — TopNの構造と同一） */}
           {(() => {
-            const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
+            const amountActive = !!(filterMinBudgetText || filterMaxBudgetText || filterMinSpendingText || filterMaxSpendingText);
             return (
               <button
                 type="button"
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 8px', marginTop: -1, userSelect: 'none' }}
+                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2332,7 +2332,7 @@ export default function RealDataSankeyPage() {
         {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
-          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', overflow: 'hidden' }}>
             {/* Input row */}
             <div style={{ position: 'relative' }}>
               {/* Search icon */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2376,7 +2376,7 @@ export default function RealDataSankeyPage() {
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRight: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderBottom: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
@@ -2642,7 +2642,7 @@ export default function RealDataSankeyPage() {
           <button
             onClick={() => setShowTopNSliders(s => !s)}
             title={showTopNSliders ? 'TopN設定 を隠す' : 'TopN設定 を表示'}
-            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.92)', border: '1px solid #e0e0e0', borderTop: 'none', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: '1px solid #e0e0e0', borderRight: '1px solid #e0e0e0', borderBottom: '1px solid #e0e0e0', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
           >
             <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#bbb">
               <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2225,7 +2225,7 @@ export default function RealDataSankeyPage() {
         {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
         <div style={{ flex: 1 }}>
           {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
-          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: showAmountSliders ? '8px 8px 0 0' : 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
             {/* Input row */}
             <div style={{ position: 'relative' }}>
               {/* Search icon */}
@@ -2299,7 +2299,7 @@ export default function RealDataSankeyPage() {
 
             {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showAmountSliders && (
-              <div style={{ borderTop: '1px solid #e8e8e8', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ padding: '0 12px 10px', display: 'flex', flexDirection: 'column', gap: 10 }}>
                 {[
                   { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
                   { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -78,11 +78,31 @@ function formatOkuYen(okuYen: number): string {
   return `${okuYen.toLocaleString()}億円`;
 }
 
-/** "1.26億", "4567万円", "1兆2000億", "100" (→億円) などを億円単位の数値に変換。解析失敗時 null */
+function parseJapaneseNumeral(s: string): number {
+  const d: Record<string, number> = { 一:1,二:2,三:3,四:4,五:5,六:6,七:7,八:8,九:9 };
+  let result = 0, cur = 0;
+  for (const c of s) {
+    if (c in d) { cur = d[c]; }
+    else if (c === '十') { result += (cur || 1) * 10; cur = 0; }
+    else if (c === '百') { result += (cur || 1) * 100; cur = 0; }
+    else if (c === '千') { result += (cur || 1) * 1000; cur = 0; }
+  }
+  return result + cur;
+}
+
+function normalizeAmountInput(s: string): string {
+  // 全角数字・小数点 → 半角
+  let t = s.replace(/[０-９]/g, c => String.fromCharCode(c.charCodeAt(0) - 0xFF10 + 0x30));
+  t = t.replace(/[．]/g, '.').replace(/[，　,\s]/g, '');
+  // 和数字ブロック（一〜千）→ アラビア数字
+  t = t.replace(/[一二三四五六七八九十百千]+/g, m => String(parseJapaneseNumeral(m)));
+  return t;
+}
+
+/** "1.26億", "４５６７万円", "一千二百億", "1兆2000億", "100" (→億円) などを億円単位の数値に変換。解析失敗時 null */
 function parseAmountToOkuYen(s: string): number | null {
-  const t = s.trim().replace(/[,，\s]/g, '');
+  const t = normalizeAmountInput(s);
   if (!t) return null;
-  // 兆 + 億 の複合 (例: "1兆2000億")
   const comboMatch = t.match(/^([\d.]+)兆([\d.]+)億?$/);
   if (comboMatch) {
     const cho = parseFloat(comboMatch[1]);
@@ -98,7 +118,7 @@ function parseAmountToOkuYen(s: string): number | null {
   if (unit.startsWith('億')) return n;
   if (unit.startsWith('万')) return n / 100;
   if (unit === '円') return n / 1e8;
-  return n; // 単位なし → 億円
+  return n;
 }
 
 function computeFocusPins(
@@ -550,7 +570,7 @@ export default function RealDataSankeyPage() {
     const hasBudget = minBudgetOku !== null || maxBudgetOku !== null;
     const hasSpending = minSpendingOku !== null || maxSpendingOku !== null;
     const trimmedQuery = debouncedQuery.trim();
-    const hasName = filterActive && trimmedQuery.length >= 2;
+    const hasName = trimmedQuery.length >= 2;
     if (!hasBudget && !hasSpending && !hasName) return null;
     const minBudgetYen = (minBudgetOku ?? 0) * 1e8;
     const maxBudgetYen = maxBudgetOku !== null ? maxBudgetOku * 1e8 : Infinity;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2293,6 +2293,23 @@ export default function RealDataSankeyPage() {
               style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
             >✕</button>
           )}
+          {/* 金額スライダー表示トグルボタン — 検索ボックス右下 */}
+          {(() => {
+            const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
+            return (
+              <button
+                type="button"
+                title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
+                aria-pressed={showAmountSliders}
+                onClick={() => setShowAmountSliders(s => !s)}
+                style={{ position: 'absolute', bottom: -1, right: 6, transform: 'translateY(100%)', zIndex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 6px 6px', cursor: 'pointer', padding: '1px 8px', userSelect: 'none' }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
+                  <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
+                </svg>
+              </button>
+            );
+          })()}
         </div>{/* end search input wrapper */}
         {/* フィルタアイコンボタン */}
         <button
@@ -2307,23 +2324,6 @@ export default function RealDataSankeyPage() {
             <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
           </svg>
         </button>
-        {/* 金額スライダー表示トグルボタン */}
-        {(() => {
-          const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
-          return (
-            <button
-              type="button"
-              title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
-              aria-pressed={showAmountSliders}
-              onClick={() => setShowAmountSliders(s => !s)}
-              style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
-                <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
-              </svg>
-            </button>
-          );
-        })()}
         </div>{/* end Row 1 flex */}
 
         {/* Row 2: 金額フィルタパネル（showAmountSliders=true のとき表示） */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -599,22 +599,13 @@ export default function RealDataSankeyPage() {
         if (n.type === 'project-budget' && matchesName(n.name)) matchingBudgetIds.add(n.id);
         if (n.type === 'recipient' && matchesName(n.name)) matchingRecipientIds.add(n.id);
       }
-      // Step2: マッチ支出先を持つ事業もマッチ扱い（OR拡張）
+      // Step2: マッチ支出先を持つ事業もマッチ扱い（支出先→事業 の一方向OR拡張のみ）
       for (const e of graphData.edges) {
         if (!e.target.startsWith('r-') || !matchingRecipientIds.has(e.target)) continue;
         const sn = nodeById.get(e.source);
         if (sn?.projectId != null) {
           const bn = budgetByPid.get(sn.projectId);
           if (bn) matchingBudgetIds.add(bn.id);
-        }
-      }
-      // Step3: マッチした事業の支出先もマッチ扱い（OR拡張）
-      for (const e of graphData.edges) {
-        if (!e.target.startsWith('r-')) continue;
-        const sn = nodeById.get(e.source);
-        if (sn?.projectId != null) {
-          const bn = budgetByPid.get(sn.projectId);
-          if (bn && matchingBudgetIds.has(bn.id)) matchingRecipientIds.add(e.target);
         }
       }
     }

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2383,7 +2383,7 @@ export default function RealDataSankeyPage() {
                     }
                   }
                 }}
-                placeholder="検索(2文字以上/PID)"
+                placeholder={filterActive ? 'フィルタ(2文字以上)' : '検索(2文字以上/PID)'}
                 style={{
                   width: '100%', boxSizing: 'border-box',
                   paddingLeft: filterActive ? 90 : 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -593,9 +593,8 @@ export default function RealDataSankeyPage() {
       if (n.type === 'project-budget' && n.projectId != null) {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
-        const failSpending = hasSpending && sn && (sn.value < minSpending || sn.value > maxSpending);
         const failName = hasName && (filterTarget === 'project' || filterTarget === 'all') && !matchesName(n.name);
-        if (failBudget || failSpending || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
+        if (failBudget || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
         const failName = hasName && (filterTarget === 'recipient' || filterTarget === 'all') && !matchesName(n.name);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -588,16 +588,54 @@ export default function RealDataSankeyPage() {
     const budgetByPid = new Map(
       graphData.nodes.filter(n => n.type === 'project-budget' && n.projectId != null).map(n => [n.projectId!, n])
     );
+    // すべて(OR)用: 事業名・支出先名それぞれのマッチセットを事前計算し相互拡張
+    const matchingBudgetIds = new Set<string>();
+    const matchingRecipientIds = new Set<string>();
+    if (hasName && filterTarget === 'all') {
+      const nodeById = new Map(graphData.nodes.map(n => [n.id, n]));
+      // Step1: 名前が一致するノードを収集
+      for (const n of graphData.nodes) {
+        if (n.aggregated) continue;
+        if (n.type === 'project-budget' && matchesName(n.name)) matchingBudgetIds.add(n.id);
+        if (n.type === 'recipient' && matchesName(n.name)) matchingRecipientIds.add(n.id);
+      }
+      // Step2: マッチ支出先を持つ事業もマッチ扱い（OR拡張）
+      for (const e of graphData.edges) {
+        if (!e.target.startsWith('r-') || !matchingRecipientIds.has(e.target)) continue;
+        const sn = nodeById.get(e.source);
+        if (sn?.projectId != null) {
+          const bn = budgetByPid.get(sn.projectId);
+          if (bn) matchingBudgetIds.add(bn.id);
+        }
+      }
+      // Step3: マッチした事業の支出先もマッチ扱い（OR拡張）
+      for (const e of graphData.edges) {
+        if (!e.target.startsWith('r-')) continue;
+        const sn = nodeById.get(e.source);
+        if (sn?.projectId != null) {
+          const bn = budgetByPid.get(sn.projectId);
+          if (bn && matchingBudgetIds.has(bn.id)) matchingRecipientIds.add(e.target);
+        }
+      }
+    }
     for (const n of graphData.nodes) {
       if (n.aggregated) continue;
       if (n.type === 'project-budget' && n.projectId != null) {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
-        const failName = hasName && (filterTarget === 'project' || filterTarget === 'all') && !matchesName(n.name);
+        const failName = hasName && (
+          filterTarget === 'project' ? !matchesName(n.name) :
+          filterTarget === 'all' ? !matchingBudgetIds.has(n.id) :
+          false
+        );
         if (failBudget || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
-        const failName = hasName && (filterTarget === 'recipient' || filterTarget === 'all') && !matchesName(n.name);
+        const failName = hasName && (
+          filterTarget === 'recipient' ? !matchesName(n.name) :
+          filterTarget === 'all' ? !matchingRecipientIds.has(n.id) :
+          false
+        );
         if (failSpending || failName) excluded.add(n.id);
       }
     }
@@ -2311,6 +2349,18 @@ export default function RealDataSankeyPage() {
                 style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
                 <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
               </svg>
+              {/* Filter target select — フィルタモード時のみ表示、虫眼鏡の隣 */}
+              {filterActive && (
+                <select
+                  value={filterTarget}
+                  onChange={e => setFilterTarget(e.target.value as 'all' | 'project' | 'recipient')}
+                  style={{ position: 'absolute', left: 28, top: '50%', transform: 'translateY(-50%)', fontSize: 10, border: '1px solid #ddd', borderRadius: 3, padding: '1px 2px', background: 'rgba(255,255,255,0.9)', color: '#555', cursor: 'pointer', height: 20 }}
+                >
+                  <option value="all">すべて</option>
+                  <option value="project">事業</option>
+                  <option value="recipient">支出先</option>
+                </select>
+              )}
               <input
                 ref={searchInputRef}
                 type="text"
@@ -2345,7 +2395,7 @@ export default function RealDataSankeyPage() {
                 placeholder="検索(2文字以上/PID)"
                 style={{
                   width: '100%', boxSizing: 'border-box',
-                  paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
+                  paddingLeft: filterActive ? 90 : 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
                   fontSize: 13, border: 'none', borderRadius: 8,
                   background: 'transparent', outline: 'none', color: '#333',
                 }}
@@ -2378,16 +2428,6 @@ export default function RealDataSankeyPage() {
             {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showAmountSliders && (
               <div style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {/* フィルター対象 */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <span style={{ fontSize: 11, color: '#555', flexShrink: 0 }}>対象</span>
-                  <select value={filterTarget} onChange={e => setFilterTarget(e.target.value as 'all' | 'project' | 'recipient')}
-                    style={{ flex: 1, fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '2px 4px', background: '#fff', color: '#333', cursor: 'pointer' }}>
-                    <option value="all">すべて</option>
-                    <option value="project">事業</option>
-                    <option value="recipient">支出先</option>
-                  </select>
-                </div>
                 {/* 予算・支出 テキスト入力 */}
                 {([
                   { label: '予算', minText: filterMinBudgetText, maxText: filterMaxBudgetText, setMin: setFilterMinBudgetText, setMax: setFilterMaxBudgetText },

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -118,7 +118,7 @@ function parseAmountToYen(s: string): number | null {
   if (unit.startsWith('億')) return n * 1e8;
   if (unit.startsWith('万')) return n * 1e4;
   if (unit === '円') return n;
-  return n; // 単位なし → 1円単位
+  return n * 1e8; // 単位なし → 億円換算
 }
 
 function computeFocusPins(

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2335,11 +2335,23 @@ export default function RealDataSankeyPage() {
           <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', overflow: 'hidden' }}>
             {/* Input row */}
             <div style={{ position: 'relative' }}>
-              {/* Search icon */}
-              <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
-                style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-                <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-              </svg>
+              {/* Search/Filter mode toggle icon */}
+              <button
+                type="button"
+                title={filterActive ? 'フィルタモード（クリックで検索モードに切替）' : '検索モード（クリックでフィルタモードに切替）'}
+                onClick={() => setFilterActive(f => !f)}
+                style={{ position: 'absolute', left: 6, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20 }}
+              >
+                {filterActive ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#1a73e8">
+                    <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999">
+                    <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+                  </svg>
+                )}
+              </button>
               {/* Filter target select — フィルタモード時のみ表示、虫眼鏡の隣 */}
               {filterActive && (
                 <select
@@ -2464,19 +2476,6 @@ export default function RealDataSankeyPage() {
           })()}
         </div>{/* end 検索セクション */}
 
-        {/* フィルタアイコンボタン */}
-        <button
-          type="button"
-          title={filterActive ? 'フィルタモード（クリックで検索モードに切替）' : '検索モード（クリックでフィルタモードに切替）'}
-          aria-pressed={filterActive}
-          onClick={() => setFilterActive(f => !f)}
-          style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${filterActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: filterActive ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
-        >
-          {/* Material Icons: filter_list */}
-          <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill={filterActive ? '#1a73e8' : '#888'}>
-            <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
-          </svg>
-        </button>
         </div>{/* end Row 1 flex */}
 
         {/* Dropdown */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2330,7 +2330,7 @@ export default function RealDataSankeyPage() {
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
         {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
           {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
           <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', overflow: 'hidden' }}>
             {/* Input row */}
@@ -2441,7 +2441,7 @@ export default function RealDataSankeyPage() {
                     )}
                   </div>
                 ))}
-                <div style={{ fontSize: 10, color: '#bbb' }}>例: 1.26億 / 4567万円 / 1兆2000億</div>
+                <div style={{ fontSize: 10, color: '#bbb', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>例: 1.26億 / 4567万円 / 1兆2000億</div>
               </div>
             )}
           </div>{/* end card */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2222,146 +2222,137 @@ export default function RealDataSankeyPage() {
       >
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
-        {/* 検索セクション: input panel + sliders + toggle（TopNパネルと同じ構造） */}
-        <div style={{ flex: 1, position: 'relative' }}>
-          {/* Input panel — border/bg/shadow をここで管理 */}
-          <div style={{ position: 'relative', background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: showAmountSliders ? '8px 8px 0 0' : '8px 8px 0 8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
-            {/* Search icon */}
-            <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
-              style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-              <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-            </svg>
-            <input
-              ref={searchInputRef}
-              type="text"
-              value={searchQuery}
-              onChange={e => { setSearchQuery(e.target.value); if (!filterActive) setShowSearchResults(true); setSearchCursorIndex(-1); }}
-              onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
-              onKeyDown={e => {
-                if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
-                if (!showSearchResults || searchPagedResults.length === 0) return;
-                if (e.key === 'ArrowDown') {
-                  e.preventDefault();
-                  setSearchCursorIndex(i => {
-                    const next = Math.min(i + 1, searchPagedResults.length - 1);
-                    setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
-                    return next;
-                  });
-                } else if (e.key === 'ArrowUp') {
-                  e.preventDefault();
-                  setSearchCursorIndex(i => {
-                    const next = Math.max(i - 1, 0);
-                    setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
-                    return next;
-                  });
-                } else if (e.key === 'Enter') {
-                  e.preventDefault();
-                  if (searchCursorIndex >= 0 && searchCursorIndex < searchPagedResults.length) {
-                    handleSearchSelect(searchPagedResults[searchCursorIndex].id);
-                    setSearchCursorIndex(-1);
+        {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
+        <div style={{ flex: 1 }}>
+          {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
+          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+            {/* Input row */}
+            <div style={{ position: 'relative' }}>
+              {/* Search icon */}
+              <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
+                style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
+                <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+              </svg>
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={e => { setSearchQuery(e.target.value); if (!filterActive) setShowSearchResults(true); setSearchCursorIndex(-1); }}
+                onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
+                onKeyDown={e => {
+                  if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
+                  if (!showSearchResults || searchPagedResults.length === 0) return;
+                  if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    setSearchCursorIndex(i => {
+                      const next = Math.min(i + 1, searchPagedResults.length - 1);
+                      setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
+                      return next;
+                    });
+                  } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    setSearchCursorIndex(i => {
+                      const next = Math.max(i - 1, 0);
+                      setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
+                      return next;
+                    });
+                  } else if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (searchCursorIndex >= 0 && searchCursorIndex < searchPagedResults.length) {
+                      handleSearchSelect(searchPagedResults[searchCursorIndex].id);
+                      setSearchCursorIndex(-1);
+                    }
                   }
-                }
-              }}
-              placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
-              style={{
-                width: '100%', boxSizing: 'border-box',
-                paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
-                fontSize: 13, border: 'none', borderRadius: 8,
-                background: 'transparent', outline: 'none', color: '#333',
-              }}
-            />
-            {/* .* regex toggle */}
-            <button
-              type="button"
-              title={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
-              aria-label={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
-              aria-pressed={searchUseRegex}
-              onClick={() => setSearchUseRegex(v => !v)}
-              style={{
-                position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',
-                background: searchUseRegex ? '#1a73e8' : 'transparent',
-                border: 'none', borderRadius: 4, cursor: 'pointer',
-                color: searchUseRegex ? '#fff' : '#888',
-                fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold',
-                lineHeight: 1, padding: '2px 4px',
-              }}
-            >.*</button>
-            {searchQuery && (
+                }}
+                placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
+                style={{
+                  width: '100%', boxSizing: 'border-box',
+                  paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
+                  fontSize: 13, border: 'none', borderRadius: 8,
+                  background: 'transparent', outline: 'none', color: '#333',
+                }}
+              />
+              {/* .* regex toggle */}
               <button
                 type="button"
-                onClick={() => { setSearchQuery(''); setDebouncedQuery(''); setShowSearchResults(false); searchInputRef.current?.focus(); }}
-                style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
-              >✕</button>
+                title={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+                aria-label={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+                aria-pressed={searchUseRegex}
+                onClick={() => setSearchUseRegex(v => !v)}
+                style={{
+                  position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',
+                  background: searchUseRegex ? '#1a73e8' : 'transparent',
+                  border: 'none', borderRadius: 4, cursor: 'pointer',
+                  color: searchUseRegex ? '#fff' : '#888',
+                  fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold',
+                  lineHeight: 1, padding: '2px 4px',
+                }}
+              >.*</button>
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => { setSearchQuery(''); setDebouncedQuery(''); setShowSearchResults(false); searchInputRef.current?.focus(); }}
+                  style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
+                >✕</button>
+              )}
+            </div>{/* end input row */}
+
+            {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
+            {showAmountSliders && (
+              <div style={{ borderTop: '1px solid #e8e8e8', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {[
+                  { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
+                  { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
+                ].map(({ label, min, max, dataMax, setMin, setMax }) => (
+                  <div key={label}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                      <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
+                      {(min > 0 || max !== null) && (
+                        <button type="button" onClick={() => { setMin(0); setMax(null); }}
+                          style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                      <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
+                      <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                        value={min}
+                        onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
+                        style={{ flex: 1, accentColor: '#1a73e8' }}
+                      />
+                      <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                        {min === 0 ? '制限なし' : formatOkuYen(min)}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
+                      <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                        value={max ?? dataMax}
+                        onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
+                        style={{ flex: 1, accentColor: '#1a73e8' }}
+                      />
+                      <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                        {max === null ? '制限なし' : formatOkuYen(max)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
             )}
-          </div>{/* end input panel */}
+          </div>{/* end card */}
 
-          {/* 金額フィルタパネル（showAmountSliders=true のとき表示、input panelに連結） */}
-          {showAmountSliders && (
-            <div style={{ marginTop: -1, background: 'rgba(255,255,255,0.97)', border: '1px solid #e0e0e0', borderTop: 'none', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {[
-                { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
-                { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
-              ].map(({ label, min, max, dataMax, setMin, setMax }) => (
-                <div key={label}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                    <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
-                    {(min > 0 || max !== null) && (
-                      <button type="button" onClick={() => { setMin(0); setMax(null); }}
-                        style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
-                    )}
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
-                    <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
-                    <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                      value={min}
-                      onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
-                      style={{ flex: 1, accentColor: '#1a73e8' }}
-                    />
-                    <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                      {min === 0 ? '制限なし' : formatOkuYen(min)}
-                    </span>
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
-                    <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                      value={max ?? dataMax}
-                      onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
-                      style={{ flex: 1, accentColor: '#1a73e8' }}
-                    />
-                    <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                      {max === null ? '制限なし' : formatOkuYen(max)}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* トグルボタン — sliders表示時: パネル下部full-width / 非表示時: 右下コーナータブ */}
+          {/* トグルボタン（card外・下部 — TopNの構造と同一） */}
           {(() => {
             const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
-            const borderColor = amountActive ? '#1a73e8' : '#e0e0e0';
-            const bg = amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)';
-            const fill = amountActive ? '#1a73e8' : '#bbb';
-            if (showAmountSliders) {
-              return (
-                <button type="button" title="金額フィルタ を隠す" aria-pressed={true}
-                  onClick={() => setShowAmountSliders(s => !s)}
-                  style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: bg, border: `1px solid ${borderColor}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={fill}>
-                    <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
-                  </svg>
-                </button>
-              );
-            }
             return (
-              <button type="button" title="金額フィルタ を表示" aria-pressed={false}
+              <button
+                type="button"
+                title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
+                aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ position: 'absolute', bottom: 0, right: 0, transform: 'translateY(100%)', display: 'flex', alignItems: 'center', justifyContent: 'center', background: bg, border: 'none', borderRight: `1px solid ${borderColor}`, borderBottom: `1px solid ${borderColor}`, borderRadius: '0 0 8px 0', cursor: 'pointer', padding: '1px 8px', userSelect: 'none' }}
+                style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill={fill}>
-                  <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+                <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
+                  <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
                 </svg>
               </button>
             );

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2308,18 +2308,22 @@ export default function RealDataSankeyPage() {
           </svg>
         </button>
         {/* 金額スライダー表示トグルボタン */}
-        <button
-          type="button"
-          title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
-          aria-pressed={showAmountSliders}
-          onClick={() => setShowAmountSliders(s => !s)}
-          style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${(filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: (filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
-        >
-          {/* Material Icons: tune */}
-          <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill={(filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#1a73e8' : '#888'}>
-            <path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"/>
-          </svg>
-        </button>
+        {(() => {
+          const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
+          return (
+            <button
+              type="button"
+              title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
+              aria-pressed={showAmountSliders}
+              onClick={() => setShowAmountSliders(s => !s)}
+              style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
+                <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
+              </svg>
+            </button>
+          );
+        })()}
         </div>{/* end Row 1 flex */}
 
         {/* Row 2: 金額フィルタパネル（showAmountSliders=true のとき表示） */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -73,6 +73,11 @@ function mergedProjectPath(x0: number, nodeW: number, bH: number, sH: number): s
 }
 
 /** ノードID → フォーカスピン状態を導出する純粋ヘルパー */
+function formatOkuYen(okuYen: number): string {
+  if (okuYen >= 10000) return `${(okuYen / 10000 % 1 === 0 ? okuYen / 10000 : (okuYen / 10000).toFixed(1))}兆円`;
+  return `${okuYen.toLocaleString()}億円`;
+}
+
 function computeFocusPins(
   nodeId: string,
   nodes: Array<{ id: string; name: string }> | undefined,
@@ -140,6 +145,12 @@ export default function RealDataSankeyPage() {
   const [searchCursorIndex, setSearchCursorIndex] = useState(-1);
   const [searchUseRegex, setSearchUseRegex] = useState(false);
   const [searchPage, setSearchPage] = useState(0);
+  // Filter feature
+  const [filterActive, setFilterActive] = useState(false);
+  const [filterMinBudget, setFilterMinBudget] = useState(0);        // 億円; 0 = no min
+  const [filterMaxBudget, setFilterMaxBudget] = useState<number | null>(null); // null = no max
+  const [filterMinSpending, setFilterMinSpending] = useState(0);    // 億円; 0 = no min
+  const [filterMaxSpending, setFilterMaxSpending] = useState<number | null>(null);
   const isPidQuery = (q: string) => /^\d+$/.test(q);
   const meetsSearchMinLength = (q: string) => isPidQuery(q) ? q.length >= 1 : q.length >= 2;
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -490,12 +501,61 @@ export default function RealDataSankeyPage() {
       .catch(e => { setError(String(e)); setLoading(false); });
   }, [year]);
 
+  // Max values for filter sliders (in 億円)
+  const graphDataStats = useMemo(() => {
+    if (!graphData) return { maxBudget: 100000, maxSpending: 100000 };
+    let mb = 0, ms = 0;
+    for (const n of graphData.nodes) {
+      if (n.type === 'project-budget') mb = Math.max(mb, n.value);
+      else if (n.type === 'project-spending' || n.type === 'recipient') ms = Math.max(ms, n.value);
+    }
+    return {
+      maxBudget: Math.max(1000, Math.ceil(mb / 1e8 / 1000) * 1000),
+      maxSpending: Math.max(1000, Math.ceil(ms / 1e8 / 1000) * 1000),
+    };
+  }, [graphData]);
+
+  // Pre-filter exclusion set: built from filter conditions, applied before filterTopN
+  const filterExcludedIds = useMemo(() => {
+    if (!filterActive || !graphData) return null;
+    const hasBudget = filterMinBudget > 0 || filterMaxBudget !== null;
+    const hasSpending = filterMinSpending > 0 || filterMaxSpending !== null;
+    if (!hasBudget && !hasSpending) return null;
+    const minBudgetYen = filterMinBudget * 1e8;
+    const maxBudgetYen = filterMaxBudget !== null ? filterMaxBudget * 1e8 : Infinity;
+    const minSpendingYen = filterMinSpending * 1e8;
+    const maxSpendingYen = filterMaxSpending !== null ? filterMaxSpending * 1e8 : Infinity;
+    const excluded = new Set<string>();
+    const spendingByPid = new Map(
+      graphData.nodes.filter(n => n.type === 'project-spending' && n.projectId != null).map(n => [n.projectId!, n])
+    );
+    for (const n of graphData.nodes) {
+      if (n.aggregated) continue;
+      if (n.type === 'project-budget' && n.projectId != null) {
+        const sn = spendingByPid.get(n.projectId);
+        const failBudget = hasBudget && (n.value < minBudgetYen || n.value > maxBudgetYen);
+        const failSpending = hasSpending && sn && (sn.value < minSpendingYen || sn.value > maxSpendingYen);
+        if (failBudget || failSpending) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
+      } else if (n.type === 'recipient') {
+        if (hasSpending && (n.value < minSpendingYen || n.value > maxSpendingYen)) excluded.add(n.id);
+      }
+    }
+    return excluded.size > 0 ? excluded : null;
+  }, [graphData, filterActive, filterMinBudget, filterMaxBudget, filterMinSpending, filterMaxSpending]);
+
   const filtered = useMemo(() => {
     if (!graphData) return null;
-    const maxOffset = Math.max(0, (graphData.nodes.filter(n => n.type === 'recipient').length) - topRecipient);
+    // Apply pre-filter: remove excluded nodes and their edges before TopN selection
+    const nodes = filterExcludedIds
+      ? graphData.nodes.filter(n => !filterExcludedIds.has(n.id))
+      : graphData.nodes;
+    const edges = filterExcludedIds
+      ? graphData.edges.filter(e => !filterExcludedIds.has(e.source) && !filterExcludedIds.has(e.target))
+      : graphData.edges;
+    const maxOffset = Math.max(0, (nodes.filter(n => n.type === 'recipient').length) - topRecipient);
     const clampedOffset = Math.min(recipientOffset, maxOffset);
-    return filterTopN(graphData.nodes, graphData.edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, showAggProject, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, projectSortBy);
-  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset]);
+    return filterTopN(nodes, edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, showAggProject, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, projectSortBy);
+  }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, filterExcludedIds]);
 
   const layout = useMemo(() => {
     if (!filtered) return null;
@@ -2149,9 +2209,11 @@ export default function RealDataSankeyPage() {
       {/* Search box — top left */}
       <div
         data-pan-disabled="true"
-        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? 322 : 12, zIndex: 100, width: 260, transition: 'left 0.2s ease' }}
+        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? 322 : 12, zIndex: 100, width: 296, transition: 'left 0.2s ease' }}
       >
-        <div style={{ position: 'relative' }}>
+        {/* Row 1: 検索inputとフィルタボタン */}
+        <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+        <div style={{ position: 'relative', flex: 1 }}>
           {/* Search icon */}
           <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
             style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
@@ -2222,7 +2284,82 @@ export default function RealDataSankeyPage() {
               style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
             >✕</button>
           )}
+        </div>{/* end search input wrapper */}
+        {/* フィルタアイコンボタン */}
+        <button
+          type="button"
+          title={filterActive ? 'フィルタ ON（クリックでOFF）' : 'フィルタ OFF（クリックでON）'}
+          aria-pressed={filterActive}
+          onClick={() => setFilterActive(f => !f)}
+          style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${filterActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: filterActive ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
+        >
+          {/* Material Icons: filter_list */}
+          <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill={filterActive ? '#1a73e8' : '#888'}>
+            <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+          </svg>
+        </button>
+        </div>{/* end Row 1 flex */}
+
+        {/* Row 2: TopN設定 表示トグルボタン */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 3 }}>
+          <button
+            type="button"
+            onClick={() => setShowTopNSliders(s => !s)}
+            title={showTopNSliders ? 'TopN・オフセット設定 を隠す' : 'TopN・オフセット設定 を表示'}
+            style={{ display: 'flex', alignItems: 'center', gap: 3, background: 'rgba(255,255,255,0.92)', border: '1px solid #e0e0e0', borderRadius: 6, cursor: 'pointer', padding: '2px 7px', fontSize: 11, color: '#666', userSelect: 'none', boxShadow: '0 1px 3px rgba(0,0,0,0.07)' }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#999">
+              <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
+            </svg>
+            TopN・オフセット
+          </button>
         </div>
+
+        {/* Row 3: フィルタパネル（filterActive=true のとき表示） */}
+        {filterActive && (
+          <div style={{ marginTop: 4, background: 'rgba(255,255,255,0.97)', border: `1px solid #c5d8f8`, borderRadius: 8, padding: '10px 12px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {/* ── 予算フィルタ ── */}
+            {[
+              { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
+              { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
+            ].map(({ label, min, max, dataMax, setMin, setMax }) => (
+              <div key={label}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                  <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
+                  {(min > 0 || max !== null) && (
+                    <button type="button" onClick={() => { setMin(0); setMax(null); }}
+                      style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
+                  )}
+                </div>
+                {/* 下限スライダー */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                  <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
+                  <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                    value={min}
+                    onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
+                    style={{ flex: 1, accentColor: '#1a73e8' }}
+                  />
+                  <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                    {min === 0 ? '制限なし' : formatOkuYen(min)}
+                  </span>
+                </div>
+                {/* 上限スライダー */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
+                  <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                    value={max ?? dataMax}
+                    onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
+                    style={{ flex: 1, accentColor: '#1a73e8' }}
+                  />
+                  <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                    {max === null ? '制限なし' : formatOkuYen(max)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* Dropdown */}
         {showSearchResults && searchResults.length > 0 && (
           <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', zIndex: 20 }}>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2220,80 +2220,124 @@ export default function RealDataSankeyPage() {
         data-pan-disabled="true"
         style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? 322 : 12, zIndex: 100, width: 296, transition: 'left 0.2s ease' }}
       >
-        {/* Row 1: 検索inputとフィルタボタン */}
-        <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-        <div style={{ position: 'relative', flex: 1 }}>
-          {/* Search icon */}
-          <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
-            style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-            <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-          </svg>
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={searchQuery}
-            onChange={e => { setSearchQuery(e.target.value); if (!filterActive) setShowSearchResults(true); setSearchCursorIndex(-1); }}
-            onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
-            onKeyDown={e => {
-              if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
-              if (!showSearchResults || searchPagedResults.length === 0) return;
-              if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                setSearchCursorIndex(i => {
-                  const next = Math.min(i + 1, searchPagedResults.length - 1);
-                  setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
-                  return next;
-                });
-              } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                setSearchCursorIndex(i => {
-                  const next = Math.max(i - 1, 0);
-                  setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
-                  return next;
-                });
-              } else if (e.key === 'Enter') {
-                e.preventDefault();
-                if (searchCursorIndex >= 0 && searchCursorIndex < searchPagedResults.length) {
-                  handleSearchSelect(searchPagedResults[searchCursorIndex].id);
-                  setSearchCursorIndex(-1);
+        {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
+        <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
+        {/* 検索セクション: input panel + sliders + toggle（TopNパネルと同じ構造） */}
+        <div style={{ flex: 1 }}>
+          {/* Input panel — border/bg/shadow をここで管理 */}
+          <div style={{ position: 'relative', background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+            {/* Search icon */}
+            <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
+              style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
+              <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+            </svg>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={e => { setSearchQuery(e.target.value); if (!filterActive) setShowSearchResults(true); setSearchCursorIndex(-1); }}
+              onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
+              onKeyDown={e => {
+                if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
+                if (!showSearchResults || searchPagedResults.length === 0) return;
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  setSearchCursorIndex(i => {
+                    const next = Math.min(i + 1, searchPagedResults.length - 1);
+                    setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
+                    return next;
+                  });
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  setSearchCursorIndex(i => {
+                    const next = Math.max(i - 1, 0);
+                    setTimeout(() => searchDropdownRef.current?.children[next + 1]?.scrollIntoView({ block: 'nearest' }), 0);
+                    return next;
+                  });
+                } else if (e.key === 'Enter') {
+                  e.preventDefault();
+                  if (searchCursorIndex >= 0 && searchCursorIndex < searchPagedResults.length) {
+                    handleSearchSelect(searchPagedResults[searchCursorIndex].id);
+                    setSearchCursorIndex(-1);
+                  }
                 }
-              }
-            }}
-            placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
-            style={{
-              width: '100%', boxSizing: 'border-box',
-              paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
-              fontSize: 13,
-              border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8,
-              background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
-              outline: 'none', color: '#333',
-            }}
-          />
-          {/* .* regex toggle */}
-          <button
-            type="button"
-            title={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
-            aria-label={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
-            aria-pressed={searchUseRegex}
-            onClick={() => setSearchUseRegex(v => !v)}
-            style={{
-              position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',
-              background: searchUseRegex ? '#1a73e8' : 'transparent',
-              border: 'none',
-              borderRadius: 4, cursor: 'pointer',
-              color: searchUseRegex ? '#fff' : '#888',
-              fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold',
-              lineHeight: 1, padding: '2px 4px',
-            }}
-          >.*</button>
-          {searchQuery && (
+              }}
+              placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
+              style={{
+                width: '100%', boxSizing: 'border-box',
+                paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
+                fontSize: 13, border: 'none', borderRadius: 8,
+                background: 'transparent', outline: 'none', color: '#333',
+              }}
+            />
+            {/* .* regex toggle */}
             <button
               type="button"
-              onClick={() => { setSearchQuery(''); setDebouncedQuery(''); setShowSearchResults(false); searchInputRef.current?.focus(); }}
-              style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
-            >✕</button>
+              title={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+              aria-label={searchUseRegex ? '正規表現検索をオフ' : '正規表現で検索'}
+              aria-pressed={searchUseRegex}
+              onClick={() => setSearchUseRegex(v => !v)}
+              style={{
+                position: 'absolute', right: searchQuery ? 30 : 6, top: '50%', transform: 'translateY(-50%)',
+                background: searchUseRegex ? '#1a73e8' : 'transparent',
+                border: 'none', borderRadius: 4, cursor: 'pointer',
+                color: searchUseRegex ? '#fff' : '#888',
+                fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold',
+                lineHeight: 1, padding: '2px 4px',
+              }}
+            >.*</button>
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => { setSearchQuery(''); setDebouncedQuery(''); setShowSearchResults(false); searchInputRef.current?.focus(); }}
+                style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 14, lineHeight: 1, padding: '2px 4px' }}
+              >✕</button>
+            )}
+          </div>{/* end input panel */}
+
+          {/* 金額フィルタパネル（showAmountSliders=true のとき表示、input panelに連結） */}
+          {showAmountSliders && (
+            <div style={{ marginTop: -1, background: 'rgba(255,255,255,0.97)', border: '1px solid #e0e0e0', borderTop: 'none', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {[
+                { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
+                { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
+              ].map(({ label, min, max, dataMax, setMin, setMax }) => (
+                <div key={label}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                    <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
+                    {(min > 0 || max !== null) && (
+                      <button type="button" onClick={() => { setMin(0); setMax(null); }}
+                        style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                    <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
+                    <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                      value={min}
+                      onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
+                      style={{ flex: 1, accentColor: '#1a73e8' }}
+                    />
+                    <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                      {min === 0 ? '制限なし' : formatOkuYen(min)}
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
+                    <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
+                      value={max ?? dataMax}
+                      onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
+                      style={{ flex: 1, accentColor: '#1a73e8' }}
+                    />
+                    <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                      {max === null ? '制限なし' : formatOkuYen(max)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
-          {/* 金額スライダー表示トグルボタン — 検索ボックス右下 */}
+
+          {/* トグルボタン（パネル外・下部 — TopNと同じ構造） */}
           {(() => {
             const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
             return (
@@ -2302,15 +2346,16 @@ export default function RealDataSankeyPage() {
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ position: 'absolute', bottom: -1, right: 6, transform: 'translateY(100%)', zIndex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 6px 6px', cursor: 'pointer', padding: '1px 8px', userSelect: 'none' }}
+                style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
+                <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
                 </svg>
               </button>
             );
           })()}
-        </div>{/* end search input wrapper */}
+        </div>{/* end 検索セクション */}
+
         {/* フィルタアイコンボタン */}
         <button
           type="button"
@@ -2325,51 +2370,6 @@ export default function RealDataSankeyPage() {
           </svg>
         </button>
         </div>{/* end Row 1 flex */}
-
-        {/* Row 2: 金額フィルタパネル（showAmountSliders=true のとき表示） */}
-        {showAmountSliders && (
-          <div style={{ marginTop: 4, background: 'rgba(255,255,255,0.97)', border: `1px solid #c5d8f8`, borderRadius: 8, padding: '10px 12px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)', display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {/* ── 予算フィルタ ── */}
-            {[
-              { label: '予算', min: filterMinBudget, max: filterMaxBudget, dataMax: graphDataStats.maxBudget, setMin: setFilterMinBudget, setMax: setFilterMaxBudget },
-              { label: '支出', min: filterMinSpending, max: filterMaxSpending, dataMax: graphDataStats.maxSpending, setMin: setFilterMinSpending, setMax: setFilterMaxSpending },
-            ].map(({ label, min, max, dataMax, setMin, setMax }) => (
-              <div key={label}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                  <span style={{ fontSize: 11, fontWeight: 600, color: '#444' }}>{label}</span>
-                  {(min > 0 || max !== null) && (
-                    <button type="button" onClick={() => { setMin(0); setMax(null); }}
-                      style={{ fontSize: 10, color: '#1a73e8', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>リセット</button>
-                  )}
-                </div>
-                {/* 下限スライダー */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
-                  <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>下限</span>
-                  <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                    value={min}
-                    onChange={e => { const v = Number(e.target.value); setMin(v); if (max !== null && v > max) setMax(v); }}
-                    style={{ flex: 1, accentColor: '#1a73e8' }}
-                  />
-                  <span style={{ fontSize: 10, color: min > 0 ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                    {min === 0 ? '制限なし' : formatOkuYen(min)}
-                  </span>
-                </div>
-                {/* 上限スライダー */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <span style={{ fontSize: 10, color: '#777', width: 22, flexShrink: 0 }}>上限</span>
-                  <input type="range" min={0} max={dataMax} step={Math.max(1, Math.floor(dataMax / 500))}
-                    value={max ?? dataMax}
-                    onChange={e => { const v = Number(e.target.value); const next = v >= dataMax ? null : v; setMax(next); if (next !== null && next < min) setMin(next); }}
-                    style={{ flex: 1, accentColor: '#1a73e8' }}
-                  />
-                  <span style={{ fontSize: 10, color: max !== null ? '#1a73e8' : '#aaa', width: 64, textAlign: 'right', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                    {max === null ? '制限なし' : formatOkuYen(max)}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
 
         {/* Dropdown */}
         {!filterActive && showSearchResults && searchResults.length > 0 && (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2223,9 +2223,9 @@ export default function RealDataSankeyPage() {
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
         {/* 検索セクション: input panel + sliders + toggle（TopNパネルと同じ構造） */}
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, position: 'relative' }}>
           {/* Input panel — border/bg/shadow をここで管理 */}
-          <div style={{ position: 'relative', background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+          <div style={{ position: 'relative', background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: showAmountSliders ? '8px 8px 0 0' : '8px 8px 0 8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
             {/* Search icon */}
             <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="#999"
               style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
@@ -2337,19 +2337,31 @@ export default function RealDataSankeyPage() {
             </div>
           )}
 
-          {/* トグルボタン（パネル外・下部 — TopNと同じ構造） */}
+          {/* トグルボタン — sliders表示時: パネル下部full-width / 非表示時: 右下コーナータブ */}
           {(() => {
             const amountActive = filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null;
+            const borderColor = amountActive ? '#1a73e8' : '#e0e0e0';
+            const bg = amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)';
+            const fill = amountActive ? '#1a73e8' : '#bbb';
+            if (showAmountSliders) {
+              return (
+                <button type="button" title="金額フィルタ を隠す" aria-pressed={true}
+                  onClick={() => setShowAmountSliders(s => !s)}
+                  style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: bg, border: `1px solid ${borderColor}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={fill}>
+                    <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+                  </svg>
+                </button>
+              );
+            }
             return (
-              <button
-                type="button"
-                title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
-                aria-pressed={showAmountSliders}
+              <button type="button" title="金額フィルタ を表示" aria-pressed={false}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+                style={{ position: 'absolute', bottom: 0, right: 0, transform: 'translateY(100%)', display: 'flex', alignItems: 'center', justifyContent: 'center', background: bg, border: 'none', borderRight: `1px solid ${borderColor}`, borderBottom: `1px solid ${borderColor}`, borderRadius: '0 0 8px 0', cursor: 'pointer', padding: '1px 8px', userSelect: 'none' }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
-                  <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
+                <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill={fill}>
+                  <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                 </svg>
               </button>
             );

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -118,7 +118,7 @@ function parseAmountToYen(s: string): number | null {
   if (unit.startsWith('億')) return n * 1e8;
   if (unit.startsWith('万')) return n * 1e4;
   if (unit === '円') return n;
-  return n * 1e8; // 単位なし → 億円換算
+  return n; // 単位なし → 1円単位
 }
 
 function computeFocusPins(

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2417,16 +2417,15 @@ export default function RealDataSankeyPage() {
 
           {/* トグルボタン（card外・下部 — TopNの構造と同一） */}
           {(() => {
-            const amountActive = !!(filterMinBudgetText || filterMaxBudgetText || filterMinSpendingText || filterMaxSpendingText);
             return (
               <button
                 type="button"
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRight: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderBottom: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: '1px solid #e0e0e0', borderRight: '1px solid #e0e0e0', borderBottom: '1px solid #e0e0e0', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
+                <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#bbb">
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
                 </svg>
               </button>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -570,7 +570,7 @@ export default function RealDataSankeyPage() {
     const hasBudget = minBudgetYen !== null || maxBudgetYen !== null;
     const hasSpending = minSpendingYen !== null || maxSpendingYen !== null;
     const trimmedQuery = debouncedQuery.trim();
-    const hasName = trimmedQuery.length >= 2;
+    const hasName = filterActive && trimmedQuery.length >= 2;
     if (!hasBudget && !hasSpending && !hasName) return null;
     const minBudget = minBudgetYen ?? 0;
     const maxBudget = maxBudgetYen ?? Infinity;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2349,7 +2349,7 @@ export default function RealDataSankeyPage() {
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 0', cursor: 'pointer', padding: '0 8px', marginTop: -1, userSelect: 'none' }}
+                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 8px', marginTop: -1, userSelect: 'none' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -99,26 +99,26 @@ function normalizeAmountInput(s: string): string {
   return t;
 }
 
-/** "1.26億", "４５６７万円", "一千二百億", "1兆2000億", "100" (→億円) などを億円単位の数値に変換。解析失敗時 null */
-function parseAmountToOkuYen(s: string): number | null {
+/** "1.26億", "４５６７万円", "一千二百億", "1兆2000億", "100億" などを1円単位の数値に変換。解析失敗時 null */
+function parseAmountToYen(s: string): number | null {
   const t = normalizeAmountInput(s);
   if (!t) return null;
   const comboMatch = t.match(/^([\d.]+)兆([\d.]+)億?$/);
   if (comboMatch) {
     const cho = parseFloat(comboMatch[1]);
     const oku = parseFloat(comboMatch[2]);
-    if (!isNaN(cho) && !isNaN(oku)) return cho * 10000 + oku;
+    if (!isNaN(cho) && !isNaN(oku)) return (cho * 10000 + oku) * 1e8;
   }
   const m = t.match(/^([\d.]+)\s*(兆円?|億円?|万円?|円)?$/);
   if (!m) return null;
   const n = parseFloat(m[1]);
   if (isNaN(n)) return null;
   const unit = m[2] ?? '';
-  if (unit.startsWith('兆')) return n * 10000;
-  if (unit.startsWith('億')) return n;
-  if (unit.startsWith('万')) return n / 100;
-  if (unit === '円') return n / 1e8;
-  return n;
+  if (unit.startsWith('兆')) return n * 1e12;
+  if (unit.startsWith('億')) return n * 1e8;
+  if (unit.startsWith('万')) return n * 1e4;
+  if (unit === '円') return n;
+  return n * 1e8; // 単位なし → 億円換算
 }
 
 function computeFocusPins(
@@ -563,19 +563,19 @@ export default function RealDataSankeyPage() {
   // Pre-filter exclusion set: built from filter conditions, applied before filterTopN
   const filterExcludedIds = useMemo(() => {
     if (!graphData) return null;
-    const minBudgetOku = parseAmountToOkuYen(filterMinBudgetText);
-    const maxBudgetOku = parseAmountToOkuYen(filterMaxBudgetText);
-    const minSpendingOku = parseAmountToOkuYen(filterMinSpendingText);
-    const maxSpendingOku = parseAmountToOkuYen(filterMaxSpendingText);
-    const hasBudget = minBudgetOku !== null || maxBudgetOku !== null;
-    const hasSpending = minSpendingOku !== null || maxSpendingOku !== null;
+    const minBudgetYen = parseAmountToYen(filterMinBudgetText);
+    const maxBudgetYen = parseAmountToYen(filterMaxBudgetText);
+    const minSpendingYen = parseAmountToYen(filterMinSpendingText);
+    const maxSpendingYen = parseAmountToYen(filterMaxSpendingText);
+    const hasBudget = minBudgetYen !== null || maxBudgetYen !== null;
+    const hasSpending = minSpendingYen !== null || maxSpendingYen !== null;
     const trimmedQuery = debouncedQuery.trim();
     const hasName = trimmedQuery.length >= 2;
     if (!hasBudget && !hasSpending && !hasName) return null;
-    const minBudgetYen = (minBudgetOku ?? 0) * 1e8;
-    const maxBudgetYen = maxBudgetOku !== null ? maxBudgetOku * 1e8 : Infinity;
-    const minSpendingYen = (minSpendingOku ?? 0) * 1e8;
-    const maxSpendingYen = maxSpendingOku !== null ? maxSpendingOku * 1e8 : Infinity;
+    const minBudget = minBudgetYen ?? 0;
+    const maxBudget = maxBudgetYen ?? Infinity;
+    const minSpending = minSpendingYen ?? 0;
+    const maxSpending = maxSpendingYen ?? Infinity;
     let nameRegex: RegExp | null = null;
     if (hasName && searchUseRegex) {
       try { nameRegex = new RegExp(trimmedQuery, 'i'); } catch { /* invalid regex */ }
@@ -589,12 +589,12 @@ export default function RealDataSankeyPage() {
       if (n.aggregated) continue;
       if (n.type === 'project-budget' && n.projectId != null) {
         const sn = spendingByPid.get(n.projectId);
-        const failBudget = hasBudget && (n.value < minBudgetYen || n.value > maxBudgetYen);
-        const failSpending = hasSpending && sn && (sn.value < minSpendingYen || sn.value > maxSpendingYen);
+        const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
+        const failSpending = hasSpending && sn && (sn.value < minSpending || sn.value > maxSpending);
         const failName = hasName && (filterTarget === 'project' || filterTarget === 'all') && !matchesName(n.name);
         if (failBudget || failSpending || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
-        const failSpending = hasSpending && (n.value < minSpendingYen || n.value > maxSpendingYen);
+        const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
         const failName = hasName && (filterTarget === 'recipient' || filterTarget === 'all') && !matchesName(n.name);
         if (failSpending || failName) excluded.add(n.id);
       }
@@ -2369,12 +2369,12 @@ export default function RealDataSankeyPage() {
                     <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>{label}</span>
                     <input type="text" value={minText} onChange={e => setMin(e.target.value)}
                       placeholder="下限"
-                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToOkuYen(minText) !== null || !minText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToYen(minText) !== null || !minText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
                     />
                     <span style={{ fontSize: 11, color: '#aaa', flexShrink: 0 }}>〜</span>
                     <input type="text" value={maxText} onChange={e => setMax(e.target.value)}
                       placeholder="上限"
-                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToOkuYen(maxText) !== null || !maxText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                      style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToYen(maxText) !== null || !maxText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
                     />
                     {(minText || maxText) && (
                       <button type="button" onClick={() => { setMin(''); setMax(''); }}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -33,6 +33,13 @@ interface SankeyUrlState {
   autoFocusRelated: boolean;
   year: '2024' | '2025';
   zoom?: number;
+  filterActive?: boolean;
+  filterTarget?: 'all' | 'project' | 'recipient';
+  filterNameQuery?: string;
+  filterMinBudgetText?: string;
+  filterMaxBudgetText?: string;
+  filterMinSpendingText?: string;
+  filterMaxSpendingText?: string;
 }
 
 function parseSearchParams(search: string): Partial<SankeyUrlState> {
@@ -58,6 +65,13 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const afr = p.get('afr'); if (afr !== null) result.autoFocusRelated = afr === '1';
   const yr = p.get('yr'); if (yr === '2024' || yr === '2025') result.year = yr;
   const z = p.get('z'); if (z !== null) { const n = parseFloat(z); if (!isNaN(n) && n >= 0.1 && n <= 10) result.zoom = n; }
+  const f = p.get('f'); if (f === '1') result.filterActive = true;
+  const nft = p.get('nft'); if (nft === 'p') result.filterTarget = 'project'; else if (nft === 'r') result.filterTarget = 'recipient'; else if (nft === 'a') result.filterTarget = 'all';
+  const nf = p.get('nf'); if (nf !== null) result.filterNameQuery = nf;
+  const fmb = p.get('fmb'); if (fmb !== null) result.filterMinBudgetText = fmb;
+  const fxb = p.get('fxb'); if (fxb !== null) result.filterMaxBudgetText = fxb;
+  const fms = p.get('fms'); if (fms !== null) result.filterMinSpendingText = fms;
+  const fxs = p.get('fxs'); if (fxs !== null) result.filterMaxSpendingText = fxs;
   return result;
 }
 
@@ -73,11 +87,6 @@ function mergedProjectPath(x0: number, nodeW: number, bH: number, sH: number): s
 }
 
 /** ノードID → フォーカスピン状態を導出する純粋ヘルパー */
-function formatOkuYen(okuYen: number): string {
-  if (okuYen >= 10000) return `${(okuYen / 10000 % 1 === 0 ? okuYen / 10000 : (okuYen / 10000).toFixed(1))}兆円`;
-  return `${okuYen.toLocaleString()}億円`;
-}
-
 function parseJapaneseNumeral(s: string): number {
   const d: Record<string, number> = { 一:1,二:2,三:3,四:4,五:5,六:6,七:7,八:8,九:9 };
   let result = 0, cur = 0;
@@ -265,6 +274,13 @@ export default function RealDataSankeyPage() {
     if (parsed.zoom !== undefined && parsed.selectedNodeId === undefined) {
       urlRestoredZoomRef.current = parsed.zoom;
     }
+    if (parsed.filterActive !== undefined) setFilterActive(parsed.filterActive);
+    if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget);
+    if (parsed.filterNameQuery !== undefined) { setSearchQuery(parsed.filterNameQuery); }
+    if (parsed.filterMinBudgetText !== undefined) setFilterMinBudgetText(parsed.filterMinBudgetText);
+    if (parsed.filterMaxBudgetText !== undefined) setFilterMaxBudgetText(parsed.filterMaxBudgetText);
+    if (parsed.filterMinSpendingText !== undefined) setFilterMinSpendingText(parsed.filterMinSpendingText);
+    if (parsed.filterMaxSpendingText !== undefined) setFilterMaxSpendingText(parsed.filterMaxSpendingText);
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-only init; state setters and refs are stable
   }, []);
 
@@ -295,6 +311,13 @@ export default function RealDataSankeyPage() {
       setFocusRelated(parsed.focusRelated ?? false);
       setAutoFocusRelated(parsed.autoFocusRelated ?? true);
       if (parsed.year !== undefined) setYear(parsed.year);
+      setFilterActive(parsed.filterActive ?? false);
+      if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget); else setFilterTarget('all');
+      setSearchQuery(parsed.filterNameQuery ?? '');
+      setFilterMinBudgetText(parsed.filterMinBudgetText ?? '');
+      setFilterMaxBudgetText(parsed.filterMaxBudgetText ?? '');
+      setFilterMinSpendingText(parsed.filterMinSpendingText ?? '');
+      setFilterMaxSpendingText(parsed.filterMaxSpendingText ?? '');
       if (parsed.selectedNodeId) pendingResetViewport.current = true;
     };
     window.addEventListener('popstate', handler);
@@ -326,6 +349,13 @@ export default function RealDataSankeyPage() {
     if (focusRelated) p.set('fr', '1');
     if (!autoFocusRelated) p.set('afr', '0');
     if (year !== '2025') p.set('yr', year);
+    if (filterActive) p.set('f', '1');
+    if (filterTarget !== 'all') p.set('nft', filterTarget === 'project' ? 'p' : 'r');
+    if (filterActive && searchQuery) p.set('nf', searchQuery);
+    if (filterMinBudgetText) p.set('fmb', filterMinBudgetText);
+    if (filterMaxBudgetText) p.set('fxb', filterMaxBudgetText);
+    if (filterMinSpendingText) p.set('fms', filterMinSpendingText);
+    if (filterMaxSpendingText) p.set('fxs', filterMaxSpendingText);
     const qs = p.toString();
     const url = qs ? `?${qs}` : window.location.pathname;
     if (action === 'push') {
@@ -333,7 +363,7 @@ export default function RealDataSankeyPage() {
     } else {
       window.history.replaceState(null, '', url);
     }
-  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year]);
+  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, includeZeroSpending, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -368,6 +398,22 @@ export default function RealDataSankeyPage() {
   }, [stopTopNRepeat]);
 
   // Reset both offsets when offsetTarget switches
+  // Reset offsets and sync URL when filter conditions change
+  const filterSigInitRef = useRef(false);
+  useEffect(() => {
+    if (!filterSigInitRef.current) { filterSigInitRef.current = true; return; }
+    pendingHistoryAction.current = 'replace';
+    setRecipientOffset(0);
+    setProjectOffset(0);
+  }, [filterActive, filterTarget, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery]);
+
+  // Sync URL when filter name query changes (separate from above to avoid double reset)
+  const filterQueryInitRef = useRef(false);
+  useEffect(() => {
+    if (!filterQueryInitRef.current) { filterQueryInitRef.current = true; return; }
+    pendingHistoryAction.current = 'replace';
+  }, [searchQuery]);
+
   const prevOffsetTargetRef = useRef(offsetTarget);
   useEffect(() => {
     if (prevOffsetTargetRef.current !== offsetTarget) {
@@ -580,7 +626,8 @@ export default function RealDataSankeyPage() {
     if (hasName && searchUseRegex) {
       try { nameRegex = new RegExp(trimmedQuery, 'i'); } catch { /* invalid regex */ }
     }
-    const matchesName = (name: string) => nameRegex ? nameRegex.test(name) : name.includes(trimmedQuery);
+    const trimmedQueryLower = trimmedQuery.toLocaleLowerCase();
+    const matchesName = (name: string) => nameRegex ? nameRegex.test(name) : name.toLocaleLowerCase().includes(trimmedQueryLower);
     const excluded = new Set<string>();
     const spendingByPid = new Map(
       graphData.nodes.filter(n => n.type === 'project-spending' && n.projectId != null).map(n => [n.projectId!, n])

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2223,7 +2223,7 @@ export default function RealDataSankeyPage() {
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
         {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
           <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: '8px 8px 0 0', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
             {/* Input row */}
@@ -2349,7 +2349,7 @@ export default function RealDataSankeyPage() {
                 title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
                 aria-pressed={showAmountSliders}
                 onClick={() => setShowAmountSliders(s => !s)}
-                style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 8px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+                style={{ alignSelf: 'flex-end', display: 'flex', alignItems: 'center', justifyContent: 'center', background: amountActive ? '#e8f0fe' : 'rgba(255,255,255,0.92)', border: `1px solid ${amountActive ? '#1a73e8' : '#e0e0e0'}`, borderTop: 'none', borderRadius: '0 0 8px 0', cursor: 'pointer', padding: '0 8px', marginTop: -1, userSelect: 'none' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill={amountActive ? '#1a73e8' : '#bbb'}>
                   <path d={showAmountSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -118,7 +118,7 @@ function parseAmountToYen(s: string): number | null {
   if (unit.startsWith('億')) return n * 1e8;
   if (unit.startsWith('万')) return n * 1e4;
   if (unit === '円') return n;
-  return n * 1e8; // 単位なし → 億円換算
+  return n; // 単位なし → 1円単位
 }
 
 function computeFocusPins(
@@ -2397,12 +2397,12 @@ export default function RealDataSankeyPage() {
                   <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                     <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>{label}</span>
                     <input type="text" value={minText} onChange={e => setMin(e.target.value)}
-                      placeholder="下限"
+                      placeholder="例: 100億、50万円"
                       style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToYen(minText) !== null || !minText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
                     />
                     <span style={{ fontSize: 11, color: '#aaa', flexShrink: 0 }}>〜</span>
                     <input type="text" value={maxText} onChange={e => setMax(e.target.value)}
-                      placeholder="上限"
+                      placeholder="例: 1兆、500億"
                       style={{ flex: 1, minWidth: 0, fontSize: 11, border: `1px solid ${parseAmountToYen(maxText) !== null || !maxText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
                     />
                     {(minText || maxText) && (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -585,6 +585,9 @@ export default function RealDataSankeyPage() {
     const spendingByPid = new Map(
       graphData.nodes.filter(n => n.type === 'project-spending' && n.projectId != null).map(n => [n.projectId!, n])
     );
+    const budgetByPid = new Map(
+      graphData.nodes.filter(n => n.type === 'project-budget' && n.projectId != null).map(n => [n.projectId!, n])
+    );
     for (const n of graphData.nodes) {
       if (n.aggregated) continue;
       if (n.type === 'project-budget' && n.projectId != null) {
@@ -597,6 +600,23 @@ export default function RealDataSankeyPage() {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
         const failName = hasName && (filterTarget === 'recipient' || filterTarget === 'all') && !matchesName(n.name);
         if (failSpending || failName) excluded.add(n.id);
+      }
+    }
+    // 支出先フィルタが有効な場合、残存支出先のない事業も除外する
+    // （filterTopNが予算額順に事業を選ぶため、小額支出先の事業が選ばれない問題を防ぐ）
+    const recipientFilterActive = hasSpending || (hasName && (filterTarget === 'recipient' || filterTarget === 'all'));
+    if (recipientFilterActive) {
+      const projectsWithSurvivingRecipients = new Set(
+        graphData.edges
+          .filter(e => e.target.startsWith('r-') && !excluded.has(e.target))
+          .map(e => e.source) // project-spending IDs
+      );
+      for (const [pid, sn] of spendingByPid) {
+        if (!excluded.has(sn.id) && !projectsWithSurvivingRecipients.has(sn.id)) {
+          excluded.add(sn.id);
+          const bn = budgetByPid.get(pid);
+          if (bn) excluded.add(bn.id);
+        }
       }
     }
     return excluded.size > 0 ? excluded : null;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -570,7 +570,7 @@ export default function RealDataSankeyPage() {
     const hasBudget = minBudgetYen !== null || maxBudgetYen !== null;
     const hasSpending = minSpendingYen !== null || maxSpendingYen !== null;
     const trimmedQuery = debouncedQuery.trim();
-    const hasName = filterActive && trimmedQuery.length >= 2;
+    const hasName = filterActive && trimmedQuery.length >= 1;
     if (!hasBudget && !hasSpending && !hasName) return null;
     const minBudget = minBudgetYen ?? 0;
     const maxBudget = maxBudgetYen ?? Infinity;
@@ -2383,7 +2383,7 @@ export default function RealDataSankeyPage() {
                     }
                   }
                 }}
-                placeholder={filterActive ? 'フィルタ(2文字以上)' : '検索(2文字以上/PID)'}
+                placeholder={filterActive ? 'フィルタ' : '検索(2文字以上/PID)'}
                 style={{
                   width: '100%', boxSizing: 'border-box',
                   paddingLeft: filterActive ? 90 : 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2342,7 +2342,7 @@ export default function RealDataSankeyPage() {
                     }
                   }
                 }}
-                placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
+                placeholder="検索(2文字以上/PID)"
                 style={{
                   width: '100%', boxSizing: 'border-box',
                   paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2225,7 +2225,7 @@ export default function RealDataSankeyPage() {
         {/* 検索セクション: input card（内部にsliders）+ toggle（TopNと同じ構造） */}
         <div style={{ flex: 1 }}>
           {/* Card: input + optional sliders（TopNのパネルdivに相当） */}
-          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+          <div style={{ background: 'rgba(255,255,255,0.95)', border: `1px solid ${searchRegexError ? '#e53935' : '#e0e0e0'}`, borderRadius: showAmountSliders ? '8px 8px 0 0' : 8, boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
             {/* Input row */}
             <div style={{ position: 'relative' }}>
               {/* Search icon */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -147,6 +147,7 @@ export default function RealDataSankeyPage() {
   const [searchPage, setSearchPage] = useState(0);
   // Filter feature
   const [filterActive, setFilterActive] = useState(false);
+  const [showAmountSliders, setShowAmountSliders] = useState(false);
   const [filterMinBudget, setFilterMinBudget] = useState(0);        // 億円; 0 = no min
   const [filterMaxBudget, setFilterMaxBudget] = useState<number | null>(null); // null = no max
   const [filterMinSpending, setFilterMinSpending] = useState(0);    // 億円; 0 = no min
@@ -517,11 +518,11 @@ export default function RealDataSankeyPage() {
 
   // Pre-filter exclusion set: built from filter conditions, applied before filterTopN
   const filterExcludedIds = useMemo(() => {
-    if (!filterActive || !graphData) return null;
+    if (!graphData) return null;
     const hasBudget = filterMinBudget > 0 || filterMaxBudget !== null;
     const hasSpending = filterMinSpending > 0 || filterMaxSpending !== null;
     const trimmedQuery = debouncedQuery.trim();
-    const hasName = trimmedQuery.length >= 2;
+    const hasName = filterActive && trimmedQuery.length >= 2;
     if (!hasBudget && !hasSpending && !hasName) return null;
     const minBudgetYen = filterMinBudget * 1e8;
     const maxBudgetYen = filterMaxBudget !== null ? filterMaxBudget * 1e8 : Infinity;
@@ -2306,10 +2307,23 @@ export default function RealDataSankeyPage() {
             <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
           </svg>
         </button>
+        {/* 金額スライダー表示トグルボタン */}
+        <button
+          type="button"
+          title={showAmountSliders ? '金額フィルタ を隠す' : '金額フィルタ を表示'}
+          aria-pressed={showAmountSliders}
+          onClick={() => setShowAmountSliders(s => !s)}
+          style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${(filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: (filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
+        >
+          {/* Material Icons: tune */}
+          <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill={(filterMinBudget > 0 || filterMaxBudget !== null || filterMinSpending > 0 || filterMaxSpending !== null) ? '#1a73e8' : '#888'}>
+            <path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"/>
+          </svg>
+        </button>
         </div>{/* end Row 1 flex */}
 
-        {/* Row 2: フィルタパネル（filterActive=true のとき表示） */}
-        {filterActive && (
+        {/* Row 2: 金額フィルタパネル（showAmountSliders=true のとき表示） */}
+        {showAmountSliders && (
           <div style={{ marginTop: 4, background: 'rgba(255,255,255,0.97)', border: `1px solid #c5d8f8`, borderRadius: 8, padding: '10px 12px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)', display: 'flex', flexDirection: 'column', gap: 10 }}>
             {/* ── 予算フィルタ ── */}
             {[

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -602,14 +602,12 @@ export default function RealDataSankeyPage() {
         if (failSpending || failName) excluded.add(n.id);
       }
     }
-    // 支出先フィルタが有効な場合、残存支出先のない事業も除外する
-    // （filterTopNが予算額順に事業を選ぶため、小額支出先の事業が選ばれない問題を防ぐ）
-    const recipientFilterActive = hasSpending || (hasName && (filterTarget === 'recipient' || filterTarget === 'all'));
-    if (recipientFilterActive) {
+    // Pass 2: 支出先フィルタが有効な場合、残存支出先のない事業を除外（recipient → project のカスケード）
+    if (hasSpending || (hasName && (filterTarget === 'recipient' || filterTarget === 'all'))) {
       const projectsWithSurvivingRecipients = new Set(
         graphData.edges
           .filter(e => e.target.startsWith('r-') && !excluded.has(e.target))
-          .map(e => e.source) // project-spending IDs
+          .map(e => e.source)
       );
       for (const [pid, sn] of spendingByPid) {
         if (!excluded.has(sn.id) && !projectsWithSurvivingRecipients.has(sn.id)) {
@@ -617,6 +615,17 @@ export default function RealDataSankeyPage() {
           const bn = budgetByPid.get(pid);
           if (bn) excluded.add(bn.id);
         }
+      }
+    }
+    // Pass 3: 残存事業のない省庁を除外（project → ministry のカスケード）
+    const ministriesWithSurvivingProjects = new Set(
+      graphData.edges
+        .filter(e => !excluded.has(e.source) && !excluded.has(e.target) && e.target.startsWith('project-budget-'))
+        .map(e => e.source)
+    );
+    for (const n of graphData.nodes) {
+      if (n.type === 'ministry' && !n.aggregated && !excluded.has(n.id)) {
+        if (!ministriesWithSurvivingProjects.has(n.id)) excluded.add(n.id);
       }
     }
     return excluded.size > 0 ? excluded : null;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -520,11 +520,17 @@ export default function RealDataSankeyPage() {
     if (!filterActive || !graphData) return null;
     const hasBudget = filterMinBudget > 0 || filterMaxBudget !== null;
     const hasSpending = filterMinSpending > 0 || filterMaxSpending !== null;
-    if (!hasBudget && !hasSpending) return null;
+    const trimmedQuery = debouncedQuery.trim();
+    const hasName = trimmedQuery.length >= 2;
+    if (!hasBudget && !hasSpending && !hasName) return null;
     const minBudgetYen = filterMinBudget * 1e8;
     const maxBudgetYen = filterMaxBudget !== null ? filterMaxBudget * 1e8 : Infinity;
     const minSpendingYen = filterMinSpending * 1e8;
     const maxSpendingYen = filterMaxSpending !== null ? filterMaxSpending * 1e8 : Infinity;
+    let nameRegex: RegExp | null = null;
+    if (hasName && searchUseRegex) {
+      try { nameRegex = new RegExp(trimmedQuery, 'i'); } catch { /* invalid regex — treat as no name filter */ }
+    }
     const excluded = new Set<string>();
     const spendingByPid = new Map(
       graphData.nodes.filter(n => n.type === 'project-spending' && n.projectId != null).map(n => [n.projectId!, n])
@@ -537,11 +543,13 @@ export default function RealDataSankeyPage() {
         const failSpending = hasSpending && sn && (sn.value < minSpendingYen || sn.value > maxSpendingYen);
         if (failBudget || failSpending) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
-        if (hasSpending && (n.value < minSpendingYen || n.value > maxSpendingYen)) excluded.add(n.id);
+        const failSpending = hasSpending && (n.value < minSpendingYen || n.value > maxSpendingYen);
+        const failName = hasName && (nameRegex ? !nameRegex.test(n.name) : !n.name.includes(trimmedQuery));
+        if (failSpending || failName) excluded.add(n.id);
       }
     }
     return excluded.size > 0 ? excluded : null;
-  }, [graphData, filterActive, filterMinBudget, filterMaxBudget, filterMinSpending, filterMaxSpending]);
+  }, [graphData, filterActive, filterMinBudget, filterMaxBudget, filterMinSpending, filterMaxSpending, debouncedQuery, searchUseRegex]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -2223,7 +2231,7 @@ export default function RealDataSankeyPage() {
             ref={searchInputRef}
             type="text"
             value={searchQuery}
-            onChange={e => { setSearchQuery(e.target.value); setShowSearchResults(true); setSearchCursorIndex(-1); }}
+            onChange={e => { setSearchQuery(e.target.value); if (!filterActive) setShowSearchResults(true); setSearchCursorIndex(-1); }}
             onFocus={() => { const q = debouncedQuery.trim(); if (meetsSearchMinLength(q)) setShowSearchResults(true); }}
             onKeyDown={e => {
               if (e.key === 'Escape') { setShowSearchResults(false); setSearchQuery(''); setDebouncedQuery(''); setSearchCursorIndex(-1); return; }
@@ -2250,7 +2258,7 @@ export default function RealDataSankeyPage() {
                 }
               }
             }}
-            placeholder="ノード検索（2文字以上／PIDは1文字〜）"
+            placeholder={filterActive ? '支出先名フィルタ（2文字以上）' : 'ノード検索（2文字以上／PIDは1文字〜）'}
             style={{
               width: '100%', boxSizing: 'border-box',
               paddingLeft: 30, paddingRight: searchQuery ? 54 : 34, paddingTop: 7, paddingBottom: 7,
@@ -2288,7 +2296,7 @@ export default function RealDataSankeyPage() {
         {/* フィルタアイコンボタン */}
         <button
           type="button"
-          title={filterActive ? 'フィルタ ON（クリックでOFF）' : 'フィルタ OFF（クリックでON）'}
+          title={filterActive ? 'フィルタモード（クリックで検索モードに切替）' : '検索モード（クリックでフィルタモードに切替）'}
           aria-pressed={filterActive}
           onClick={() => setFilterActive(f => !f)}
           style={{ flexShrink: 0, width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${filterActive ? '#1a73e8' : '#e0e0e0'}`, borderRadius: 8, background: filterActive ? '#e8f0fe' : 'rgba(255,255,255,0.95)', cursor: 'pointer', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}
@@ -2300,22 +2308,7 @@ export default function RealDataSankeyPage() {
         </button>
         </div>{/* end Row 1 flex */}
 
-        {/* Row 2: TopN設定 表示トグルボタン */}
-        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 3 }}>
-          <button
-            type="button"
-            onClick={() => setShowTopNSliders(s => !s)}
-            title={showTopNSliders ? 'TopN・オフセット設定 を隠す' : 'TopN・オフセット設定 を表示'}
-            style={{ display: 'flex', alignItems: 'center', gap: 3, background: 'rgba(255,255,255,0.92)', border: '1px solid #e0e0e0', borderRadius: 6, cursor: 'pointer', padding: '2px 7px', fontSize: 11, color: '#666', userSelect: 'none', boxShadow: '0 1px 3px rgba(0,0,0,0.07)' }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#999">
-              <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
-            </svg>
-            TopN・オフセット
-          </button>
-        </div>
-
-        {/* Row 3: フィルタパネル（filterActive=true のとき表示） */}
+        {/* Row 2: フィルタパネル（filterActive=true のとき表示） */}
         {filterActive && (
           <div style={{ marginTop: 4, background: 'rgba(255,255,255,0.97)', border: `1px solid #c5d8f8`, borderRadius: 8, padding: '10px 12px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)', display: 'flex', flexDirection: 'column', gap: 10 }}>
             {/* ── 予算フィルタ ── */}
@@ -2361,7 +2354,7 @@ export default function RealDataSankeyPage() {
         )}
 
         {/* Dropdown */}
-        {showSearchResults && searchResults.length > 0 && (
+        {!filterActive && showSearchResults && searchResults.length > 0 && (
           <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', zIndex: 20 }}>
             {/* Count header */}
             <div style={{ padding: '5px 10px', fontSize: 11, color: '#999', borderBottom: '1px solid #f0f0f0' }}>
@@ -2397,7 +2390,7 @@ export default function RealDataSankeyPage() {
           </div>
         )}
         {/* No results */}
-        {showSearchResults && meetsSearchMinLength(debouncedQuery.trim()) && searchResults.length === 0 && (
+        {!filterActive && showSearchResults && meetsSearchMinLength(debouncedQuery.trim()) && searchResults.length === 0 && (
           <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 4, background: '#fff', border: '1px solid #e0e0e0', borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', padding: '10px 12px', fontSize: 12, color: '#999', zIndex: 20 }}>
             該当なし
           </div>

--- a/docs/tasks/20260425_1606_sankey-svg検索フィルタ機能設計.md
+++ b/docs/tasks/20260425_1606_sankey-svg検索フィルタ機能設計.md
@@ -45,7 +45,7 @@
 
 ### レイヤー変更範囲
 
-```
+```text
 app/lib/sankey-svg-filter.ts   ← filterTopN の引数拡張（コアロジック）
 app/sankey-svg/page.tsx        ← 状態管理・UI
 ```
@@ -69,7 +69,7 @@ valueFilter?: {
 
 ### filterTopN 内部処理
 
-```
+```text
 1. allNodes を受け取る
 2. nameFilter が設定されていれば、該当タイプのノードを名前でフィルタ（matchしないノードをexcludedSetに追加）
 3. valueFilter が設定されていれば、project-budget/project-spending/recipientのvalueでフィルタ（同様にexcludedSetに追加）
@@ -112,7 +112,7 @@ const [filterMaxSpending, setFilterMaxSpending] = useState<number | null>(null);
 
 **実装方針**: 既存の検索ボックスにモード切り替えを追加する。
 
-```
+```text
 [ 🔍 / 🔽 ] [ ___検索・フィルタ文字列___ ] [×]
               ↑ アイコンクリックで search/filter モード切り替え
 ```
@@ -126,7 +126,7 @@ const [filterMaxSpending, setFilterMaxSpending] = useState<number | null>(null);
 
 設定パネル（⚙ ギアアイコン）内に追加する。
 
-```
+```text
 ─────────────────────────
 金額フィルタ
   予算:  [ 下限: ___億円 ] 〜 [ 上限: ___億円 ]

--- a/docs/tasks/20260425_1606_sankey-svg検索フィルタ機能設計.md
+++ b/docs/tasks/20260425_1606_sankey-svg検索フィルタ機能設計.md
@@ -1,0 +1,157 @@
+# sankey-svg 検索フィルタ機能 設計
+
+## 目的
+
+ユーザーが大量のノード（5,000事業・26,000支出先）の中から関心のあるノードだけを絞り込めるようにして、目的のノードに素早く到達できるようになるため。
+
+---
+
+## 現状の検索機能との差異
+
+| 機能 | 現在の検索 | 今回設計するフィルタ |
+|------|-----------|------------------|
+| 動作 | 名前に一致するノードを一覧表示し、クリックでジャンプ | Sankey図のレイアウト自体を絞り込む |
+| 結果 | ドロップダウンパネルに表示 | 図の中に直接反映される |
+| 表示ノード数 | 全ノードが図に残る | 条件を満たすノードのみが図に残る |
+
+---
+
+## 機能スコープ
+
+### Feature 1: 名前フィルタ
+
+入力した文字列に名前が一致するノードのみをレイアウトに含める。
+
+- 対象ノードタイプ: 府省庁 / 事業 / 支出先（全タイプ同時、または個別タイプ選択）
+- マッチ方式: 部分一致（既存の検索と同じ）
+- PID直接指定も対応（既存の検索ロジックを流用）
+
+**動作の定義（重要）**: フィルタは `filterTopN` への「候補プール制限」として機能する。マッチしないノードはTopN選択の候補から除外され、マッチするノードが優先的にTopNに入る。集計ノード（「その他の支出先」等）はフィルタ対象外（常に表示）。
+
+### Feature 2: 金額フィルタ
+
+予算額・支出額の最小値/最大値でノードを絞り込む。
+
+対象:
+- **事業**: 予算額下限 / 予算額上限（project-budget の value）
+- **事業**: 支出額下限 / 支出額上限（project-spending の value）
+- **支出先**: 支出額下限 / 支出額上限（recipient の value）
+
+単位: 円（UIでは「億円」表示、内部計算は1円単位のまま）
+
+---
+
+## アーキテクチャ
+
+### レイヤー変更範囲
+
+```
+app/lib/sankey-svg-filter.ts   ← filterTopN の引数拡張（コアロジック）
+app/sankey-svg/page.tsx        ← 状態管理・UI
+```
+
+### filterTopN 引数拡張
+
+```typescript
+// 新規追加パラメータ
+nameFilter?: {
+  query: string;          // 検索文字列
+  types: NodeFilterType[]; // 対象タイプ ('ministry'|'project'|'recipient'|'all')
+  useRegex?: boolean;
+}
+valueFilter?: {
+  minBudget?: number;    // 予算下限（円）
+  maxBudget?: number;    // 予算上限（円）
+  minSpending?: number;  // 支出下限（円）
+  maxSpending?: number;  // 支出上限（円）
+}
+```
+
+### filterTopN 内部処理
+
+```
+1. allNodes を受け取る
+2. nameFilter が設定されていれば、該当タイプのノードを名前でフィルタ（matchしないノードをexcludedSetに追加）
+3. valueFilter が設定されていれば、project-budget/project-spending/recipientのvalueでフィルタ（同様にexcludedSetに追加）
+4. 既存のTopN選択ロジックは excludedSet を避けるように動作する（includeZeroSpending の除外ロジックと同じパターン）
+5. 集計ノード（aggregated=true）は excludedSet から免除
+```
+
+**既存の除外ロジックとの統合**: 現在 `zeroSpendingProjectIds` / `zeroSpendingBudgetIds` で行っているパターンを参考に、`filterExcludedIds` セットとして統合する。
+
+### 状態管理（page.tsx）
+
+```typescript
+// 名前フィルタ
+const [nameFilterQuery, setNameFilterQuery] = useState('');
+const [nameFilterTypes, setNameFilterTypes] = useState<NodeFilterType>('all');
+
+// 金額フィルタ
+const [filterMinBudget, setFilterMinBudget] = useState<number | null>(null);
+const [filterMaxBudget, setFilterMaxBudget] = useState<number | null>(null);
+const [filterMinSpending, setFilterMinSpending] = useState<number | null>(null);
+const [filterMaxSpending, setFilterMaxSpending] = useState<number | null>(null);
+```
+
+### URL パラメータ
+
+| パラメータ | 値の例 | 意味 |
+|-----------|--------|------|
+| `nf` | `北海道` | 名前フィルタ文字列 |
+| `nft` | `r` / `p` / `m` / `a` | 対象タイプ（recipient/project/ministry/all） |
+| `fmb` | `1000000000` | 予算下限（円） |
+| `fxb` | `5000000000` | 予算上限（円） |
+| `fms` | `100000000` | 支出下限（円） |
+| `fxs` | `500000000` | 支出上限（円） |
+
+---
+
+## UI 設計
+
+### 名前フィルタ
+
+**実装方針**: 既存の検索ボックスにモード切り替えを追加する。
+
+```
+[ 🔍 / 🔽 ] [ ___検索・フィルタ文字列___ ] [×]
+              ↑ アイコンクリックで search/filter モード切り替え
+```
+
+- `search` モード（現行）: 入力するとドロップダウン結果一覧が表示され、クリックでジャンプ
+- `filter` モード（新規）: 入力した文字列で図をリアルタイムフィルタ。ドロップダウンは表示しない
+
+フィルタアクティブ状態のインジケータ: 検索ボックスの枠色を変える（例: 青枠）
+
+### 金額フィルタ
+
+設定パネル（⚙ ギアアイコン）内に追加する。
+
+```
+─────────────────────────
+金額フィルタ
+  予算:  [ 下限: ___億円 ] 〜 [ 上限: ___億円 ]
+  支出:  [ 下限: ___億円 ] 〜 [ 上限: ___億円 ]
+─────────────────────────
+```
+
+入力単位は「億円」（内部は円に変換）。空欄 = 制限なし。フィルタ適用中はパネルヘッダーにインジケータを表示。
+
+---
+
+## 既存機能との相互作用
+
+| 既存機能 | フィルタとの組み合わせ |
+|---------|-------------------|
+| focusRelated（関連ノードのみ表示） | フィルタ適用後の候補プールに対してfocusRelatedが動作する |
+| offset（スクロール） | フィルタ後の候補プールでランキングが再計算されるため、offsetは0にリセットする |
+| pinnedProjectId | ピン留め事業はフィルタ除外対象から免除する（現在のzeroSpending pinと同じ扱い） |
+| aggregated node | フィルタ除外対象から免除（常に表示） |
+| autoFocusRelated | フィルタ適用後に残ったノードに対して通常通り動作 |
+
+---
+
+## 整合性チェック
+
+- `app/lib/sankey-svg-filter.ts`: Pure logic のみ（HTTP・React なし）✅
+- `app/sankey-svg/page.tsx`: 状態管理・UI のみ ✅
+- `scripts/`: 変更なし ✅


### PR DESCRIPTION
## 目的

ユーザーが5,000事業・26,000支出先の中から予算や支出金額の条件で素早く絞り込めるようになるため。

## 変更内容

### 新機能: フィルタパネル
- 検索ボックス右隣に **フィルタアイコンボタン**（filter_list）を追加
- ボタンをクリックするとフィルタパネルが展開し、以下のスライダーが表示される：
  - **予算 下限/上限** レンジスライダー（億円単位）
  - **支出 下限/上限** レンジスライダー（億円単位）
- スライダーがデータの最大値の場合は「制限なし」と表示
- 各カテゴリに個別リセットボタン

### 新機能: TopN・オフセット設定トグルボタン
- 検索ボックス下に **「TopN・オフセット」トグルボタン** を追加
- 右上のTopN設定パネルの表示/非表示を切り替える

### 内部実装
- `filterExcludedIds` useMemo: フィルタ条件から除外ノードIDセットを計算
- `filtered` useMemo: `filterTopN` 呼び出し前にノード/エッジを pre-filter（第一段階抽出）
- 既存の focusRelated・offset・pinnedProject などの機能はそのまま動作
- 設計ドキュメント: `docs/tasks/20260425_1606_sankey-svg検索フィルタ機能設計.md`

## テスト方法

```bash
npm run dev
```

1. `localhost:3002/sankey-svg` を開く
2. 検索ボックス右の `≡` アイコンをクリック → フィルタパネルが展開
3. 予算下限スライダーを右に動かす → 小さな事業が消えることを確認
4. 支出上限スライダーを左に動かす → 大きな支出先が消えることを確認
5. フィルタONのまま focusRelated・offset などが正常動作することを確認
6. 検索ボックス下の「TopN・オフセット」ボタンで右上パネルが開閉することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added name- and amount-driven filtering with target selector (projects/recipients/all) and optional regex matching
  * Collapsible budget/spending panel with min/max sliders, reset controls, and updated wider filter layout
  * Filter toggle icon; search dropdown/no-results hidden while filter mode is active
  * Minor TopN toggle styling tweaks

* **Documentation**
  * Added specification for the Sankey search/filter capability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->