### PR TITLE
feat: すべてのノードラベルを表示 ON/OFF 動作の見直し

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -811,7 +811,7 @@ export default function RealDataSankeyPage() {
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
-  }, [filtered, svgWidth, svgHeight, showLabels]);
+  }, [filtered, svgWidth, svgHeight]);
 
   // Extra height (data units) added by node shifts — stored in ref for use in zoom/pan callbacks
   const shiftExtraHRef = useRef(0);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -799,16 +799,21 @@ export default function RealDataSankeyPage() {
 
   const layout = useMemo(() => {
     if (!filtered) return null;
-    // Two-pass: estimate fit zoom from ungapped layout, derive stable gaps from it.
+    if (!showLabels) {
+      // OFF: #181 相当 — extra spacing なし、pure NODE_PAD
+      const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
+      layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
+      return result;
+    }
+    // ON: two-pass — column gaps + minNodeGap を fitZoom 基準で算出
     const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
     const availH = Math.max(100, svgHeight - SEARCH_BOX_RESERVE);
     const fitZoom = Math.max(0.1, Math.min(10,
       Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
     ));
-    const minNodeGap = showLabels ? NODE_PAD : 14 / fitZoom;
-    const extraRecipientGapSVG = 360 / fitZoom;  // project-spending → recipient label space
-    const extraMinistryGapSVG = 310 / fitZoom;   // ministry → project-budget label space
-    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, minNodeGap, extraRecipientGapSVG, extraMinistryGapSVG);
+    const extraRecipientGapSVG = 360 / fitZoom;
+    const extraMinistryGapSVG  = 310 / fitZoom;
+    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
   }, [filtered, svgWidth, svgHeight, showLabels]);
@@ -1841,7 +1846,7 @@ export default function RealDataSankeyPage() {
                       const isSelectedMerged = node.id === selectedNodeId || spendingNode?.id === selectedNodeId;
                       const maxH = Math.max(bH, sH);
                       const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
-                      const labelVisible = !showLabels || topShift > 0 || maxH * zoom > 10 || isSelectedMerged;
+                      const labelVisible = topShift > 0 || maxH * zoom > 10 || isSelectedMerged;
                       const nodeOpacity = connectedNodeIds
                         ? (isConnected ? 1 : 0.3)
                         : (hoveredNode && hoveredNode !== node ? 0.4 : 1);
@@ -1915,7 +1920,7 @@ export default function RealDataSankeyPage() {
                     const h = node.y1 - node.y0;
                     const isSelected = node.id === selectedNodeId;
                     const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
-                    const labelVisible = !showLabels || topShift > 0 || (h + NODE_PAD) * zoom > 10 || isSelected;
+                    const labelVisible = topShift > 0 || (h + NODE_PAD) * zoom > 10 || isSelected;
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
                     return (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -799,13 +799,7 @@ export default function RealDataSankeyPage() {
 
   const layout = useMemo(() => {
     if (!filtered) return null;
-    if (!showLabels) {
-      // OFF: #181 相当 — extra spacing なし、pure NODE_PAD
-      const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
-      layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
-      return result;
-    }
-    // ON: two-pass — column gaps + minNodeGap を fitZoom 基準で算出
+    // Two-pass: fitZoom 基準で列間隔を算出（ON/OFF 共通）
     const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
     const availH = Math.max(100, svgHeight - SEARCH_BOX_RESERVE);
     const fitZoom = Math.max(0.1, Math.min(10,
@@ -813,6 +807,7 @@ export default function RealDataSankeyPage() {
     ));
     const extraRecipientGapSVG = 360 / fitZoom;
     const extraMinistryGapSVG  = 310 / fitZoom;
+    // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -171,7 +171,7 @@ export default function RealDataSankeyPage() {
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
   const [showSettings, setShowSettings] = useState(false);
-  const [showLabels, setShowLabels] = useState(false);
+  const [showLabels, setShowLabels] = useState(true);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
   const [showAggProject, setShowAggProject] = useState(true);
   const [projectSortBy, setProjectSortBy] = useState<'budget' | 'spending'>('budget');
@@ -308,7 +308,7 @@ export default function RealDataSankeyPage() {
       setTopMinistry(parsed.topMinistry ?? 37);
       setTopProject(parsed.topProject ?? 40);
       setTopRecipient(parsed.topRecipient ?? 40);
-      setShowLabels(parsed.showLabels ?? false);
+      setShowLabels(parsed.showLabels ?? true);
       setShowAggRecipient(parsed.showAggRecipient ?? true);
       setShowAggProject(parsed.showAggProject ?? true);
       setProjectSortBy(parsed.projectSortBy ?? 'budget');
@@ -562,7 +562,7 @@ export default function RealDataSankeyPage() {
 
   // Compute max extra height from label shifts at a given zoom level (2-pass helper)
   const calcShiftExtraH = useCallback((nodes: { y0: number; y1: number; id: string; type: string }[], zoomK: number): number => {
-    if (showLabelsRef.current) return 0;
+    if (!showLabelsRef.current) return 0;
     const LABEL_SLOT = 12;
     const colShifts = new Map<number, number>();
     for (const node of nodes) {
@@ -805,7 +805,7 @@ export default function RealDataSankeyPage() {
     const fitZoom = Math.max(0.1, Math.min(10,
       Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
     ));
-    const minNodeGap = showLabels ? 14 / fitZoom : NODE_PAD;
+    const minNodeGap = showLabels ? NODE_PAD : 14 / fitZoom;
     const extraRecipientGapSVG = 360 / fitZoom;  // project-spending → recipient label space
     const extraMinistryGapSVG = 310 / fitZoom;   // ministry → project-budget label space
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, minNodeGap, extraRecipientGapSVG, extraMinistryGapSVG);
@@ -820,7 +820,7 @@ export default function RealDataSankeyPage() {
   const nodeShiftInfo = useMemo(() => {
     const LABEL_SLOT = 12;
     const info = new Map<string, { cumShift: number; topShift: number }>();
-    if (!layout || showLabels) { shiftExtraHRef.current = 0; return info; }
+    if (!layout || !showLabels) { shiftExtraHRef.current = 0; return info; }
     const nodesByColumn = new Map<number, typeof layout.nodes[0][]>();
     for (const node of layout.nodes) {
       const col = getColumn(node);
@@ -1841,7 +1841,7 @@ export default function RealDataSankeyPage() {
                       const isSelectedMerged = node.id === selectedNodeId || spendingNode?.id === selectedNodeId;
                       const maxH = Math.max(bH, sH);
                       const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
-                      const labelVisible = showLabels || topShift > 0 || maxH * zoom > 10 || isSelectedMerged;
+                      const labelVisible = !showLabels || topShift > 0 || maxH * zoom > 10 || isSelectedMerged;
                       const nodeOpacity = connectedNodeIds
                         ? (isConnected ? 1 : 0.3)
                         : (hoveredNode && hoveredNode !== node ? 0.4 : 1);
@@ -1915,7 +1915,7 @@ export default function RealDataSankeyPage() {
                     const h = node.y1 - node.y0;
                     const isSelected = node.id === selectedNodeId;
                     const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
-                    const labelVisible = showLabels || topShift > 0 || (h + NODE_PAD) * zoom > 10 || isSelected;
+                    const labelVisible = !showLabels || topShift > 0 || (h + NODE_PAD) * zoom > 10 || isSelected;
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
                     return (

--- a/docs/tasks/20260430_0557_sankey-svg列間隔ズーム連動設計検討.md
+++ b/docs/tasks/20260430_0557_sankey-svg列間隔ズーム連動設計検討.md
@@ -1,0 +1,109 @@
+# /sankey-svg 列間隔ズーム連動設計 検討メモ
+
+## 要件
+
+zoom in しても列の水平配置が常にビューポートを均等に埋め、pan なしで全ノードが見える状態を保ちたい。ノードの幅も動的に変化する必要がある。
+
+---
+
+## 試みた実装アプローチ
+
+### アプローチ: containerWidth / nodeW を 1/zoom でスケール
+
+SVGの列位置はスクリーン座標で `x_screen = x_svg * zoom` であることを利用し、`x_svg = const_screen / zoom` になるよう x 配置を zoom に反比例させる。
+
+**変更した箇所:**
+
+```typescript
+// page.tsx — layout useMemo
+const nodeW = NODE_W / zoom;          // ノード幅 = 18px スクリーン定数
+const containerW = svgWidth / zoom;   // 全列がビューポート幅に収まる
+
+const noGap = computeLayout(..., containerW, ..., nodeW);
+// fitZoom は縦方向のみ（x はビューポートを埋める設計のため不要）
+const fitZoom = availH / (MARGIN.top + noGap.contentH) * 0.9;
+
+const extraRecipientGapSVG = 360 / zoom;  // スクリーン常数360px
+const extraMinistryGapSVG  = 310 / zoom;  // スクリーン常数310px
+const result = computeLayout(..., containerW, ..., nodeW);
+```
+
+```typescript
+// sankey-svg-filter.ts — computeLayout
+// nodeW パラメータ追加、NODE_W を nodeW に置き換え
+// LABEL_SPACE = 200 * nodeW / NODE_W  (スクリーン常数200px)
+```
+
+**fitZoomWithShifts も縦方向のみに変更:**
+
+```typescript
+const fitZoomWithShifts = (...) => {
+  let k = availH / (MARGIN.top + contentH) * 0.9;  // x 項を除去
+  // ...
+};
+```
+
+### 理論的な正しさ
+
+- `colSpacing_SVG * zoom = (svgWidth - margins - NODE_W) / maxCol` = 定数 ✓
+- `nodeW_SVG * zoom = NODE_W` = 定数 ✓
+- 追加ギャップ `360/zoom * zoom = 360px` = 定数 ✓
+- pan.x ≈ 0（コンテンツがビューポートを埋めるため自動的に0になる）✓
+
+---
+
+## 課題・断念した理由
+
+### 1. MARGIN の扱い
+
+`MARGIN.left` は SVG 座標の定数（≈100px）。`containerW = svgWidth / zoom` を使うと、`MARGIN.left * zoom` がスクリーンで zoom 倍に拡大する。zoom=2 では左マージンが 200px 取られる。
+
+スクリーン定数にするには `effectiveMarginLeft = MARGIN.left / zoom` が必要で、layout 全体への波及が大きい。
+
+### 2. layout が zoom に依存することの副作用
+
+- `layout` useMemo が zoom 変化のたびに再計算される（頻繁）
+- zoom ↔ layout ↔ fitZoom の循環依存が生じやすい
+- `nodeShiftInfo`（topShift）も zoom に依存しているため、2重の zoom 依存ループが発生
+
+### 3. 既存コンポーネントとの連携
+
+フォーカス計算（`focusOnNeighborhood`）、ミニマップ、ポップアップ位置など、node.x0/x1 を参照する箇所が多く、viewport-filling に合わせた全体修正が必要。
+
+---
+
+## 今後の実装方針（案）
+
+### 案A: SVG transform の x/y 分離
+
+```
+<g transform="matrix(1, 0, 0, zoom, pan.x, pan.y)">
+  <!-- scale_x=1（x は zoom しない）、scale_y=zoom -->
+```
+
+これにより x は常にスクリーン固定、y のみ zoom が効く。フォーカスや pan の計算を全面的に書き直す必要があるが、コンセプトとして最も整合性が高い。
+
+**必要な修正:**
+- SVG transform を `matrix(1, 0, 0, zoom, pan.x, pan.y)` に変更
+- `shiftedRibbonPath` のパス計算を matrix に対応
+- pan の水平操作を削除（x は常に固定）
+- フォーカス、ミニマップ、ポップアップの座標計算を更新
+
+### 案B: zoom 変化時に layout を段階的に更新
+
+zoom を離散化（例: 0.1 単位）して `layout` の再計算頻度を抑えつつ、`containerW = svgWidth / zoom` を使う。
+
+### 案C: 現状維持 + 初期表示だけ最適化
+
+現在の layout は fitZoom で正しく設定される。zoom in/out 後に「全体表示ボタン」で再フィットする UX で十分と判断し、連動対応はしない。
+
+---
+
+## 現在の状態
+
+**実装を revert し、PR #182 の状態（列間隔は fitZoom ベースで固定）に戻している。**
+
+以下はそのまま維持:
+- 列間隔: `extraRecipientGapSVG = 360 / fitZoom`、`extraMinistryGapSVG = 310 / fitZoom`
+- ノード幅: NODE_W 固定（18 SVG units）
+- zoom/pan: 従来の `scale(zoom)` による均一スケール

--- a/docs/tasks/20260430_0557_sankey-svg列間隔ズーム連動設計検討.md
+++ b/docs/tasks/20260430_0557_sankey-svg列間隔ズーム連動設計検討.md
@@ -76,9 +76,10 @@ const fitZoomWithShifts = (...) => {
 
 ### 案A: SVG transform の x/y 分離
 
-```
+```xml
 <g transform="matrix(1, 0, 0, zoom, pan.x, pan.y)">
   <!-- scale_x=1（x は zoom しない）、scale_y=zoom -->
+</g>
 ```
 
 これにより x は常にスクリーン固定、y のみ zoom が効く。フォーカスや pan の計算を全面的に書き直す必要があるが、コンセプトとして最も整合性が高い。


### PR DESCRIPTION
## Summary

- `すべてのノードラベルを表示` の ON/OFF の動作を入れ替え
  - **ON（デフォルト）**: topShift + ズームベースラベル表示（ズームに連動してノード間隔が自動調整）
  - **OFF**: ラベル表示なし → ズームベースのみ（#181 相当の従来動作）
- 列間隔拡張（`extraRecipientGapSVG` / `extraMinistryGapSVG`）は ON/OFF 共通で常時適用
- 設計検討メモを追加（列間隔ズーム連動の試みと断念理由）

## Test plan

- [ ] ON（デフォルト）: ズームイン/アウトでノード間隔が自動調整されることを確認
- [ ] ON: 小さいノードが topShift で下方シフトされラベルが読めることを確認
- [ ] OFF: ズームが小さい時にラベルが非表示になることを確認
- [ ] OFF: 列間隔が ON と同じ幅であることを確認
- [ ] チェックボックス切り替え時にビューが正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted label visibility settings and layout gap computation for improved default display behavior.

* **Documentation**
  * Added design documentation regarding column-spacing and zoom synchronization considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->