### PR TITLE
feat: 府省庁フィルタ複数選択・検索結果への反映

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -36,7 +36,7 @@ interface SankeyUrlState {
   filterActive?: boolean;
   filterTarget?: 'project' | 'recipient';
   filterNameQuery?: string;
-  filterMinistryName?: string;
+  filterMinistryNames?: string[];
   filterMinBudgetText?: string;
   filterMaxBudgetText?: string;
   filterMinSpendingText?: string;
@@ -68,7 +68,7 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const f = p.get('f'); if (f === '1') result.filterActive = true;
   const nft = p.get('nft'); if (nft === 'p') result.filterTarget = 'project'; else if (nft === 'r') result.filterTarget = 'recipient';
   const nf = p.get('nf'); if (nf !== null) result.filterNameQuery = nf;
-  const fm = p.get('fm'); if (fm !== null) result.filterMinistryName = fm;
+  const fm = p.get('fm'); if (fm !== null) result.filterMinistryNames = fm ? fm.split(',') : [];
   const fmb = p.get('fmb'); if (fmb !== null) result.filterMinBudgetText = fmb;
   const fxb = p.get('fxb'); if (fxb !== null) result.filterMaxBudgetText = fxb;
   const fms = p.get('fms'); if (fms !== null) result.filterMinSpendingText = fms;
@@ -203,7 +203,9 @@ export default function RealDataSankeyPage() {
   const [filterActive, setFilterActive] = useState(false);
   const [showAmountSliders, setShowAmountSliders] = useState(false);
   const [filterTarget, setFilterTarget] = useState<'project' | 'recipient'>('recipient');
-  const [filterMinistryName, setFilterMinistryName] = useState('');
+  const [filterMinistryNames, setFilterMinistryNames] = useState<string[]>([]);
+  const [showMinistryDropdown, setShowMinistryDropdown] = useState(false);
+  const ministryDropdownRef = useRef<HTMLDivElement>(null);
   const [filterMinBudgetText, setFilterMinBudgetText] = useState('');
   const [filterMaxBudgetText, setFilterMaxBudgetText] = useState('');
   const [filterMinSpendingText, setFilterMinSpendingText] = useState('');
@@ -277,7 +279,7 @@ export default function RealDataSankeyPage() {
     if (parsed.filterActive !== undefined) setFilterActive(parsed.filterActive);
     if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget);
     if (parsed.filterNameQuery !== undefined) { setSearchQuery(parsed.filterNameQuery); }
-    if (parsed.filterMinistryName !== undefined) setFilterMinistryName(parsed.filterMinistryName);
+    if (parsed.filterMinistryNames !== undefined) setFilterMinistryNames(parsed.filterMinistryNames);
     if (parsed.filterMinBudgetText !== undefined) setFilterMinBudgetText(parsed.filterMinBudgetText);
     if (parsed.filterMaxBudgetText !== undefined) setFilterMaxBudgetText(parsed.filterMaxBudgetText);
     if (parsed.filterMinSpendingText !== undefined) setFilterMinSpendingText(parsed.filterMinSpendingText);
@@ -314,7 +316,7 @@ export default function RealDataSankeyPage() {
       setFilterActive(parsed.filterActive ?? false);
       if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget); else setFilterTarget('recipient');
       setSearchQuery(parsed.filterNameQuery ?? '');
-      setFilterMinistryName(parsed.filterMinistryName ?? '');
+      setFilterMinistryNames(parsed.filterMinistryNames ?? []);
       setFilterMinBudgetText(parsed.filterMinBudgetText ?? '');
       setFilterMaxBudgetText(parsed.filterMaxBudgetText ?? '');
       setFilterMinSpendingText(parsed.filterMinSpendingText ?? '');
@@ -352,7 +354,7 @@ export default function RealDataSankeyPage() {
     if (filterActive) p.set('f', '1');
     if (filterTarget === 'project') p.set('nft', 'p');
     if (filterActive && searchQuery) p.set('nf', searchQuery);
-    if (filterMinistryName) p.set('fm', filterMinistryName);
+    if (filterMinistryNames.length > 0) p.set('fm', filterMinistryNames.join(','));
     if (filterMinBudgetText) p.set('fmb', filterMinBudgetText);
     if (filterMaxBudgetText) p.set('fxb', filterMaxBudgetText);
     if (filterMinSpendingText) p.set('fms', filterMinSpendingText);
@@ -364,7 +366,7 @@ export default function RealDataSankeyPage() {
     } else {
       window.history.replaceState(null, '', url);
     }
-  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, filterMinistryName, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText]);
+  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, filterMinistryNames, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -373,6 +375,16 @@ export default function RealDataSankeyPage() {
   const [zoom, setZoom] = useState(1);
   // Keep zoomRef current for use in debounce timeouts
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
+  useEffect(() => {
+    if (!showMinistryDropdown) return;
+    const handler = (e: MouseEvent) => {
+      if (ministryDropdownRef.current && !ministryDropdownRef.current.contains(e.target as Node)) {
+        setShowMinistryDropdown(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showMinistryDropdown]);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef({ x: 0, y: 0 });
@@ -656,7 +668,7 @@ export default function RealDataSankeyPage() {
     const hasSpending = minSpendingYen !== null || maxSpendingYen !== null;
     const trimmedQuery = debouncedQuery.trim();
     const hasName = filterActive && trimmedQuery.length >= 1;
-    const hasMinistry = !!filterMinistryName;
+    const hasMinistry = filterMinistryNames.length > 0;
     if (!hasBudget && !hasSpending && !hasName && !hasMinistry) return null;
     const minBudget = minBudgetYen ?? -Infinity;
     const maxBudget = maxBudgetYen ?? Infinity;
@@ -678,7 +690,7 @@ export default function RealDataSankeyPage() {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
         const failName = hasName && filterTarget === 'project' && !matchesName(n.name);
-        const failMinistry = hasMinistry && n.ministry !== filterMinistryName;
+        const failMinistry = hasMinistry && !filterMinistryNames.includes(n.ministry ?? '');
         if (failBudget || failName || failMinistry) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
@@ -725,7 +737,7 @@ export default function RealDataSankeyPage() {
       }
     }
     return excluded.size > 0 ? excluded : null;
-  }, [graphData, filterActive, filterTarget, filterMinistryName, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery, searchUseRegex]);
+  }, [graphData, filterActive, filterTarget, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery, searchUseRegex]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -2487,24 +2499,46 @@ export default function RealDataSankeyPage() {
             {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showAmountSliders && (
               <div style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {/* 府省庁フィルタ */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                  <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>省庁</span>
-                  <select
-                    value={filterMinistryName}
-                    onChange={e => { pendingHistoryAction.current = 'replace'; setFilterMinistryName(e.target.value); }}
-                    style={{ flex: 1, minWidth: 0, fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: filterMinistryName ? '#333' : '#aaa', outline: 'none', cursor: 'pointer' }}
-                  >
-                    <option value="">全府省庁</option>
-                    {graphData?.nodes.filter(n => n.type === 'ministry').sort((a, b) => a.name.localeCompare(b.name, 'ja')).map(n => (
-                      <option key={n.id} value={n.name}>{n.name}</option>
-                    ))}
-                  </select>
-                  {filterMinistryName && (
-                    <button type="button" onClick={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryName(''); }}
-                      style={{ fontSize: 10, color: '#aaa', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px', flexShrink: 0 }}>×</button>
-                  )}
-                </div>
+                {/* 府省庁フィルタ（複数選択ドロップダウン） */}
+                {(() => {
+                  const ministryNodes = (graphData?.nodes ?? []).filter(n => n.type === 'ministry').sort((a, b) => b.value - a.value);
+                  const allSelected = filterMinistryNames.length === 0;
+                  const label = allSelected ? '全府省庁' : filterMinistryNames.length === 1 ? filterMinistryNames[0] : `選択中 (${filterMinistryNames.length}/${ministryNodes.length})`;
+                  return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }} ref={ministryDropdownRef}>
+                      <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>省庁</span>
+                      <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
+                        <button type="button"
+                          onClick={() => setShowMinistryDropdown(v => !v)}
+                          style={{ width: '100%', fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '3px 20px 3px 5px', background: '#fafafa', color: allSelected ? '#aaa' : '#333', outline: 'none', cursor: 'pointer', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        >{label}</button>
+                        <span style={{ position: 'absolute', right: 5, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', fontSize: 10, color: '#aaa' }}>{showMinistryDropdown ? '▲' : '▼'}</span>
+                        {showMinistryDropdown && (
+                          <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 50, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 220, overflowY: 'auto', marginTop: 2 }}
+                            onMouseDown={e => e.stopPropagation()}>
+                            <label style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', cursor: 'pointer', borderBottom: '1px solid #f0f0f0', fontWeight: 600 }}>
+                              <input type="checkbox" checked={allSelected} onChange={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames([]); }} style={{ width: 12, height: 12 }} />
+                              <span style={{ fontSize: 11, color: '#333' }}>すべて選択/解除</span>
+                            </label>
+                            {ministryNodes.map(n => (
+                              <label key={n.id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', cursor: 'pointer' }}>
+                                <input type="checkbox"
+                                  checked={!allSelected && filterMinistryNames.includes(n.name)}
+                                  onChange={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames(prev => prev.includes(n.name) ? prev.filter(m => m !== n.name) : [...prev, n.name]); }}
+                                  style={{ width: 12, height: 12 }} />
+                                <span style={{ fontSize: 11, color: '#333' }}>{n.name}</span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      {!allSelected && (
+                        <button type="button" onClick={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames([]); }}
+                          style={{ fontSize: 10, color: '#aaa', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px', flexShrink: 0 }}>×</button>
+                      )}
+                    </div>
+                  );
+                })()}
                 {/* 予算・支出 テキスト入力 */}
                 {([
                   { label: '予算', minText: filterMinBudgetText, maxText: filterMaxBudgetText, setMin: setFilterMinBudgetText, setMax: setFilterMaxBudgetText },

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1376,7 +1376,7 @@ export default function RealDataSankeyPage() {
     const hasMinistryFilter = filterMinistryNames.length > 0;
     for (const n of graphData.nodes) {
       if (n.type === 'project-budget') continue; // merged into project-spending entry
-      if (hasMinistryFilter && n.ministry != null && !filterMinistryNames.includes(n.ministry)) continue;
+      if (hasMinistryFilter && (n.ministry == null || !filterMinistryNames.includes(n.ministry))) continue;
       if (pidQuery !== null) {
         if (n.type === 'project-spending' && n.projectId === pidQuery) {
           const bv = budgetNodeByPid.get(n.projectId)?.value ?? 0;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -701,8 +701,8 @@ export default function RealDataSankeyPage() {
         if (failSpending || failName) excluded.add(n.id);
       }
     }
-    // Pass 2: 支出先フィルタが有効な場合、残存支出先のない事業を除外（recipient → project のカスケード）
-    if (hasSpending || (hasName && filterTarget === 'recipient')) {
+    // Pass 2: 支出先・予算フィルタが有効な場合、残存支出先のない事業／孤立支出先を除外
+    if (hasSpending || hasBudget || hasMinistry || (hasName && filterTarget === 'recipient')) {
       const projectsWithSurvivingRecipients = new Set(
         graphData.edges
           .filter(e => e.target.startsWith('r-') && !excluded.has(e.target))

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -69,7 +69,7 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const f = p.get('f'); if (f === '1') result.filterActive = true;
   const nft = p.get('nft'); if (nft === 'p') result.filterTarget = 'project'; else if (nft === 'r') result.filterTarget = 'recipient';
   const nf = p.get('nf'); if (nf !== null) result.filterNameQuery = nf;
-  const fm = p.get('fm'); if (fm !== null) result.filterMinistryNames = fm ? fm.split(',') : [];
+  const fm = p.getAll('fm'); if (fm.length > 0) result.filterMinistryNames = Array.from(new Set(fm.map(v => v.trim()).filter(Boolean)));
   const fmb = p.get('fmb'); if (fmb !== null) result.filterMinBudgetText = fmb;
   const fxb = p.get('fxb'); if (fxb !== null) result.filterMaxBudgetText = fxb;
   const fms = p.get('fms'); if (fms !== null) result.filterMinSpendingText = fms;
@@ -357,7 +357,7 @@ export default function RealDataSankeyPage() {
     if (filterActive) p.set('f', '1');
     if (filterTarget === 'project') p.set('nft', 'p');
     if (filterActive && searchQuery) p.set('nf', searchQuery);
-    if (filterMinistryNames.length > 0) p.set('fm', filterMinistryNames.join(','));
+    for (const name of filterMinistryNames) p.append('fm', name);
     if (filterMinBudgetText) p.set('fmb', filterMinBudgetText);
     if (filterMaxBudgetText) p.set('fxb', filterMaxBudgetText);
     if (filterMinSpendingText) p.set('fms', filterMinSpendingText);
@@ -380,13 +380,25 @@ export default function RealDataSankeyPage() {
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
   useEffect(() => {
     if (!showMinistryDropdown) return;
-    const handler = (e: MouseEvent) => {
+    const onMouseDown = (e: MouseEvent) => {
       if (ministryDropdownRef.current && !ministryDropdownRef.current.contains(e.target as Node)) {
         setShowMinistryDropdown(false);
       }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    const recompute = () => {
+      if (ministryButtonRef.current) {
+        const r = ministryButtonRef.current.getBoundingClientRect();
+        setMinistryDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width, maxHeight: Math.max(120, window.innerHeight - r.bottom - 16) });
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('resize', recompute);
+    window.addEventListener('scroll', recompute, true);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('resize', recompute);
+      window.removeEventListener('scroll', recompute, true);
+    };
   }, [showMinistryDropdown]);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
@@ -673,6 +685,7 @@ export default function RealDataSankeyPage() {
     const hasName = filterActive && trimmedQuery.length >= 1;
     const hasMinistry = filterMinistryNames.length > 0;
     if (!hasBudget && !hasSpending && !hasName && !hasMinistry) return null;
+    const selectedMinistrySet = new Set(filterMinistryNames);
     const minBudget = minBudgetYen ?? -Infinity;
     const maxBudget = maxBudgetYen ?? Infinity;
     const minSpending = minSpendingYen ?? 0;
@@ -693,7 +706,7 @@ export default function RealDataSankeyPage() {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
         const failName = hasName && filterTarget === 'project' && !matchesName(n.name);
-        const failMinistry = hasMinistry && !filterMinistryNames.includes(n.ministry ?? '');
+        const failMinistry = hasMinistry && !selectedMinistrySet.has(n.ministry ?? '');
         if (failBudget || failName || failMinistry) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
@@ -1374,12 +1387,13 @@ export default function RealDataSankeyPage() {
       matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
     // 府省庁フィルタが設定されている場合、検索対象を選択府省庁の事業・支出先に絞る
+    const searchMinistrySet = new Set(filterMinistryNames);
     let allowedIds: Set<string> | null = null;
     if (filterMinistryNames.length > 0) {
       allowedIds = new Set<string>();
       const allowedSpendingIds = new Set<string>();
       for (const n of graphData.nodes) {
-        if (n.type === 'project-spending' && n.ministry != null && filterMinistryNames.includes(n.ministry)) {
+        if (n.type === 'project-spending' && n.ministry != null && searchMinistrySet.has(n.ministry)) {
           allowedIds.add(n.id);
           allowedSpendingIds.add(n.id);
         }

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1373,26 +1373,12 @@ export default function RealDataSankeyPage() {
       const qLower = q.toLocaleLowerCase();
       matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
-    const hasMinistryFilter = filterMinistryNames.length > 0;
-    // recipientノードは ministry フィールドを持たないため、選択府省庁の事業と接続されているかでフィルタする
-    let allowedRecipientIds: Set<string> | null = null;
-    if (hasMinistryFilter) {
-      const allowedProjectIds = new Set(
-        graphData.nodes.filter(n => n.type === 'project-spending' && n.ministry != null && filterMinistryNames.includes(n.ministry)).map(n => n.id)
-      );
-      allowedRecipientIds = new Set(
-        graphData.edges.filter(e => allowedProjectIds.has(e.source)).map(e => e.target)
-      );
-    }
-    for (const n of graphData.nodes) {
+    // filterExcludedIds をフィルタの唯一の根拠として使用（金額・府省庁・名前 全条件を一元管理）
+    const nodesToSearch = filterExcludedIds
+      ? graphData.nodes.filter(n => !filterExcludedIds.has(n.id))
+      : graphData.nodes;
+    for (const n of nodesToSearch) {
       if (n.type === 'project-budget') continue; // merged into project-spending entry
-      if (hasMinistryFilter) {
-        if (n.type === 'recipient') {
-          if (!allowedRecipientIds!.has(n.id)) continue;
-        } else if (n.ministry == null || !filterMinistryNames.includes(n.ministry)) {
-          continue;
-        }
-      }
       if (pidQuery !== null) {
         if (n.type === 'project-spending' && n.projectId === pidQuery) {
           const bv = budgetNodeByPid.get(n.projectId)?.value ?? 0;
@@ -1410,7 +1396,7 @@ export default function RealDataSankeyPage() {
       }
     }
     return results.sort((a, b) => b.sortValue - a.sortValue);
-  }, [graphData, debouncedQuery, searchUseRegex, filterMinistryNames, budgetNodeByPid]);
+  }, [graphData, debouncedQuery, searchUseRegex, filterExcludedIds, budgetNodeByPid]);
 
   const SEARCH_PAGE_SIZE = 200;
   const searchPagedResults = useMemo(

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -433,7 +433,7 @@ export default function RealDataSankeyPage() {
     pendingHistoryAction.current = 'replace';
     setRecipientOffset(0);
     setProjectOffset(0);
-  }, [filterActive, filterTarget, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery]);
+  }, [filterActive, filterTarget, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery]);
 
   // Sync URL when filter name query changes (separate from above to avoid double reset)
   const filterQueryInitRef = useRef(false);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1373,10 +1373,26 @@ export default function RealDataSankeyPage() {
       const qLower = q.toLocaleLowerCase();
       matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
-    // filterExcludedIds をフィルタの唯一の根拠として使用（金額・府省庁・名前 全条件を一元管理）
-    const nodesToSearch = filterExcludedIds
-      ? graphData.nodes.filter(n => !filterExcludedIds.has(n.id))
-      : graphData.nodes;
+    // 府省庁フィルタが設定されている場合、検索対象を選択府省庁の事業・支出先に絞る
+    let allowedIds: Set<string> | null = null;
+    if (filterMinistryNames.length > 0) {
+      allowedIds = new Set<string>();
+      const allowedSpendingIds = new Set<string>();
+      for (const n of graphData.nodes) {
+        if (n.type === 'project-spending' && n.ministry != null && filterMinistryNames.includes(n.ministry)) {
+          allowedIds.add(n.id);
+          allowedSpendingIds.add(n.id);
+        }
+      }
+      for (const e of graphData.edges) {
+        if (allowedSpendingIds.has(e.source) && e.target.startsWith('r-')) allowedIds.add(e.target);
+      }
+    }
+    // 金額フィルタは filterExcludedIds 経由で適用
+    const nodesToSearch = graphData.nodes.filter(n =>
+      (!allowedIds || allowedIds.has(n.id)) &&
+      (!filterExcludedIds || !filterExcludedIds.has(n.id))
+    );
     for (const n of nodesToSearch) {
       if (n.type === 'project-budget') continue; // merged into project-spending entry
       if (pidQuery !== null) {
@@ -1396,7 +1412,7 @@ export default function RealDataSankeyPage() {
       }
     }
     return results.sort((a, b) => b.sortValue - a.sortValue);
-  }, [graphData, debouncedQuery, searchUseRegex, filterExcludedIds, budgetNodeByPid]);
+  }, [graphData, debouncedQuery, searchUseRegex, filterExcludedIds, filterMinistryNames, budgetNodeByPid]);
 
   const SEARCH_PAGE_SIZE = 200;
   const searchPagedResults = useMemo(

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import type { GraphData, LayoutNode, LayoutLink } from '@/types/sankey-svg';
 import type { ProjectDetail } from '@/types/project-details';
 import {
@@ -205,7 +206,9 @@ export default function RealDataSankeyPage() {
   const [filterTarget, setFilterTarget] = useState<'project' | 'recipient'>('recipient');
   const [filterMinistryNames, setFilterMinistryNames] = useState<string[]>([]);
   const [showMinistryDropdown, setShowMinistryDropdown] = useState(false);
+  const [ministryDropdownRect, setMinistryDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
   const ministryDropdownRef = useRef<HTMLDivElement>(null);
+  const ministryButtonRef = useRef<HTMLButtonElement>(null);
   const [filterMinBudgetText, setFilterMinBudgetText] = useState('');
   const [filterMaxBudgetText, setFilterMaxBudgetText] = useState('');
   const [filterMinSpendingText, setFilterMinSpendingText] = useState('');
@@ -2504,17 +2507,29 @@ export default function RealDataSankeyPage() {
                   const ministryNodes = (graphData?.nodes ?? []).filter(n => n.type === 'ministry').sort((a, b) => b.value - a.value);
                   const allSelected = filterMinistryNames.length === 0;
                   const label = allSelected ? '全府省庁' : filterMinistryNames.length === 1 ? filterMinistryNames[0] : `選択中 (${filterMinistryNames.length}/${ministryNodes.length})`;
+                  const chevron = (
+                    <svg xmlns="http://www.w3.org/2000/svg" height="14px" viewBox="0 -960 960 960" width="14px" fill="#aaa"
+                      style={{ transform: showMinistryDropdown ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', display: 'block' }}>
+                      <path d="M480-360 280-560h400L480-360Z"/>
+                    </svg>
+                  );
                   return (
                     <div style={{ display: 'flex', alignItems: 'center', gap: 4 }} ref={ministryDropdownRef}>
                       <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>省庁</span>
                       <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
-                        <button type="button"
-                          onClick={() => setShowMinistryDropdown(v => !v)}
+                        <button type="button" ref={ministryButtonRef}
+                          onClick={() => {
+                            if (ministryButtonRef.current) {
+                              const r = ministryButtonRef.current.getBoundingClientRect();
+                              setMinistryDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
+                            }
+                            setShowMinistryDropdown(v => !v);
+                          }}
                           style={{ width: '100%', fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '3px 20px 3px 5px', background: '#fafafa', color: allSelected ? '#aaa' : '#333', outline: 'none', cursor: 'pointer', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
                         >{label}</button>
-                        <span style={{ position: 'absolute', right: 5, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', fontSize: 10, color: '#aaa' }}>{showMinistryDropdown ? '▲' : '▼'}</span>
-                        {showMinistryDropdown && (
-                          <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 50, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 220, overflowY: 'auto', marginTop: 2 }}
+                        <span style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', display: 'flex', alignItems: 'center' }}>{chevron}</span>
+                        {showMinistryDropdown && ministryDropdownRect && createPortal(
+                          <div style={{ position: 'fixed', top: ministryDropdownRect.top, left: ministryDropdownRect.left, width: ministryDropdownRect.width, zIndex: 9999, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 260, overflowY: 'auto' }}
                             onMouseDown={e => e.stopPropagation()}>
                             <label style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', cursor: 'pointer', borderBottom: '1px solid #f0f0f0', fontWeight: 600 }}>
                               <input type="checkbox" checked={allSelected} onChange={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames([]); }} style={{ width: 12, height: 12 }} />
@@ -2529,7 +2544,8 @@ export default function RealDataSankeyPage() {
                                 <span style={{ fontSize: 11, color: '#333' }}>{n.name}</span>
                               </label>
                             ))}
-                          </div>
+                          </div>,
+                          document.body
                         )}
                       </div>
                       {!allSelected && (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2529,7 +2529,7 @@ export default function RealDataSankeyPage() {
                         >{label}</button>
                         <span style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', display: 'flex', alignItems: 'center' }}>{chevron}</span>
                         {showMinistryDropdown && ministryDropdownRect && createPortal(
-                          <div style={{ position: 'fixed', top: ministryDropdownRect.top, left: ministryDropdownRect.left, width: ministryDropdownRect.width, zIndex: 9999, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 260, overflowY: 'auto' }}
+                          <div style={{ position: 'fixed', top: ministryDropdownRect.top, left: ministryDropdownRect.left, width: ministryDropdownRect.width, zIndex: 9999, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 480, overflowY: 'auto' }}
                             onMouseDown={e => e.stopPropagation()}>
                             <label style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', cursor: 'pointer', borderBottom: '1px solid #f0f0f0', fontWeight: 600 }}>
                               <input type="checkbox" checked={allSelected} onChange={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames([]); }} style={{ width: 12, height: 12 }} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1374,9 +1374,25 @@ export default function RealDataSankeyPage() {
       matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
     const hasMinistryFilter = filterMinistryNames.length > 0;
+    // recipientノードは ministry フィールドを持たないため、選択府省庁の事業と接続されているかでフィルタする
+    let allowedRecipientIds: Set<string> | null = null;
+    if (hasMinistryFilter) {
+      const allowedProjectIds = new Set(
+        graphData.nodes.filter(n => n.type === 'project-spending' && n.ministry != null && filterMinistryNames.includes(n.ministry)).map(n => n.id)
+      );
+      allowedRecipientIds = new Set(
+        graphData.edges.filter(e => allowedProjectIds.has(e.source)).map(e => e.target)
+      );
+    }
     for (const n of graphData.nodes) {
       if (n.type === 'project-budget') continue; // merged into project-spending entry
-      if (hasMinistryFilter && (n.ministry == null || !filterMinistryNames.includes(n.ministry))) continue;
+      if (hasMinistryFilter) {
+        if (n.type === 'recipient') {
+          if (!allowedRecipientIds!.has(n.id)) continue;
+        } else if (n.ministry == null || !filterMinistryNames.includes(n.ministry)) {
+          continue;
+        }
+      }
       if (pidQuery !== null) {
         if (n.type === 'project-spending' && n.projectId === pidQuery) {
           const bv = budgetNodeByPid.get(n.projectId)?.value ?? 0;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -206,7 +206,7 @@ export default function RealDataSankeyPage() {
   const [filterTarget, setFilterTarget] = useState<'project' | 'recipient'>('recipient');
   const [filterMinistryNames, setFilterMinistryNames] = useState<string[]>([]);
   const [showMinistryDropdown, setShowMinistryDropdown] = useState(false);
-  const [ministryDropdownRect, setMinistryDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [ministryDropdownRect, setMinistryDropdownRect] = useState<{ top: number; left: number; width: number; maxHeight: number } | null>(null);
   const ministryDropdownRef = useRef<HTMLDivElement>(null);
   const ministryButtonRef = useRef<HTMLButtonElement>(null);
   const [filterMinBudgetText, setFilterMinBudgetText] = useState('');
@@ -1373,8 +1373,10 @@ export default function RealDataSankeyPage() {
       const qLower = q.toLocaleLowerCase();
       matcher = name => name.toLocaleLowerCase().includes(qLower);
     }
+    const hasMinistryFilter = filterMinistryNames.length > 0;
     for (const n of graphData.nodes) {
       if (n.type === 'project-budget') continue; // merged into project-spending entry
+      if (hasMinistryFilter && n.ministry != null && !filterMinistryNames.includes(n.ministry)) continue;
       if (pidQuery !== null) {
         if (n.type === 'project-spending' && n.projectId === pidQuery) {
           const bv = budgetNodeByPid.get(n.projectId)?.value ?? 0;
@@ -1392,7 +1394,7 @@ export default function RealDataSankeyPage() {
       }
     }
     return results.sort((a, b) => b.sortValue - a.sortValue);
-  }, [graphData, debouncedQuery, searchUseRegex]);
+  }, [graphData, debouncedQuery, searchUseRegex, filterMinistryNames, budgetNodeByPid]);
 
   const SEARCH_PAGE_SIZE = 200;
   const searchPagedResults = useMemo(
@@ -2521,7 +2523,7 @@ export default function RealDataSankeyPage() {
                           onClick={() => {
                             if (ministryButtonRef.current) {
                               const r = ministryButtonRef.current.getBoundingClientRect();
-                              setMinistryDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
+                              setMinistryDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width, maxHeight: Math.max(120, window.innerHeight - r.bottom - 16) });
                             }
                             setShowMinistryDropdown(v => !v);
                           }}
@@ -2529,7 +2531,7 @@ export default function RealDataSankeyPage() {
                         >{label}</button>
                         <span style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', display: 'flex', alignItems: 'center' }}>{chevron}</span>
                         {showMinistryDropdown && ministryDropdownRect && createPortal(
-                          <div style={{ position: 'fixed', top: ministryDropdownRect.top, left: ministryDropdownRect.left, width: ministryDropdownRect.width, zIndex: 9999, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: 480, overflowY: 'auto' }}
+                          <div style={{ position: 'fixed', top: ministryDropdownRect.top, left: ministryDropdownRect.left, width: ministryDropdownRect.width, zIndex: 9999, background: '#fff', border: '1px solid #ddd', borderRadius: 4, boxShadow: '0 4px 12px rgba(0,0,0,0.12)', maxHeight: ministryDropdownRect.maxHeight, overflowY: 'auto' }}
                             onMouseDown={e => e.stopPropagation()}>
                             <label style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', cursor: 'pointer', borderBottom: '1px solid #f0f0f0', fontWeight: 600 }}>
                               <input type="checkbox" checked={allSelected} onChange={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryNames([]); }} style={{ width: 12, height: 12 }} />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -36,6 +36,7 @@ interface SankeyUrlState {
   filterActive?: boolean;
   filterTarget?: 'project' | 'recipient';
   filterNameQuery?: string;
+  filterMinistryName?: string;
   filterMinBudgetText?: string;
   filterMaxBudgetText?: string;
   filterMinSpendingText?: string;
@@ -67,6 +68,7 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const f = p.get('f'); if (f === '1') result.filterActive = true;
   const nft = p.get('nft'); if (nft === 'p') result.filterTarget = 'project'; else if (nft === 'r') result.filterTarget = 'recipient';
   const nf = p.get('nf'); if (nf !== null) result.filterNameQuery = nf;
+  const fm = p.get('fm'); if (fm !== null) result.filterMinistryName = fm;
   const fmb = p.get('fmb'); if (fmb !== null) result.filterMinBudgetText = fmb;
   const fxb = p.get('fxb'); if (fxb !== null) result.filterMaxBudgetText = fxb;
   const fms = p.get('fms'); if (fms !== null) result.filterMinSpendingText = fms;
@@ -201,6 +203,7 @@ export default function RealDataSankeyPage() {
   const [filterActive, setFilterActive] = useState(false);
   const [showAmountSliders, setShowAmountSliders] = useState(false);
   const [filterTarget, setFilterTarget] = useState<'project' | 'recipient'>('recipient');
+  const [filterMinistryName, setFilterMinistryName] = useState('');
   const [filterMinBudgetText, setFilterMinBudgetText] = useState('');
   const [filterMaxBudgetText, setFilterMaxBudgetText] = useState('');
   const [filterMinSpendingText, setFilterMinSpendingText] = useState('');
@@ -274,6 +277,7 @@ export default function RealDataSankeyPage() {
     if (parsed.filterActive !== undefined) setFilterActive(parsed.filterActive);
     if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget);
     if (parsed.filterNameQuery !== undefined) { setSearchQuery(parsed.filterNameQuery); }
+    if (parsed.filterMinistryName !== undefined) setFilterMinistryName(parsed.filterMinistryName);
     if (parsed.filterMinBudgetText !== undefined) setFilterMinBudgetText(parsed.filterMinBudgetText);
     if (parsed.filterMaxBudgetText !== undefined) setFilterMaxBudgetText(parsed.filterMaxBudgetText);
     if (parsed.filterMinSpendingText !== undefined) setFilterMinSpendingText(parsed.filterMinSpendingText);
@@ -310,6 +314,7 @@ export default function RealDataSankeyPage() {
       setFilterActive(parsed.filterActive ?? false);
       if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget); else setFilterTarget('recipient');
       setSearchQuery(parsed.filterNameQuery ?? '');
+      setFilterMinistryName(parsed.filterMinistryName ?? '');
       setFilterMinBudgetText(parsed.filterMinBudgetText ?? '');
       setFilterMaxBudgetText(parsed.filterMaxBudgetText ?? '');
       setFilterMinSpendingText(parsed.filterMinSpendingText ?? '');
@@ -347,6 +352,7 @@ export default function RealDataSankeyPage() {
     if (filterActive) p.set('f', '1');
     if (filterTarget === 'project') p.set('nft', 'p');
     if (filterActive && searchQuery) p.set('nf', searchQuery);
+    if (filterMinistryName) p.set('fm', filterMinistryName);
     if (filterMinBudgetText) p.set('fmb', filterMinBudgetText);
     if (filterMaxBudgetText) p.set('fxb', filterMaxBudgetText);
     if (filterMinSpendingText) p.set('fms', filterMinSpendingText);
@@ -358,7 +364,7 @@ export default function RealDataSankeyPage() {
     } else {
       window.history.replaceState(null, '', url);
     }
-  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText]);
+  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, filterMinistryName, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -650,7 +656,8 @@ export default function RealDataSankeyPage() {
     const hasSpending = minSpendingYen !== null || maxSpendingYen !== null;
     const trimmedQuery = debouncedQuery.trim();
     const hasName = filterActive && trimmedQuery.length >= 1;
-    if (!hasBudget && !hasSpending && !hasName) return null;
+    const hasMinistry = !!filterMinistryName;
+    if (!hasBudget && !hasSpending && !hasName && !hasMinistry) return null;
     const minBudget = minBudgetYen ?? -Infinity;
     const maxBudget = maxBudgetYen ?? Infinity;
     const minSpending = minSpendingYen ?? 0;
@@ -671,7 +678,8 @@ export default function RealDataSankeyPage() {
         const sn = spendingByPid.get(n.projectId);
         const failBudget = hasBudget && (n.value < minBudget || n.value > maxBudget);
         const failName = hasName && filterTarget === 'project' && !matchesName(n.name);
-        if (failBudget || failName) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
+        const failMinistry = hasMinistry && n.ministry !== filterMinistryName;
+        if (failBudget || failName || failMinistry) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
       } else if (n.type === 'recipient') {
         const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
         const failName = hasName && filterTarget === 'recipient' && !matchesName(n.name);
@@ -717,7 +725,7 @@ export default function RealDataSankeyPage() {
       }
     }
     return excluded.size > 0 ? excluded : null;
-  }, [graphData, filterActive, filterTarget, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery, searchUseRegex]);
+  }, [graphData, filterActive, filterTarget, filterMinistryName, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedQuery, searchUseRegex]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -2479,6 +2487,24 @@ export default function RealDataSankeyPage() {
             {/* 金額フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showAmountSliders && (
               <div style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {/* 府省庁フィルタ */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <span style={{ fontSize: 11, color: '#555', width: 22, flexShrink: 0 }}>省庁</span>
+                  <select
+                    value={filterMinistryName}
+                    onChange={e => { pendingHistoryAction.current = 'replace'; setFilterMinistryName(e.target.value); }}
+                    style={{ flex: 1, minWidth: 0, fontSize: 11, border: '1px solid #ddd', borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: filterMinistryName ? '#333' : '#aaa', outline: 'none', cursor: 'pointer' }}
+                  >
+                    <option value="">全府省庁</option>
+                    {graphData?.nodes.filter(n => n.type === 'ministry').sort((a, b) => a.name.localeCompare(b.name, 'ja')).map(n => (
+                      <option key={n.id} value={n.name}>{n.name}</option>
+                    ))}
+                  </select>
+                  {filterMinistryName && (
+                    <button type="button" onClick={() => { pendingHistoryAction.current = 'replace'; setFilterMinistryName(''); }}
+                      style={{ fontSize: 10, color: '#aaa', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px', flexShrink: 0 }}>×</button>
+                  )}
+                </div>
                 {/* 予算・支出 テキスト入力 */}
                 {([
                   { label: '予算', minText: filterMinBudgetText, maxText: filterMaxBudgetText, setMin: setFilterMinBudgetText, setMax: setFilterMaxBudgetText },


### PR DESCRIPTION
## 目的

データ閲覧者が府省庁を絞り込んだ状態でキーワード検索できるようにするため。従来は府省庁フィルタと検索が独立しており、絞り込んでいても全府省庁の候補が検索結果に表示されていた。

## 変更内容

### 府省庁フィルタ（複数選択対応）
- 金額フィルタパネル上部に府省庁フィルタを追加
- 単一選択（`<select>`）→ チェックボックスドロップダウン（複数選択）に変更
- 府省庁リストを予算額降順でソート
- ドロップダウンアイコンを Material Icons SVG シェブロンに変更
- ドロップダウンを `createPortal` で `document.body` に描画し、親 div のクリッピングを回避
- ドロップダウン高さをウィンドウ高さに連動（`window.innerHeight - ボタン下端 - 16px`）
- URL パラメータ `fm` にカンマ区切りで保存・復元

### 検索結果への府省庁フィルタ反映
- 府省庁フィルタ選択時、検索結果を選択府省庁の事業・支出先のみに限定
- 支出先は「選択府省庁の事業と接続されているか」で判定

### 検索結果への金額フィルタ反映
- `filterExcludedIds` の Pass 2 条件を拡張（`hasBudget` / `hasMinistry` 追加）
- 予算フィルタで除外された事業にしか繋がっていない支出先も検索結果から除外

## テスト方法

```
npm run dev
# localhost:3002/sankey-svg にアクセス
```

1. フィルタパネルを開き、府省庁ドロップダウンから複数の府省庁を選択
2. 選択府省庁のみがサンキー図に反映されることを確認
3. 同状態でキーワード検索し、選択府省庁の事業・支出先のみがヒットすることを確認
4. 予算フィルタ（例: 下限 100億）を設定し、検索結果が絞られることを確認
5. URL に `fm=デジタル庁,厚生労働省` 形式で保存・復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select Ministry filter with a dropdown UI for selecting/clearing ministries.
  * Filter selections persist in the URL and sync with browser navigation.

* **Enhancements**
  * Search now respects the active Ministry filter and returns only relevant results.
  * Ministry filtering excludes unmatched projects and cascades exclusions to related nodes for consistent display.
  * Dropdown auto-closes on outside click and repositions on resize/scroll.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->