### PR TITLE
fix: ズームインで列間隔が広がり続ける問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ npx tsc --noEmit         # TypeScript 型チェック
 `main` ブランチへの push → Vercel 自動ビルド（東京リージョン `hnd1`）。
 `prebuild` フックが `.gz` → `.json` を自動展開。
 
+## Agent の行動ルール
+
+- **PR は必ずユーザーの明示的な許可を得てから作成すること。** 実装・修正が完了しても、ユーザーから「PR を出してください」「PR お願いします」などの指示がない限り、自律的に PR を作成・プッシュしてはならない。
+- コミットは実装完了のタイミングで行ってよいが、プッシュ・PR 作成は指示待ちとする。
+
 ## Documentation Standards
 
 - **Task docs**（設計・調査・実装計画）: `docs/tasks/YYYYMMDD_HHMM_タイトル.md`

--- a/app/lib/sankey-svg-constants.ts
+++ b/app/lib/sankey-svg-constants.ts
@@ -29,8 +29,8 @@ export const MARGIN = { top: 30, right: 20, bottom: 10, left: 20 };
 export const NODE_W = 18;
 export const NODE_PAD = 2;
 // 列間隔の画面ピクセル上限（ズームインしても超えない）
-export const MAX_RECIPIENT_GAP_PX = 360;
-export const MAX_MINISTRY_GAP_PX  = 310;
+export const MAX_RECIPIENT_GAP_PX = 930;
+export const MAX_MINISTRY_GAP_PX  = 620;
 
 // ── Colors & Labels ──
 

--- a/app/lib/sankey-svg-constants.ts
+++ b/app/lib/sankey-svg-constants.ts
@@ -28,6 +28,9 @@ export const SVG_H_MIN = 400;
 export const MARGIN = { top: 30, right: 20, bottom: 10, left: 20 };
 export const NODE_W = 18;
 export const NODE_PAD = 2;
+// 列間隔の画面ピクセル上限（ズームインしても超えない）
+export const MAX_RECIPIENT_GAP_PX = 360;
+export const MAX_MINISTRY_GAP_PX  = 310;
 
 // ── Colors & Labels ──
 

--- a/app/lib/sankey-svg-constants.ts
+++ b/app/lib/sankey-svg-constants.ts
@@ -29,8 +29,8 @@ export const MARGIN = { top: 30, right: 20, bottom: 10, left: 20 };
 export const NODE_W = 18;
 export const NODE_PAD = 2;
 // 列間隔の画面ピクセル上限（ズームインしても超えない）
-export const MAX_RECIPIENT_GAP_PX = 930;
-export const MAX_MINISTRY_GAP_PX  = 620;
+export const MAX_RECIPIENT_GAP_PX = 650;
+export const MAX_MINISTRY_GAP_PX  = 450;
 
 // ── Colors & Labels ──
 

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1927,7 +1927,7 @@ export default function RealDataSankeyPage() {
                                 onMouseLeave={() => setHoveredNode(null)}
                                 onMouseDown={(e) => e.preventDefault()}
                                 onClick={(e) => handleNodeClick(node, e)}>
-                                {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
+                                {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                               </text>
                             )}
                           </g>
@@ -1966,7 +1966,7 @@ export default function RealDataSankeyPage() {
                               onMouseLeave={() => setHoveredNode(null)}
                               onMouseDown={(e) => e.preventDefault()}
                               onClick={(e) => handleNodeClick(node, e)}>
-                              {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
+                              {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
                             </text>
                           </>)}
                         </g>
@@ -2022,7 +2022,7 @@ export default function RealDataSankeyPage() {
                             onMouseDown={(e) => e.preventDefault()}
                             onClick={(e) => handleNodeClick(node, e)}
                           >
-                            {node.name.length > 20 ? node.name.slice(0, 20) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
+                            {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                           </text>
                         )}
                       </g>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, useDeferredValue } from 'react';
+import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { GraphData, LayoutNode, LayoutLink } from '@/types/sankey-svg';
 import type { ProjectDetail } from '@/types/project-details';
@@ -407,7 +407,6 @@ export default function RealDataSankeyPage() {
 
   // Zoom/Pan state
   const [zoom, setZoom] = useState(1);
-  const deferredZoom = useDeferredValue(zoom);
   // Keep zoomRef current for use in debounce timeouts
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
   useEffect(() => {
@@ -861,20 +860,14 @@ export default function RealDataSankeyPage() {
 
   const layout = useMemo(() => {
     if (!filtered) return null;
-    // Two-pass: fitZoom 基準で列間隔を算出（ON/OFF 共通）
-    const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
-    const availH = Math.max(100, svgHeight - SEARCH_BOX_RESERVE);
-    const fitZoom = Math.max(0.1, Math.min(10,
-      Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
-    ));
-    // 画面ピクセル上限を設ける: min(gap_at_fitZoom, gap_at_currentZoom) でズームインしても上限内に収まる
-    const extraRecipientGapSVG = Math.min(MAX_RECIPIENT_GAP_PX / fitZoom, MAX_RECIPIENT_GAP_PX / deferredZoom);
-    const extraMinistryGapSVG  = Math.min(MAX_MINISTRY_GAP_PX  / fitZoom, MAX_MINISTRY_GAP_PX  / deferredZoom);
+    // ギャップは zoom で割ることで画面上の間隔を常に MAX_*_GAP_PX に固定
+    const extraRecipientGapSVG = MAX_RECIPIENT_GAP_PX / zoom;
+    const extraMinistryGapSVG  = MAX_MINISTRY_GAP_PX  / zoom;
     // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
-  }, [filtered, svgWidth, svgHeight, deferredZoom]);
+  }, [filtered, svgWidth, svgHeight, zoom]);
 
   // Extra height (data units) added by node shifts — stored in ref for use in zoom/pan callbacks
   const shiftExtraHRef = useRef(0);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1692,14 +1692,12 @@ export default function RealDataSankeyPage() {
       ctx.fillRect(x, y, w, h);
     }
 
-    // Viewport: what part of the SVG world is visible in the container?
-    // Container shows screen coords (0,0) to (containerW, containerH)
-    // Screen to SVG: svgX = (screenX - pan.x) / zoom
+    // Viewport: x is screen-fixed, y remains zoomed SVG world.
     const cW = container.clientWidth;
     const cH = container.clientHeight;
-    const vpLeft = -pan.x / zoom;
+    const vpLeft = -pan.x;
     const vpTop = -pan.y / zoom;
-    const vpW = cW / zoom;
+    const vpW = cW;
     const vpH = cH / zoom;
 
     // Convert to minimap coords
@@ -1727,10 +1725,10 @@ export default function RealDataSankeyPage() {
     const scaleY = minimapH / svgHeight;
     const svgX = mx / scaleX;
     const svgY = my / scaleY;
-    // Center the container on this SVG coord
+    // Center horizontally in screen space and vertically in zoomed SVG world.
     const cW = container.clientWidth;
     const cH = container.clientHeight;
-    setPan({ x: cW / 2 - svgX * zoom, y: cH / 2 - svgY * zoom });
+    setPan({ x: cW / 2 - svgX, y: cH / 2 - svgY * zoom });
   }, [svgWidth, svgHeight, minimapH, zoom]);
 
   // Escape key: focusRelated ON → フィルターのみOFF、OFF → 選択解除

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -49,40 +49,8 @@ interface SankeyUrlState {
   acNone?: boolean;
 }
 
-type ColumnLayoutKey = 'total' | 'ministry' | 'project' | 'recipient';
-type ColumnOffsets = Record<ColumnLayoutKey, number>;
-
-const COLUMN_LAYOUT_STORAGE_KEY = 'sankey-svg.columnOffsets.v1';
-const DEFAULT_COLUMN_OFFSETS: ColumnOffsets = {
-  total: 0,
-  ministry: 0,
-  project: 0,
-  recipient: 0,
-};
 const SCREEN_LEFT_PADDING_PX = 32;
 const SCREEN_HORIZONTAL_FIT_RATIO = 0.82;
-
-function parseColumnOffsets(value: string | null): ColumnOffsets | null {
-  if (!value) return null;
-  try {
-    const parsed = JSON.parse(value) as Partial<Record<ColumnLayoutKey, unknown>>;
-    return {
-      total: typeof parsed.total === 'number' ? parsed.total : 0,
-      ministry: typeof parsed.ministry === 'number' ? parsed.ministry : 0,
-      project: typeof parsed.project === 'number' ? parsed.project : 0,
-      recipient: typeof parsed.recipient === 'number' ? parsed.recipient : 0,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function getColumnLayoutKey(node: Pick<LayoutNode, 'type'>): ColumnLayoutKey {
-  if (node.type === 'total') return 'total';
-  if (node.type === 'ministry') return 'ministry';
-  if (node.type === 'project-budget' || node.type === 'project-spending') return 'project';
-  return 'recipient';
-}
 
 function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const p = new URLSearchParams(search);
@@ -217,14 +185,6 @@ export default function RealDataSankeyPage() {
   const [hoveredNode, setHoveredNode] = useState<LayoutNode | null>(null);
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
-  const [columnOffsets, setColumnOffsets] = useState<ColumnOffsets>(DEFAULT_COLUMN_OFFSETS);
-  const columnOffsetsLoadedRef = useRef(false);
-  const [draggingColumn, setDraggingColumn] = useState<{
-    key: ColumnLayoutKey;
-    pointerId: number;
-    startClientX: number;
-    startOffsets: ColumnOffsets;
-  } | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showLabels, setShowLabels] = useState(true);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
@@ -573,17 +533,6 @@ export default function RealDataSankeyPage() {
   }, [topProject, offsetTarget]);
 
   const svgRef = useRef<SVGSVGElement>(null);
-
-  useEffect(() => {
-    const restored = parseColumnOffsets(window.localStorage.getItem(COLUMN_LAYOUT_STORAGE_KEY));
-    if (restored) setColumnOffsets(restored);
-    columnOffsetsLoadedRef.current = true;
-  }, []);
-
-  useEffect(() => {
-    if (!columnOffsetsLoadedRef.current) return;
-    window.localStorage.setItem(COLUMN_LAYOUT_STORAGE_KEY, JSON.stringify(columnOffsets));
-  }, [columnOffsets]);
 
   const layoutRef = useRef<{ contentW: number; contentH: number; nodes: { y0: number; y1: number; id: string; type: string }[] } | null>(null);
   const showLabelsRef = useRef(showLabels);
@@ -1695,63 +1644,21 @@ export default function RealDataSankeyPage() {
   const screenToInnerX = useCallback((screenX: number) => screenX / zoom - MARGIN.left, [zoom]);
   const screenWToInner = useCallback((screenW: number) => screenW / zoom, [zoom]);
   const getNodeScreenX0 = useCallback((node: LayoutNode): number => {
-    const offset = columnOffsets[getColumnLayoutKey(node)];
     const left = MARGIN.left + SCREEN_LEFT_PADDING_PX;
     if (node.type === 'project-spending') {
       const budgetId = node.id === '__agg-project-spending'
         ? '__agg-project-budget'
         : node.projectId != null ? `project-budget-${node.projectId}` : null;
       const budgetNode = budgetId ? nodeByLayoutId.get(budgetId) : null;
-      if (budgetNode) return left + budgetNode.x0 * horizontalScale + screenNodeW + offset;
+      if (budgetNode) return left + budgetNode.x0 * horizontalScale + screenNodeW;
     }
-    return left + node.x0 * horizontalScale + offset;
-  }, [columnOffsets, horizontalScale, nodeByLayoutId, screenNodeW]);
+    return left + node.x0 * horizontalScale;
+  }, [horizontalScale, nodeByLayoutId, screenNodeW]);
   const getNodeScreenX1 = useCallback((node: LayoutNode): number => getNodeScreenX0(node) + screenNodeW, [getNodeScreenX0, screenNodeW]);
   const getNodeInnerX0 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX0(node)), [getNodeScreenX0, screenToInnerX]);
   const getNodeInnerX1 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX1(node)), [getNodeScreenX1, screenToInnerX]);
   const innerNodeW = screenWToInner(screenNodeW);
   const innerLabelGap = screenWToInner(3);
-
-  const clampColumnOffset = useCallback((key: ColumnLayoutKey, rawOffset: number): number => {
-    if (!layout) return rawOffset;
-    const columnNodes = layout.nodes.filter(node => getColumnLayoutKey(node) === key);
-    if (columnNodes.length === 0) return rawOffset;
-    const currentOffset = columnOffsets[key];
-    const baseLeft = Math.min(...columnNodes.map(node => getNodeScreenX0(node) - currentOffset));
-    const minLeft = MARGIN.left + SCREEN_LEFT_PADDING_PX;
-    const maxLeft = Math.max(minLeft, svgWidth - MARGIN.right - screenNodeW);
-    return Math.max(minLeft - baseLeft, Math.min(maxLeft - baseLeft, rawOffset));
-  }, [columnOffsets, getNodeScreenX0, layout, screenNodeW, svgWidth]);
-
-  const handleColumnPointerDown = useCallback((key: ColumnLayoutKey, e: React.PointerEvent<HTMLDivElement>) => {
-    if (e.pointerType === 'mouse' && e.button !== 0) return;
-    e.preventDefault();
-    e.stopPropagation();
-    e.currentTarget.setPointerCapture(e.pointerId);
-    setDraggingColumn({
-      key,
-      pointerId: e.pointerId,
-      startClientX: e.clientX,
-      startOffsets: columnOffsets,
-    });
-  }, [columnOffsets]);
-
-  const handleColumnPointerMove = useCallback((key: ColumnLayoutKey, e: React.PointerEvent<HTMLDivElement>) => {
-    if (!draggingColumn || draggingColumn.key !== key || draggingColumn.pointerId !== e.pointerId) return;
-    e.preventDefault();
-    e.stopPropagation();
-    const dx = e.clientX - draggingColumn.startClientX;
-    setColumnOffsets(prev => {
-      const nextOffset = clampColumnOffset(key, draggingColumn.startOffsets[key] + dx);
-      if (prev[key] === nextOffset) return prev;
-      return { ...prev, [key]: nextOffset };
-    });
-  }, [clampColumnOffset, draggingColumn]);
-
-  const stopColumnDrag = useCallback((e?: React.PointerEvent<HTMLDivElement>) => {
-    if (e) e.stopPropagation();
-    setDraggingColumn(null);
-  }, []);
 
   // Draw minimap
   useEffect(() => {
@@ -2155,7 +2062,6 @@ export default function RealDataSankeyPage() {
             {(() => {
               const maxCol = layout.maxCol || 1;
               const colNodeTypes = ['total', 'ministry', 'project-budget', 'recipient'] as const;
-              const colLayoutKeys: ColumnLayoutKey[] = ['total', 'ministry', 'project', 'recipient'];
               const colAmounts: (number | null)[] = colNodeTypes.map((t, i) => {
                 const nodes = t === 'total' ? layout.nodes.filter(n => n.type === 'total') : layout.nodes.filter(n => n.type === t);
                 return i === 0 ? (nodes[0]?.value ?? null) : nodes.reduce((s, n) => s + n.value, 0);
@@ -2169,7 +2075,6 @@ export default function RealDataSankeyPage() {
               );
               return COL_LABELS.map((label, i) => {
                 // Use actual node x0 from layout (accounts for extraMinistryGapSVG / extraRecipientGapSVG)
-                const columnKey = colLayoutKeys[i];
                 const colNodes = layout.nodes.filter(n => n.type === colNodeTypes[i]);
                 const screenX = pan.x + (colNodes.length > 0
                   ? Math.min(...colNodes.map(n => getNodeScreenX0(n))) + screenNodeW / 2
@@ -2194,16 +2099,10 @@ export default function RealDataSankeyPage() {
                       position: 'absolute', left: screenX, top,
                       transform: 'translateX(-50%)',
                       textAlign: 'center', fontSize: 13, color: '#999',
-                      whiteSpace: 'nowrap', userSelect: 'none',
-                      cursor: draggingColumn?.key === columnKey ? 'grabbing' : 'grab',
+                      whiteSpace: 'nowrap', userSelect: 'none', cursor: 'default',
                       zIndex: 8, lineHeight: 1.4,
                       background: 'rgba(255,255,255,0.82)', padding: '2px 8px', borderRadius: 4,
                     }}
-                    onPointerDown={(e) => handleColumnPointerDown(columnKey, e)}
-                    onPointerMove={(e) => handleColumnPointerMove(columnKey, e)}
-                    onPointerUp={stopColumnDrag}
-                    onPointerCancel={stopColumnDrag}
-                    onLostPointerCapture={() => setDraggingColumn(null)}
                     onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredColIndex(i); }}
                     onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                     onMouseLeave={() => setHoveredColIndex(null)}
@@ -3331,14 +3230,6 @@ export default function RealDataSankeyPage() {
                 <input type="checkbox" checked={autoFocusRelated} onChange={e => { pendingHistoryAction.current = 'replace'; setAutoFocusRelated(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>選択時に関連ノードのみ表示</span>
               </label>
-              <button
-                type="button"
-                data-pan-disabled="true"
-                onClick={() => setColumnOffsets(DEFAULT_COLUMN_OFFSETS)}
-                style={{ alignSelf: 'flex-start', fontSize: 12, padding: '4px 8px', borderRadius: 4, border: '1px solid #ddd', background: '#fff', color: '#555', cursor: 'pointer' }}
-              >
-                列位置をリセット
-              </button>
             </div>
           </>
         )}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -49,6 +49,41 @@ interface SankeyUrlState {
   acNone?: boolean;
 }
 
+type ColumnLayoutKey = 'total' | 'ministry' | 'project' | 'recipient';
+type ColumnOffsets = Record<ColumnLayoutKey, number>;
+
+const COLUMN_LAYOUT_STORAGE_KEY = 'sankey-svg.columnOffsets.v1';
+const DEFAULT_COLUMN_OFFSETS: ColumnOffsets = {
+  total: 0,
+  ministry: 0,
+  project: 0,
+  recipient: 0,
+};
+const SCREEN_LEFT_PADDING_PX = 32;
+const SCREEN_HORIZONTAL_FIT_RATIO = 0.82;
+
+function parseColumnOffsets(value: string | null): ColumnOffsets | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<Record<ColumnLayoutKey, unknown>>;
+    return {
+      total: typeof parsed.total === 'number' ? parsed.total : 0,
+      ministry: typeof parsed.ministry === 'number' ? parsed.ministry : 0,
+      project: typeof parsed.project === 'number' ? parsed.project : 0,
+      recipient: typeof parsed.recipient === 'number' ? parsed.recipient : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getColumnLayoutKey(node: Pick<LayoutNode, 'type'>): ColumnLayoutKey {
+  if (node.type === 'total') return 'total';
+  if (node.type === 'ministry') return 'ministry';
+  if (node.type === 'project-budget' || node.type === 'project-spending') return 'project';
+  return 'recipient';
+}
+
 function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const p = new URLSearchParams(search);
   const result: Partial<SankeyUrlState> = {};
@@ -170,8 +205,8 @@ export default function RealDataSankeyPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [topMinistry, setTopMinistry] = useState(37);
-  const [topProject, setTopProject] = useState(40);
-  const [topRecipient, setTopRecipient] = useState(40);
+  const [topProject, setTopProject] = useState(50);
+  const [topRecipient, setTopRecipient] = useState(50);
   const [recipientOffset, setRecipientOffset] = useState(0);
   const [projectOffset, setProjectOffset] = useState(0);
   const [offsetTarget, setOffsetTarget] = useState<'recipient' | 'project'>('recipient');
@@ -182,6 +217,14 @@ export default function RealDataSankeyPage() {
   const [hoveredNode, setHoveredNode] = useState<LayoutNode | null>(null);
   const [hoveredColIndex, setHoveredColIndex] = useState<number | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const [columnOffsets, setColumnOffsets] = useState<ColumnOffsets>(DEFAULT_COLUMN_OFFSETS);
+  const columnOffsetsLoadedRef = useRef(false);
+  const [draggingColumn, setDraggingColumn] = useState<{
+    key: ColumnLayoutKey;
+    pointerId: number;
+    startClientX: number;
+    startOffsets: ColumnOffsets;
+  } | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showLabels, setShowLabels] = useState(true);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
@@ -321,7 +364,7 @@ export default function RealDataSankeyPage() {
       // Pre-update prev refs so reset effects don't fire for URL-restored values
       prevOffsetTargetRef.current = parsed.offsetTarget ?? 'recipient';
       prevProjectSortByRef.current = parsed.projectSortBy ?? 'budget';
-      prevTopProjectRef.current = parsed.topProject ?? 40;
+      prevTopProjectRef.current = parsed.topProject ?? 50;
       setSelectedNodeId(parsed.selectedNodeId ?? null);
       setPinnedProjectId(parsed.pinnedProjectId ?? null);
       setPinnedRecipientId(parsed.pinnedRecipientId ?? null);
@@ -330,8 +373,8 @@ export default function RealDataSankeyPage() {
       setOffsetTarget(parsed.offsetTarget ?? 'recipient');
       setProjectOffset(parsed.projectOffset ?? 0);
       setTopMinistry(parsed.topMinistry ?? 37);
-      setTopProject(parsed.topProject ?? 40);
-      setTopRecipient(parsed.topRecipient ?? 40);
+      setTopProject(parsed.topProject ?? 50);
+      setTopRecipient(parsed.topRecipient ?? 50);
       setShowLabels(parsed.showLabels ?? true);
       setShowAggRecipient(parsed.showAggRecipient ?? true);
       setShowAggProject(parsed.showAggProject ?? true);
@@ -372,8 +415,8 @@ export default function RealDataSankeyPage() {
     if (offsetTarget === 'project') p.set('ot', 'p');
     if (projectOffset !== 0) p.set('po', String(projectOffset));
     if (topMinistry !== 37) p.set('tm', String(topMinistry));
-    if (topProject !== 40) p.set('tp', String(topProject));
-    if (topRecipient !== 40) p.set('tr', String(topRecipient));
+    if (topProject !== 50) p.set('tp', String(topProject));
+    if (topRecipient !== 50) p.set('tr', String(topRecipient));
     if (!showLabels) p.set('sl', '0');
     if (!showAggRecipient) p.set('ar', '0');
     if (!showAggProject) p.set('ap', '0');
@@ -531,6 +574,49 @@ export default function RealDataSankeyPage() {
 
   const svgRef = useRef<SVGSVGElement>(null);
 
+  useEffect(() => {
+    const restored = parseColumnOffsets(window.localStorage.getItem(COLUMN_LAYOUT_STORAGE_KEY));
+    if (restored) setColumnOffsets(restored);
+    columnOffsetsLoadedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!columnOffsetsLoadedRef.current) return;
+    window.localStorage.setItem(COLUMN_LAYOUT_STORAGE_KEY, JSON.stringify(columnOffsets));
+  }, [columnOffsets]);
+
+  const layoutRef = useRef<{ contentW: number; contentH: number; nodes: { y0: number; y1: number; id: string; type: string }[] } | null>(null);
+  const showLabelsRef = useRef(showLabels);
+  showLabelsRef.current = showLabels;
+
+  // Top offset reserved for the search box (top:12 + height:36 + gap:8)
+  const SEARCH_BOX_RESERVE = 56;
+
+  // Compute max extra height from label shifts at a given zoom level (2-pass helper)
+  const calcShiftExtraH = useCallback((nodes: { y0: number; y1: number; id: string; type: string }[], zoomK: number): number => {
+    if (!showLabelsRef.current) return 0;
+    const LABEL_SLOT = 12;
+    const colShifts = new Map<number, number>();
+    for (const node of nodes) {
+      const h = Math.max(1, node.y1 - node.y0);
+      const topShift = h * zoomK < LABEL_SLOT ? Math.max(0, LABEL_SLOT / zoomK - h) : 0;
+      const col = getColumn(node);
+      colShifts.set(col, (colShifts.get(col) ?? 0) + topShift);
+    }
+    return colShifts.size > 0 ? Math.max(...colShifts.values()) : 0;
+  }, []);
+
+  const getZoomAnchoredPanY = useCallback((anchorY: number, nextZoom: number): number => {
+    const l = layoutRef.current;
+    if (!l) return anchorY - (anchorY - pan.y) * (nextZoom / zoom);
+    const currentTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, zoom);
+    const nextTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, nextZoom);
+    const currentScreenH = Math.max(1, currentTotalH * zoom);
+    const nextScreenH = Math.max(1, nextTotalH * nextZoom);
+    const ratioFromTop = (anchorY - pan.y) / currentScreenH;
+    return anchorY - ratioFromTop * nextScreenH;
+  }, [calcShiftExtraH, pan.y, zoom]);
+
   // Prevent overlay control interactions from bubbling into canvas pan/zoom
   const isOverlayControlTarget = (target: EventTarget | null) =>
     target instanceof Element &&
@@ -557,16 +643,14 @@ export default function RealDataSankeyPage() {
     const el = containerRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
     const my = e.clientY - rect.top;
 
     const doZoom = (dy: number) => {
       const delta = dy > 0 ? 0.9 : 1.1;
       const newZoom = Math.max(0.2, Math.min(baseZoom * 10, zoom * delta));
-      const newPanX = mx - (mx - pan.x) * (newZoom / zoom);
-      const newPanY = my - (my - pan.y) * (newZoom / zoom);
+      const newPanY = getZoomAnchoredPanY(my, newZoom);
       setZoom(newZoom);
-      setPan({ x: newPanX, y: newPanY });
+      setPan({ x: pan.x, y: newPanY });
       scheduleZoomUrlWrite();
     };
 
@@ -581,7 +665,7 @@ export default function RealDataSankeyPage() {
         setPan(prev => ({ x: prev.x - e.deltaX * speed, y: prev.y - e.deltaY * speed }));
       }
     }
-  }, [zoom, pan, baseZoom, scheduleZoomUrlWrite, scrollMode]);
+  }, [zoom, pan, baseZoom, getZoomAnchoredPanY, scheduleZoomUrlWrite, scrollMode]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0 || isOverlayControlTarget(e.target)) return; // left click only
@@ -606,39 +690,17 @@ export default function RealDataSankeyPage() {
     setIsPanning(false);
   }, []);
 
-  const layoutRef = useRef<{ contentW: number; contentH: number; nodes: { y0: number; y1: number; id: string; type: string }[] } | null>(null);
-  const showLabelsRef = useRef(showLabels);
-  showLabelsRef.current = showLabels;
-
-  // Top offset reserved for the search box (top:12 + height:36 + gap:8)
-  const SEARCH_BOX_RESERVE = 56;
-
-  // Compute max extra height from label shifts at a given zoom level (2-pass helper)
-  const calcShiftExtraH = useCallback((nodes: { y0: number; y1: number; id: string; type: string }[], zoomK: number): number => {
-    if (!showLabelsRef.current) return 0;
-    const LABEL_SLOT = 12;
-    const colShifts = new Map<number, number>();
-    for (const node of nodes) {
-      const h = Math.max(1, node.y1 - node.y0);
-      const topShift = h * zoomK < LABEL_SLOT ? Math.max(0, LABEL_SLOT / zoomK - h) : 0;
-      const col = getColumn(node);
-      colShifts.set(col, (colShifts.get(col) ?? 0) + topShift);
-    }
-    return colShifts.size > 0 ? Math.max(...colShifts.values()) : 0;
-  }, []);
-
   // Converge on fit zoom accounting for label shifts (shifts grow as zoom shrinks → iterate)
   const fitZoomWithShifts = useCallback((
     nodes: { y0: number; y1: number; id: string; type: string }[],
     contentW: number, contentH: number, cW: number, availH: number
   ): { k: number; totalH: number } => {
-    const totalW = MARGIN.left + contentW;
-    let k = Math.max(0.2, Math.min(10, Math.min(cW / totalW, availH / (MARGIN.top + contentH)) * 0.9));
+    let k = Math.max(0.2, Math.min(10, (availH / (MARGIN.top + contentH)) * 0.9));
     let totalH = MARGIN.top + contentH;
     for (let i = 0; i < 6; i++) {
       const extraH = calcShiftExtraH(nodes, k);
       totalH = MARGIN.top + contentH + extraH;
-      const newK = Math.max(0.2, Math.min(10, Math.min(cW / totalW, availH / totalH) * 0.9));
+      const newK = Math.max(0.2, Math.min(10, (availH / totalH) * 0.9));
       if (Math.abs(newK - k) < 0.0005) { k = newK; break; }
       k = newK;
     }
@@ -655,7 +717,7 @@ export default function RealDataSankeyPage() {
       const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
       setZoom(k);
       setBaseZoom(k);
-      setPan({ x: (cW - (MARGIN.left + l.contentW) * k) / 2, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
+      setPan({ x: 0, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
     } else {
       setZoom(1);
       setBaseZoom(1);
@@ -673,7 +735,7 @@ export default function RealDataSankeyPage() {
       const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
       setZoom(k);
       setBaseZoom(k);
-      setPan({ x: (cW - (MARGIN.left + l.contentW) * k) / 2, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
+      setPan({ x: 0, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
     } else {
       setZoom(1);
       setBaseZoom(1);
@@ -866,13 +928,13 @@ export default function RealDataSankeyPage() {
     const fitZoom = Math.max(0.1, Math.min(10,
       Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
     ));
-    // ズームアウト時は fitZoom 基準のギャップ（元の挙動）、ズームイン時は上限で固定
-    const extraRecipientGapSVG = Math.min(MAX_RECIPIENT_GAP_PX / fitZoom, MAX_RECIPIENT_GAP_PX / zoom);
-    const extraMinistryGapSVG  = Math.min(MAX_MINISTRY_GAP_PX  / fitZoom, MAX_MINISTRY_GAP_PX  / zoom);
+    // Horizontal rendering is screen-fixed; compute x layout once from the fit scale.
+    const extraRecipientGapSVG = MAX_RECIPIENT_GAP_PX / fitZoom;
+    const extraMinistryGapSVG  = MAX_MINISTRY_GAP_PX  / fitZoom;
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
-  }, [filtered, svgWidth, svgHeight, zoom]);
+  }, [filtered, svgWidth, svgHeight]);
 
   // Cumulative shift per node: { cumShift: slot-level offset, topShift: rect-within-slot offset }
   const nodeShiftInfo = useMemo(() => {
@@ -1254,24 +1316,19 @@ export default function RealDataSankeyPage() {
   const focusOnNode = useCallback((node: LayoutNode) => {
     const container = containerRef.current;
     if (!container) return;
-    const cW = container.clientWidth;
     const cH = container.clientHeight;
-    const cx = MARGIN.left + node.x0 + NODE_W / 2;
     const cy = MARGIN.top + node.y0 + (node.y1 - node.y0) / 2;
     const h = node.y1 - node.y0;
     const minZoomForLabel = 10 / (h + NODE_PAD);
-    const panelW = isPanelCollapsed ? 0 : 310;
-    const availableW = cW - panelW;
     const targetK = Math.max(zoom, Math.min(baseZoom * 10, minZoomForLabel * 1.2));
     setZoom(targetK);
-    setPan({ x: panelW + availableW / 2 - cx * targetK, y: cH / 2 - cy * targetK });
-  }, [zoom, baseZoom, isPanelCollapsed]);
+    setPan(prev => ({ x: prev.x, y: cH / 2 - cy * targetK }));
+  }, [zoom, baseZoom]);
 
   const focusOnNeighborhood = useCallback((nodeOverride?: LayoutNode) => {
     const node = nodeOverride ?? selectedNode;
     if (!node || (!nodeOverride && !selectedNodeInLayout) || !layout || !containerRef.current) return;
     const container = containerRef.current;
-    const cW = container.clientWidth;
     const cH = container.clientHeight;
     // BFS: include all transitively connected nodes (upstream + downstream)
     const neighborIds = new Set<string>();
@@ -1285,21 +1342,15 @@ export default function RealDataSankeyPage() {
     }
     const neighborNodes = layout.nodes.filter(n => neighborIds.has(n.id));
     if (neighborNodes.length === 0) return;
-    const minX = Math.min(...neighborNodes.map(n => n.x0));
     const minY = Math.min(...neighborNodes.map(n => n.y0));
-    const maxX = Math.max(...neighborNodes.map(n => n.x1));
     const maxY = Math.max(...neighborNodes.map(n => n.y1));
     const PADDING = 40;
-    const boxW = (maxX - minX) + PADDING * 2;
     const boxH = (maxY - minY) + PADDING * 2;
-    const panelW = isPanelCollapsed ? 0 : 310;
-    const availableW = cW - panelW;
-    const targetK = Math.max(0.2, Math.min(baseZoom * 10, Math.min(availableW / boxW, cH / boxH) * 0.9));
-    const centerX = MARGIN.left + (minX + maxX) / 2;
+    const targetK = Math.max(0.2, Math.min(baseZoom * 10, (cH / boxH) * 0.9));
     const centerY = MARGIN.top + (minY + maxY) / 2;
     setZoom(targetK);
-    setPan({ x: panelW + availableW / 2 - centerX * targetK, y: cH / 2 - centerY * targetK });
-  }, [selectedNode, selectedNodeInLayout, layout, isPanelCollapsed, baseZoom]);
+    setPan(prev => ({ x: prev.x, y: cH / 2 - centerY * targetK }));
+  }, [selectedNode, selectedNodeInLayout, layout, baseZoom]);
 
   const handleConnectionClick = useCallback((nodeId: string) => {
     // If already in layout, select and focus directly (no effect needed)
@@ -1602,7 +1653,7 @@ export default function RealDataSankeyPage() {
           const { k: fitK, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
           setBaseZoom(fitK);
           setZoom(k);
-          setPan({ x: (cW - (MARGIN.left + l.contentW) * k) / 2, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
+          setPan({ x: 0, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
         } else {
           setZoom(k); setBaseZoom(k); setPan({ x: 0, y: SEARCH_BOX_RESERVE });
         }
@@ -1630,6 +1681,78 @@ export default function RealDataSankeyPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layout, focusOnNeighborhood, isPanelCollapsed]);
 
+  const nodeByLayoutId = useMemo(() => {
+    const m = new Map<string, LayoutNode>();
+    for (const node of layout?.nodes ?? []) m.set(node.id, node);
+    return m;
+  }, [layout]);
+
+  const horizontalScale = useMemo(() => {
+    if (!layout) return 1;
+    return Math.max(0.2, Math.min(10, (svgWidth / (MARGIN.left + layout.contentW + SCREEN_LEFT_PADDING_PX)) * SCREEN_HORIZONTAL_FIT_RATIO));
+  }, [layout, svgWidth]);
+  const screenNodeW = NODE_W;
+  const screenToInnerX = useCallback((screenX: number) => screenX / zoom - MARGIN.left, [zoom]);
+  const screenWToInner = useCallback((screenW: number) => screenW / zoom, [zoom]);
+  const getNodeScreenX0 = useCallback((node: LayoutNode): number => {
+    const offset = columnOffsets[getColumnLayoutKey(node)];
+    const left = MARGIN.left + SCREEN_LEFT_PADDING_PX;
+    if (node.type === 'project-spending') {
+      const budgetId = node.id === '__agg-project-spending'
+        ? '__agg-project-budget'
+        : node.projectId != null ? `project-budget-${node.projectId}` : null;
+      const budgetNode = budgetId ? nodeByLayoutId.get(budgetId) : null;
+      if (budgetNode) return left + budgetNode.x0 * horizontalScale + screenNodeW + offset;
+    }
+    return left + node.x0 * horizontalScale + offset;
+  }, [columnOffsets, horizontalScale, nodeByLayoutId, screenNodeW]);
+  const getNodeScreenX1 = useCallback((node: LayoutNode): number => getNodeScreenX0(node) + screenNodeW, [getNodeScreenX0, screenNodeW]);
+  const getNodeInnerX0 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX0(node)), [getNodeScreenX0, screenToInnerX]);
+  const getNodeInnerX1 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX1(node)), [getNodeScreenX1, screenToInnerX]);
+  const innerNodeW = screenWToInner(screenNodeW);
+  const innerLabelGap = screenWToInner(3);
+
+  const clampColumnOffset = useCallback((key: ColumnLayoutKey, rawOffset: number): number => {
+    if (!layout) return rawOffset;
+    const columnNodes = layout.nodes.filter(node => getColumnLayoutKey(node) === key);
+    if (columnNodes.length === 0) return rawOffset;
+    const currentOffset = columnOffsets[key];
+    const baseLeft = Math.min(...columnNodes.map(node => getNodeScreenX0(node) - currentOffset));
+    const minLeft = MARGIN.left + SCREEN_LEFT_PADDING_PX;
+    const maxLeft = Math.max(minLeft, svgWidth - MARGIN.right - screenNodeW);
+    return Math.max(minLeft - baseLeft, Math.min(maxLeft - baseLeft, rawOffset));
+  }, [columnOffsets, getNodeScreenX0, layout, screenNodeW, svgWidth]);
+
+  const handleColumnPointerDown = useCallback((key: ColumnLayoutKey, e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setDraggingColumn({
+      key,
+      pointerId: e.pointerId,
+      startClientX: e.clientX,
+      startOffsets: columnOffsets,
+    });
+  }, [columnOffsets]);
+
+  const handleColumnPointerMove = useCallback((key: ColumnLayoutKey, e: React.PointerEvent<HTMLDivElement>) => {
+    if (!draggingColumn || draggingColumn.key !== key || draggingColumn.pointerId !== e.pointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const dx = e.clientX - draggingColumn.startClientX;
+    setColumnOffsets(prev => {
+      const nextOffset = clampColumnOffset(key, draggingColumn.startOffsets[key] + dx);
+      if (prev[key] === nextOffset) return prev;
+      return { ...prev, [key]: nextOffset };
+    });
+  }, [clampColumnOffset, draggingColumn]);
+
+  const stopColumnDrag = useCallback((e?: React.PointerEvent<HTMLDivElement>) => {
+    if (e) e.stopPropagation();
+    setDraggingColumn(null);
+  }, []);
+
   // Draw minimap
   useEffect(() => {
     if (!showMinimap || !layout) return;
@@ -1654,9 +1777,9 @@ export default function RealDataSankeyPage() {
 
     // Draw nodes (at their SVG-coord positions including MARGIN)
     for (const node of layout.nodes) {
-      const x = (MARGIN.left + node.x0) * scaleX;
+      const x = getNodeScreenX0(node) * scaleX;
       const y = (MARGIN.top + node.y0) * scaleY;
-      const w = Math.max(1, NODE_W * scaleX);
+      const w = Math.max(1, screenNodeW * scaleX);
       const h = Math.max(0.5, (node.y1 - node.y0) * scaleY);
       ctx.fillStyle = getNodeColor(node);
       ctx.fillRect(x, y, w, h);
@@ -1683,7 +1806,7 @@ export default function RealDataSankeyPage() {
     ctx.strokeRect(mX, mY, mW, mH);
     ctx.fillStyle = 'rgba(59, 130, 246, 0.08)';
     ctx.fillRect(mX, mY, mW, mH);
-  }, [showMinimap, layout, zoom, pan, svgWidth, minimapH]);
+  }, [showMinimap, layout, zoom, pan, svgWidth, svgHeight, minimapH, getNodeScreenX0, screenNodeW]);
 
   const minimapNavigate = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = minimapRef.current;
@@ -1701,7 +1824,7 @@ export default function RealDataSankeyPage() {
     const cW = container.clientWidth;
     const cH = container.clientHeight;
     setPan({ x: cW / 2 - svgX * zoom, y: cH / 2 - svgY * zoom });
-  }, [svgWidth, minimapH, zoom]);
+  }, [svgWidth, svgHeight, minimapH, zoom]);
 
   // Escape key: focusRelated ON → フィルターのみOFF、OFF → 選択解除
   useEffect(() => {
@@ -1720,10 +1843,10 @@ export default function RealDataSankeyPage() {
 
   const applyZoom = useCallback((factor: number) => {
     const nz = Math.max(0.2, Math.min(baseZoom * 10, zoom * factor));
-    setPan({ x: svgWidth / 2 - (svgWidth / 2 - pan.x) * (nz / zoom), y: svgHeight / 2 - (svgHeight / 2 - pan.y) * (nz / zoom) });
+    setPan({ x: pan.x, y: getZoomAnchoredPanY(svgHeight / 2, nz) });
     setZoom(nz);
     scheduleZoomUrlWrite();
-  }, [zoom, pan, svgWidth, svgHeight, baseZoom, scheduleZoomUrlWrite]);
+  }, [zoom, pan.x, svgHeight, baseZoom, getZoomAnchoredPanY, scheduleZoomUrlWrite]);
 
   // Edge path with per-node cumulative shift applied to y coordinates
   const shiftedRibbonPath = (link: Parameters<typeof ribbonPath>[0]): string => {
@@ -1736,7 +1859,7 @@ export default function RealDataSankeyPage() {
     const tgt = nodeShiftInfo.get(link.target.id) ?? { cumShift: 0, topShift: 0 };
     const srcShift = src.cumShift + src.topShift;
     const tgtShift = tgt.cumShift + tgt.topShift;
-    const sx = link.source.x1, tx = link.target.x0;
+    const sx = getNodeInnerX1(link.source), tx = getNodeInnerX0(link.target);
     const sTop = link.y0 + srcShift, sBot = sTop + link.sourceWidth;
     const tTop = link.y1 + tgtShift, tBot = tTop + link.targetWidth;
     const mx = (sx + tx) / 2;
@@ -1835,7 +1958,7 @@ export default function RealDataSankeyPage() {
                     }}
                     onMouseLeave={() => setHoveredLink(null)}
                     onClick={(e) => e.stopPropagation()}
-                    style={{ cursor: 'grab', transition: 'fill-opacity 0.2s ease, d 0.3s ease', d: `path("${shiftedRibbonPath(link)}")` } as React.CSSProperties}
+                    style={{ cursor: 'grab', transition: 'fill-opacity 0.16s ease', d: `path("${shiftedRibbonPath(link)}")` } as React.CSSProperties}
                   />
                 ))}
 
@@ -1848,10 +1971,11 @@ export default function RealDataSankeyPage() {
                   for (const node of layout.nodes) {
                     const col = getColumn(node);
                     const cur = colMinX0.get(col);
-                    if (cur === undefined || node.x0 < cur) colMinX0.set(col, node.x0);
+                    const nodeX0 = getNodeInnerX0(node);
+                    if (cur === undefined || nodeX0 < cur) colMinX0.set(col, nodeX0);
                   }
                   return Array.from(cols).filter(c => c < lastCol).map(c => {
-                    const labelStart = (colMinX0.get(c) ?? 0) + NODE_W;
+                    const labelStart = (colMinX0.get(c) ?? 0) + innerNodeW;
                     // Clip end = leftmost x0 of next VISUAL column (skip project-spending)
                     let nextColNodes: typeof layout.nodes = [];
                     for (let nc = c + 1; nc <= lastCol; nc++) {
@@ -1859,8 +1983,8 @@ export default function RealDataSankeyPage() {
                       if (nextColNodes.length > 0) break;
                     }
                     const clipEnd = nextColNodes.length > 0
-                      ? Math.min(...nextColNodes.map(n => n.x0))
-                      : labelStart + layout.colSpacing - NODE_W;
+                      ? Math.min(...nextColNodes.map(n => getNodeInnerX0(n)))
+                      : labelStart + screenWToInner(layout.colSpacing * horizontalScale - screenNodeW);
                     return (
                       <defs key={`clip-col-${c}`}>
                         <clipPath id={`clip-col-${c}`}>
@@ -1905,7 +2029,7 @@ export default function RealDataSankeyPage() {
                         // No paired spending node — render as plain budget rect
                         return (
                           <g key={node.id} className="snk-node" style={{ transform: `translateY(${node.y0 + cumShift}px)`, transition: 'transform 0.3s ease' }}>
-                            <rect x={node.x0} y={topShift} width={NODE_W} fill={getNodeColor(node)} rx={1}
+                            <rect x={getNodeInnerX0(node)} y={topShift} width={innerNodeW} fill={getNodeColor(node)} rx={1}
                               style={{ height: bH, opacity: nodeOpacity, cursor: 'pointer', transition: 'opacity 0.2s ease, height 0.3s ease' }}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
@@ -1913,7 +2037,7 @@ export default function RealDataSankeyPage() {
                               onClick={(e) => handleNodeClick(node, e)}
                             />
                             {labelVisible && (
-                              <text x={node.x1 + 3} y={topShift + bH / 2} fontSize={11 / zoom} dominantBaseline="middle"
+                              <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={11 / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                                 style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                                 onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -1930,7 +2054,7 @@ export default function RealDataSankeyPage() {
                       return (
                         <g key={node.id} className="snk-node" style={{ transform: `translateY(${node.y0 + cumShift}px)`, transition: 'transform 0.3s ease' }}>
                           <path
-                            d={mergedProjectPath(node.x0, NODE_W, bH, sH)}
+                            d={mergedProjectPath(getNodeInnerX0(node), innerNodeW, bH, sH)}
                             fill={nodeFill}
                             transform={topShift > 0 ? `translate(0, ${topShift})` : undefined}
                             style={{ opacity: nodeOpacity, cursor: 'pointer', transition: 'opacity 0.2s ease' }}
@@ -1941,7 +2065,7 @@ export default function RealDataSankeyPage() {
                           />
                           {labelVisible && (<>
                             {/* Left label: budget amount */}
-                            <text x={node.x0 - 3} y={topShift + Math.max(bH, sH) / 2} fontSize={11 / zoom} dominantBaseline="middle" textAnchor="end"
+                            <text x={getNodeInnerX0(node) - innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={11 / zoom} dominantBaseline="middle" textAnchor="end"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                               style={{ userSelect: 'none', cursor: 'pointer' }}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -1952,7 +2076,7 @@ export default function RealDataSankeyPage() {
                               {formatYen(node.value)}{node.isScaled && node.rawValue != null && <tspan fill="#888"> / {formatYen(node.rawValue)}</tspan>}
                             </text>
                             {/* Right label: project name + spending amount */}
-                            <text x={spendingNode.x1 + 3} y={topShift + Math.max(bH, sH) / 2} fontSize={11 / zoom} dominantBaseline="middle"
+                            <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={11 / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                               style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -1976,9 +2100,9 @@ export default function RealDataSankeyPage() {
                     return (
                       <g key={node.id} className="snk-node" style={{ transform: `translateY(${node.y0 + cumShift}px)`, transition: 'transform 0.3s ease' }}>
                         <rect
-                          x={node.x0}
+                          x={getNodeInnerX0(node)}
                           y={topShift}
-                          width={NODE_W}
+                          width={innerNodeW}
                           fill={getNodeColor(node)}
                           rx={1}
                           style={{
@@ -2003,7 +2127,7 @@ export default function RealDataSankeyPage() {
                         />
                         {labelVisible && (
                           <text
-                            x={node.x1 + 3}
+                            x={getNodeInnerX1(node) + innerLabelGap}
                             y={topShift + h / 2}
                             fontSize={11 / zoom}
                             dominantBaseline="middle"
@@ -2030,8 +2154,8 @@ export default function RealDataSankeyPage() {
             {/* Column labels — DOM overlay, positioned from zoom/pan to avoid hiding behind search box */}
             {(() => {
               const maxCol = layout.maxCol || 1;
-              const innerW = svgWidth - MARGIN.left - MARGIN.right;
               const colNodeTypes = ['total', 'ministry', 'project-budget', 'recipient'] as const;
+              const colLayoutKeys: ColumnLayoutKey[] = ['total', 'ministry', 'project', 'recipient'];
               const colAmounts: (number | null)[] = colNodeTypes.map((t, i) => {
                 const nodes = t === 'total' ? layout.nodes.filter(n => n.type === 'total') : layout.nodes.filter(n => n.type === t);
                 return i === 0 ? (nodes[0]?.value ?? null) : nodes.reduce((s, n) => s + n.value, 0);
@@ -2045,12 +2169,11 @@ export default function RealDataSankeyPage() {
               );
               return COL_LABELS.map((label, i) => {
                 // Use actual node x0 from layout (accounts for extraMinistryGapSVG / extraRecipientGapSVG)
+                const columnKey = colLayoutKeys[i];
                 const colNodes = layout.nodes.filter(n => n.type === colNodeTypes[i]);
-                const colX0 = colNodes.length > 0
-                  ? Math.min(...colNodes.map(n => n.x0))
-                  : (i / maxCol) * (innerW - NODE_W);
-                const colInnerX = MARGIN.left + colX0 + NODE_W / 2;
-                const screenX = pan.x + colInnerX * zoom;
+                const screenX = pan.x + (colNodes.length > 0
+                  ? Math.min(...colNodes.map(n => getNodeScreenX0(n))) + screenNodeW / 2
+                  : MARGIN.left + SCREEN_LEFT_PADDING_PX + (i / maxCol) * (svgWidth - MARGIN.left - MARGIN.right - SCREEN_LEFT_PADDING_PX - screenNodeW) + screenNodeW / 2);
                 const total = colAmounts[i];
                 const amountLine = i === 2 && total != null
                   ? `${formatYen(total)} / ${formatYen(projectSpendingTotal)}`
@@ -2071,10 +2194,16 @@ export default function RealDataSankeyPage() {
                       position: 'absolute', left: screenX, top,
                       transform: 'translateX(-50%)',
                       textAlign: 'center', fontSize: 13, color: '#999',
-                      whiteSpace: 'nowrap', userSelect: 'none', cursor: 'default',
+                      whiteSpace: 'nowrap', userSelect: 'none',
+                      cursor: draggingColumn?.key === columnKey ? 'grabbing' : 'grab',
                       zIndex: 8, lineHeight: 1.4,
                       background: 'rgba(255,255,255,0.82)', padding: '2px 8px', borderRadius: 4,
                     }}
+                    onPointerDown={(e) => handleColumnPointerDown(columnKey, e)}
+                    onPointerMove={(e) => handleColumnPointerMove(columnKey, e)}
+                    onPointerUp={stopColumnDrag}
+                    onPointerCancel={stopColumnDrag}
+                    onLostPointerCapture={() => setDraggingColumn(null)}
                     onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredColIndex(i); }}
                     onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                     onMouseLeave={() => setHoveredColIndex(null)}
@@ -2128,7 +2257,7 @@ export default function RealDataSankeyPage() {
             const GAP = 8;
             const tipW = 240;
             const nodeScreenH = (hoveredNode.y1 - hoveredNode.y0) * zoom;
-            const screenCx = pan.x + (MARGIN.left + hoveredNode.x0 + NODE_W / 2) * zoom;
+            const screenCx = pan.x + getNodeScreenX0(hoveredNode) + screenNodeW / 2;
             const screenTop = pan.y + (MARGIN.top + hoveredNode.y0) * zoom;
             const screenBottom = screenTop + nodeScreenH;
             const lx = Math.max(4, Math.min(screenCx - tipW / 2, svgWidth - tipW - 4));
@@ -3180,12 +3309,12 @@ export default function RealDataSankeyPage() {
                 <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>
               </label>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-                <input type="checkbox" checked={showAggRecipient} onChange={e => { pendingHistoryAction.current = 'replace'; setShowAggRecipient(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
-                <span style={{ color: '#555' }}>支出先の集約ノードを表示</span>
-              </label>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showAggProject} onChange={e => { pendingHistoryAction.current = 'replace'; setShowAggProject(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>事業の集約ノードを表示</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={showAggRecipient} onChange={e => { pendingHistoryAction.current = 'replace'; setShowAggRecipient(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>支出先の集約ノードを表示</span>
               </label>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <span style={{ color: '#555' }}>事業ノードの並び順:</span>
@@ -3202,6 +3331,14 @@ export default function RealDataSankeyPage() {
                 <input type="checkbox" checked={autoFocusRelated} onChange={e => { pendingHistoryAction.current = 'replace'; setAutoFocusRelated(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>選択時に関連ノードのみ表示</span>
               </label>
+              <button
+                type="button"
+                data-pan-disabled="true"
+                onClick={() => setColumnOffsets(DEFAULT_COLUMN_OFFSETS)}
+                style={{ alignSelf: 'flex-start', fontSize: 12, padding: '4px 8px', borderRadius: 4, border: '1px solid #ddd', background: '#fff', color: '#555', cursor: 'pointer' }}
+              >
+                列位置をリセット
+              </button>
             </div>
           </>
         )}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -860,10 +860,15 @@ export default function RealDataSankeyPage() {
 
   const layout = useMemo(() => {
     if (!filtered) return null;
-    // ギャップは zoom で割ることで画面上の間隔を常に MAX_*_GAP_PX に固定
-    const extraRecipientGapSVG = MAX_RECIPIENT_GAP_PX / zoom;
-    const extraMinistryGapSVG  = MAX_MINISTRY_GAP_PX  / zoom;
-    // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
+    // fitZoom を求めるための第1パス（ギャップなし）
+    const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
+    const availH = Math.max(100, svgHeight - SEARCH_BOX_RESERVE);
+    const fitZoom = Math.max(0.1, Math.min(10,
+      Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
+    ));
+    // ズームアウト時は fitZoom 基準のギャップ（元の挙動）、ズームイン時は上限で固定
+    const extraRecipientGapSVG = Math.min(MAX_RECIPIENT_GAP_PX / fitZoom, MAX_RECIPIENT_GAP_PX / zoom);
+    const extraMinistryGapSVG  = Math.min(MAX_MINISTRY_GAP_PX  / fitZoom, MAX_MINISTRY_GAP_PX  / zoom);
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback, useDeferredValue } from 'react';
 import { createPortal } from 'react-dom';
 import type { GraphData, LayoutNode, LayoutLink } from '@/types/sankey-svg';
 import type { ProjectDetail } from '@/types/project-details';
 import {
   COL_LABELS, MARGIN, NODE_W, NODE_PAD,
+  MAX_RECIPIENT_GAP_PX, MAX_MINISTRY_GAP_PX,
   TYPE_COLORS, TYPE_LABELS,
   getColumn, getNodeColor, getLinkColor, ribbonPath, formatYen,
 } from '@/app/lib/sankey-svg-constants';
@@ -406,6 +407,7 @@ export default function RealDataSankeyPage() {
 
   // Zoom/Pan state
   const [zoom, setZoom] = useState(1);
+  const deferredZoom = useDeferredValue(zoom);
   // Keep zoomRef current for use in debounce timeouts
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
   useEffect(() => {
@@ -865,13 +867,14 @@ export default function RealDataSankeyPage() {
     const fitZoom = Math.max(0.1, Math.min(10,
       Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
     ));
-    const extraRecipientGapSVG = 360 / fitZoom;
-    const extraMinistryGapSVG  = 310 / fitZoom;
+    // 画面ピクセル上限を設ける: min(gap_at_fitZoom, gap_at_currentZoom) でズームインしても上限内に収まる
+    const extraRecipientGapSVG = Math.min(MAX_RECIPIENT_GAP_PX / fitZoom, MAX_RECIPIENT_GAP_PX / deferredZoom);
+    const extraMinistryGapSVG  = Math.min(MAX_MINISTRY_GAP_PX  / fitZoom, MAX_MINISTRY_GAP_PX  / deferredZoom);
     // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
-  }, [filtered, svgWidth, svgHeight]);
+  }, [filtered, svgWidth, svgHeight, deferredZoom]);
 
   // Extra height (data units) added by node shifts — stored in ref for use in zoom/pan callbacks
   const shiftExtraHRef = useRef(0);

--- a/docs/tasks/20260501_1126_sankey-svg列間隔ズーム連動上限設計.md
+++ b/docs/tasks/20260501_1126_sankey-svg列間隔ズーム連動上限設計.md
@@ -1,0 +1,127 @@
+# /sankey-svg 列間隔ズーム連動上限設計
+
+作成日: 2026-05-01
+
+## 目的
+
+閲覧者がズームインしたとき、事業列と支出先列の間に意味のない空白が広がり続けることを防ぐ。
+ラベルが全て読める十分な間隔になった時点で列間隔の拡大を止め、空白エリアを最小化する。
+
+---
+
+## 現状調査
+
+### 列間隔の計算フロー
+
+`app/sankey-svg/page.tsx` の `layout` useMemo（依存: `[filtered, svgWidth, svgHeight]`）:
+
+```typescript
+// 1. ギャップなしレイアウトで fitZoom を算出
+const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
+const fitZoom = min(svgWidth / noGap.contentW, svgHeight / noGap.contentH) * 0.9;
+
+// 2. ギャップを SVG 座標系で計算
+const extraRecipientGapSVG = 360 / fitZoom;   // 支出先列の左オフセット（SVG単位）
+const extraMinistryGapSVG  = 310 / fitZoom;   // 事業列の左オフセット（SVG単位）
+
+// 3. ギャップを含む最終レイアウトを計算
+const result = computeLayout(..., NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
+```
+
+`computeLayout`（`app/lib/sankey-svg-filter.ts`）では、各ノードの x0 に対してギャップを加算する:
+
+```typescript
+node.x0 = col * colSpacing + (col >= 2 ? extraMinistryGapSVG : 0);
+// recipient 列は逆方向にオフセット
+node.x0 -= colSpacing - extraRecipientGapSVG;
+```
+
+### 問題のメカニズム
+
+レイアウトは SVG 座標系で計算される。実際の表示には `transform="scale(zoom)"` が適用される。
+
+**画面上での列間隔** = `extraRecipientGapSVG × zoom` = `360 / fitZoom × zoom` [px]
+
+| zoom / fitZoom | 画面上の列間隔 |
+|---|---|
+| 1.0（fit時） | 360 px |
+| 2.0 | 720 px |
+| 3.0 | 1,080 px |
+| 4.0 | 1,440 px |
+
+ズームインするほど比例して広がる。一方、ラベルのフォントサイズは SVG 上で `11/zoom` に設定されているため、**画面上では常に 11px 固定**。ラベルの実表示幅は zoom によらず最大 250〜280px 程度（支出先の長い名称）であり、360px 以上の列間隔は過剰となる。
+
+---
+
+## 設計
+
+### 方針
+
+- **列間隔の画面ピクセル上限**を定数 `MAX_RECIPIENT_GAP_PX`・`MAX_MINISTRY_GAP_PX` として定義する
+- 実際の zoom を考慮し、上限を超えないよう SVG 単位のギャップを上限クランプする
+- レイアウト計算（ky の二分探索など）は zoom に依存せず変更しない
+
+### 定数定義（`app/lib/sankey-svg-constants.ts`）
+
+```typescript
+export const MAX_RECIPIENT_GAP_PX = 360;  // 支出先列の最大列間隔（画面px）
+export const MAX_MINISTRY_GAP_PX  = 310;  // 事業列の最大列間隔（画面px）
+```
+
+これらは現在の gap 設計値（`360 / fitZoom`・`310 / fitZoom` は fit 時に 360px・310px になる）と一致させる。
+
+### ギャップ計算の変更（`app/sankey-svg/page.tsx`）
+
+```text
+変更前:
+  extraRecipientGapSVG = 360 / fitZoom
+  extraMinistryGapSVG  = 310 / fitZoom
+
+変更後:
+  extraRecipientGapSVG = min(MAX_RECIPIENT_GAP_PX / fitZoom, MAX_RECIPIENT_GAP_PX / zoom)
+  extraMinistryGapSVG  = min(MAX_MINISTRY_GAP_PX  / fitZoom, MAX_MINISTRY_GAP_PX  / zoom)
+```
+
+| zoom / fitZoom | 変更前（画面px） | 変更後（画面px） |
+|---|---|---|
+| < 1.0（ズームアウト） | 360 * zoom/fitZoom（縮小） | 同左（変化なし） |
+| 1.0（fit時） | 360 | 360（変化なし） |
+| 2.0（ズームイン） | 720 | **360（上限適用）** |
+| 3.0 | 1,080 | **360（上限適用）** |
+
+ズームアウト時は現状と同じ（fitZoom < zoom → 右辺が小さくなる → 現状の値）。
+ズームイン時は画面上の間隔が MAX_GAP_PX に固定される。
+
+### layout useMemo の依存配列への zoom 追加
+
+ギャップが zoom に依存するため、`layout` useMemo の依存配列に `zoom`（または `useDeferredValue(zoom)`）を追加する必要がある。
+
+**パフォーマンス考慮:**
+
+`computeLayout` は O(n log n) 程度（ky 二分探索 × ノード数）。ノード数は通常数百程度のため、1回の計算は 1ms 未満。ただしズーム操作中は毎フレーム走るため、`useDeferredValue` でラグなし操作感を維持しつつバックグラウンドで再計算する方式が望ましい。
+
+```text
+const deferredZoom = useDeferredValue(zoom);
+// layout useMemo の中で zoom の代わりに deferredZoom を使用
+// 依存配列: [filtered, svgWidth, svgHeight, deferredZoom]
+```
+
+`useDeferredValue` により:
+- ズーム操作中はトランジションを維持（旧レイアウトを表示）
+- 操作が落ち着いた後に新レイアウトが反映される
+
+---
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/lib/sankey-svg-constants.ts` | `MAX_RECIPIENT_GAP_PX`・`MAX_MINISTRY_GAP_PX` 定数を追加 |
+| `app/sankey-svg/page.tsx` | `extraRecipientGapSVG`・`extraMinistryGapSVG` の計算式を変更、`useDeferredValue(zoom)` を layout に適用 |
+
+---
+
+## 補足: `colSpacing` との関係
+
+`colSpacing` はコンテナ幅から自動計算されるため変更しない。
+`extraRecipientGapSVG` は受領者列のみに追加される SVG オフセットであり、他の列には影響しない。

--- a/docs/tasks/20260502_0740_sankey-svg画面固定列レイアウト設計.md
+++ b/docs/tasks/20260502_0740_sankey-svg画面固定列レイアウト設計.md
@@ -260,12 +260,10 @@ nextX >= prevX + prevWidth + minGapPx;
 
 ### 実装メモ
 
-- 2026-05-02 時点で Step 1〜5 の最小実装を PR #189 ブランチ上で開始した
+- 2026-05-02 時点で Step 1〜4 の最小実装を PR #189 ブランチ上で開始した
 - 既存の SVG transform は残しつつ、描画 x を screen px 基準に変換する helper を導入した
 - zoom / fit / focus は横方向の中心合わせをやめ、縦方向 pan を中心に扱う
-- 列ラベルをドラッグすると列ごとの screen px offset を調整する
-- 列 offset は `localStorage` の `sankey-svg.columnOffsets.v1` に保持する
-- 設定パネルから列位置をリセットできる
+- 列ラベルドラッグ、列 offset 永続化、列位置リセット UI は今回 PR では見送り、別 PR で実装する
 
 ### Step 1: 設計上の責務分離
 

--- a/docs/tasks/20260502_0740_sankey-svg画面固定列レイアウト設計.md
+++ b/docs/tasks/20260502_0740_sankey-svg画面固定列レイアウト設計.md
@@ -1,0 +1,350 @@
+# /sankey-svg 画面固定列レイアウト設計
+
+## 背景
+
+PR #189 では、zoom in 時に事業列・支出先列の間隔が広がり続ける問題に対して、列間隔の画面 px 上限を設ける実装を試した。
+
+ただし調整を進める中で、本当に欲しい挙動は「列間隔の上限」ではなく、次のように整理できる。
+
+- zoom しても、列の画面上の横位置・間隔は変わらない
+- zoom しても、ノードの画面上の横幅は変わらない
+- pan していない状態では、左から `総計 → 省庁 → 事業 → 支出先` と各ノードラベルが無駄なく収まる
+- 列間隔はユーザー設定として保持できる
+- 列ラベルをドラッグして列位置・列間隔を調整できる
+
+つまり、`/sankey-svg` の zoom は主に「縦方向の詳細を見る」操作とし、横方向のレイアウトは画面に固定された編集可能なカラムとして扱う。
+
+## 現状の問題
+
+現在の描画は以下の transform を使っている。
+
+```tsx
+<g transform={`translate(${pan.x},${pan.y}) scale(${zoom})`}>
+  <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+```
+
+このため、SVG 内の `x0/x1`、列間隔、ノード幅、左マージンがすべて `zoom` 倍される。
+
+ラベルは `fontSize={11 / zoom}` で画面 px を一定にしているため、zoom in しても文字サイズはほぼ一定だが、列間隔だけは拡大し続ける。結果として、ラベルが読み切れる以上に空白が広がる。
+
+PR #189 の `Math.min(MAX_GAP / fitZoom, MAX_GAP / zoom)` はこの拡大を抑える応急的な解決だが、「横方向は zoom の影響を受けない」というモデルにはまだなっていない。
+
+## 目標
+
+### 画面座標で固定するもの
+
+- 列の x 位置
+- 列間隔
+- ノード幅
+- ノードラベルのフォントサイズ
+- ノードラベル表示に必要な横余白
+
+### zoom の影響を受けるもの
+
+- ノードの高さ
+- ノード間の縦方向 gap
+- リンクの太さ
+- 縦方向の pan
+- 縦方向の focus / fit
+
+### 原則
+
+横方向は screen space、縦方向は world/SVG space として扱う。
+
+```text
+screenX = columnLayout[col].x + optionalPanX
+screenW = configuredNodeWidth
+
+screenY = panY + (MARGIN.top + node.y0 + shiftY) * zoom
+screenH = (node.y1 - node.y0) * zoom
+```
+
+## 非目標
+
+- 最初の実装で列ドラッグ UI まで完成させること
+- すべての座標系を一度に完全刷新すること
+- 横方向 pan の高度な操作を維持すること
+- 既存の Sankey 高さ計算や TopN/filter ロジックを変更すること
+
+## 推奨アプローチ
+
+### A. x 座標を layout から分離する
+
+`computeLayout` が返す `x0/x1` をそのまま描画に使うのではなく、描画時に列ごとの screen x を適用する。
+
+```ts
+type ColumnKey = 'total' | 'ministry' | 'projectBudget' | 'projectSpending' | 'recipient';
+
+type ColumnLayout = {
+  key: ColumnKey;
+  x: number;      // screen px
+  width: number;  // screen px
+};
+```
+
+列判定は既存の `getColumn(node)` をベースにする。事業列は予算・支出の統合表示があるため、以下のように扱う。
+
+```text
+total:           col 0
+ministry:        col 1
+projectBudget:   col 2
+projectSpending: col 3
+recipient:       col 4
+```
+
+ただし画面上では `projectBudget` と `projectSpending` は近接したペアとして扱い、ユーザー設定では「事業列」としてまとめて動かす。
+
+### B. 描画座標変換 helper を作る
+
+いきなり全 JSX に式を散らさず、描画用 helper を集約する。
+
+```ts
+const sx = (node: LayoutNode) => columnLayout[getColumnKey(node)].x;
+const sw = (node: LayoutNode) => columnLayout[getColumnKey(node)].width;
+const sy = (y: number) => pan.y + (MARGIN.top + y) * zoom;
+const sh = (h: number) => h * zoom;
+```
+
+この段階では `pan.x` は原則 0 とし、必要なら「列全体の水平オフセット」としてだけ扱う。
+
+### C. SVG transform の依存を減らす
+
+最終的にはノード・リンクを screen 座標で直接描く。
+
+```tsx
+<svg>
+  <g data-layer="links">{/* screen coords */}</g>
+  <g data-layer="nodes">{/* screen coords */}</g>
+</svg>
+```
+
+`translate(... ) scale(zoom)` に頼らず、各座標を helper で変換する。
+
+これにより、テキストが y 方向だけ伸びる問題や、ノード幅を `1 / zoom` 補正する問題を避けられる。
+
+## レイアウト仕様
+
+### 初期列配置
+
+pan していない状態で、左から無駄なく収める。
+
+```text
+leftPadding
+total column
+gap.totalToMinistry
+ministry column
+gap.ministryToProject
+project budget/spending pair
+gap.projectToRecipient
+recipient column
+rightPadding
+```
+
+初期値案:
+
+```ts
+const DEFAULT_COLUMN_SETTINGS = {
+  nodeWidth: 18,
+  totalX: 20,
+  ministryX: 130,
+  projectBudgetX: 430,
+  projectSpendingX: 456,
+  recipientX: 980,
+};
+```
+
+実際の初期値は固定値ではなく、`svgWidth` とラベル推定幅から計算する。
+
+### ラベル幅推定
+
+初期配置は「ラベルが無駄なく収まる」を優先するため、列間隔の最小値をラベル幅から求める。
+
+```ts
+labelWidthPx = min(maxLabelChars, displayName.length) * averageCharPx + amountWidthPx + padding
+```
+
+初期案:
+
+- `averageCharPx`: 11
+- `projectLabelChars`: 40
+- `recipientLabelChars`: 40
+- `amountWidthPx`: 110
+- `padding`: 24
+
+ただし日本語・英数字・金額の混在で誤差が出るため、将来的には実測 (`getBBox` / canvas measureText) に置き換える。
+
+### 事業列の扱い
+
+事業は `project-budget` と `project-spending` のペアがある。
+
+- 通常ノード: `projectBudgetX` と `projectSpendingX` を近接配置
+- 統合ノード: 2列分を覆う形状として描く
+- ユーザーが「事業列」をドラッグした場合は、両方の x を同時に移動
+- 予算・支出間の距離は別設定にする
+
+```ts
+projectPairGapPx = 8;
+projectSpendingX = projectBudgetX + nodeWidth + projectPairGapPx;
+```
+
+## ユーザー設定
+
+列位置は URL state または localStorage に保持する。
+
+### URL state 案
+
+共有可能性を優先するなら URL に入れる。
+
+```text
+cx=20,130,430,456,980
+cw=18
+```
+
+メリット:
+
+- URL共有で再現できる
+- 戻る/進むに乗せやすい
+
+デメリット:
+
+- URLが長くなる
+- ドラッグ中に history を汚しやすい
+
+### localStorage 案
+
+個人設定として扱うなら localStorage に入れる。
+
+```ts
+localStorage.setItem('sankey-svg.columnLayout.v1', JSON.stringify(settings));
+```
+
+メリット:
+
+- URLが汚れない
+- ドラッグ操作に向く
+
+デメリット:
+
+- 他者に共有できない
+
+推奨は両方の併用。
+
+- デフォルト: localStorage
+- 「現在の列配置をURLに反映」操作を後で追加可能にする
+
+## 列ラベルドラッグ
+
+列ラベル overlay をドラッグハンドルにする。
+
+### 操作仕様
+
+- 列ラベルに `cursor: ew-resize`
+- drag 中は該当列の x を更新
+- 事業ラベルは `projectBudgetX/projectSpendingX` をまとめて動かす
+- `Shift + drag` で右側の列全体を連動移動する案も検討
+- ダブルクリックで該当列を自動フィット位置に戻す
+- 設定リセットボタンで全列を初期配置に戻す
+
+### 制約
+
+列が交差しないように最小間隔を設ける。
+
+```ts
+minGapPx = 24;
+nextX >= prevX + prevWidth + minGapPx;
+```
+
+事業列と支出先列の間はラベル幅に応じた `minProjectToRecipientGapPx` を持つ。
+
+## 実装ステップ
+
+### 実装メモ
+
+- 2026-05-02 時点で Step 1〜5 の最小実装を PR #189 ブランチ上で開始した
+- 既存の SVG transform は残しつつ、描画 x を screen px 基準に変換する helper を導入した
+- zoom / fit / focus は横方向の中心合わせをやめ、縦方向 pan を中心に扱う
+- 列ラベルをドラッグすると列ごとの screen px offset を調整する
+- 列 offset は `localStorage` の `sankey-svg.columnOffsets.v1` に保持する
+- 設定パネルから列位置をリセットできる
+
+### Step 1: 設計上の責務分離
+
+- `columnLayout` state を追加
+- 既存 layout の `x0/x1` は当面残す
+- 描画用に `getScreenX(node)` / `getScreenNodeWidth(node)` helper を追加
+- まだ transform は変えない
+
+目的: 既存コードのどこが x 座標に依存しているかを明確にする。
+
+### Step 2: ノード描画だけ screen x 化
+
+- ノード rect/path の x と width を screen px 基準に変える
+- y/h は既存 zoom を維持
+- ラベル位置も screen x 基準に変える
+- 横方向 pan は一時的に無効化または `columnPanX` として限定
+
+目的: zoom in してもノード幅とラベル横位置が変わらない状態を作る。
+
+### Step 3: リンク path を screen x 化
+
+- `ribbonPath` / `shiftedRibbonPath` を screen 座標版に分ける
+- source/target の x は columnLayout、y/width は zoom 後の screen y/h を使う
+
+目的: ノードとリンクの座標系を揃える。
+
+### Step 4: minimap / focus / hover を更新
+
+- hover popup の x/y 計算を screen 座標 helper に寄せる
+- focus は横方向 center を動かさず、縦方向 pan のみ調整する
+- minimap は縦方向 viewport 表示を主目的に再定義する
+
+目的: 周辺機能の破綻を防ぐ。
+
+### Step 5: 列ラベルドラッグと永続化
+
+- column label overlay に drag handler を追加
+- localStorage に保存
+- reset column layout を設定メニューに追加
+
+目的: ユーザーが列間隔を調整できる状態にする。
+
+## リスク
+
+### 1. SVG 全体 transform からの脱却範囲が広い
+
+ノード、リンク、テキスト、hover、focus、minimap が座標変換に依存している。Step を分けて、各段階で動作確認する必要がある。
+
+### 2. x/y 座標系が混在する
+
+移行中は layout x と screen x が同時に存在する。helper なしに直接式を書くと破綻しやすい。
+
+対策:
+
+- `screenCoords` helper を必ず通す
+- `LayoutNode.x0/x1` を直接参照する箇所を `rg "x0|x1"` で棚卸しする
+
+### 3. テキストの縦伸び
+
+`matrix(1,0,0,zoom)` 方式を採ると text が縦方向に歪む。今回の推奨は「座標を screen 化して transform 依存を減らす」ため、この問題を避けられる。
+
+### 4. パフォーマンス
+
+zoom ごとに layout 全体を再計算すると重い。最終的には x レイアウトは zoom に依存させず、y/label shift のみ zoom 依存にする。
+
+## PR #189 の扱い
+
+PR #189 の現在の実装は「列間隔の上限 clamp」であり、本設計の最終形ではない。
+
+選択肢:
+
+1. PR #189 は一度「調査・暫定対応」として閉じ、新しいブランチで本設計を段階実装する
+2. PR #189 のブランチをそのまま使い、clamp 実装を Step 1 の設計に置き換えていく
+
+推奨は 2。ただし大きめの座標系変更になるため、次のコミットではまだ UI 動作を変えず、`columnLayout` と helper 導入までに留める。
+
+## 次の作業
+
+1. `LayoutNode.x0/x1` を参照している描画箇所を棚卸しする
+2. `ColumnLayout` 型と初期値計算関数を設計する
+3. ノード描画だけ screen x 化する小さな PR/コミットを作る
+4. スクリーンショットで zoom 100% / 200% / 400% の列位置を比較する


### PR DESCRIPTION
## 目的

ズームインしたとき事業列・支出先列の間に意味のない空白が広がり続けることを防ぐ。ラベルが全て読める十分な間隔になった時点で列間隔の拡大を止め、空白エリアを最小化する。

## 問題

列間隔（SVG単位）は `360 / fitZoom` で固定されているため、実際の zoom を乗じると `360 × (zoom / fitZoom)` 画面pxに比例拡大する。ラベルのフォントサイズは常に11px固定なのに対し、列間隔だけが無制限に広がっていた。

## 変更内容

### `app/lib/sankey-svg-constants.ts`
- `MAX_RECIPIENT_GAP_PX = 360`・`MAX_MINISTRY_GAP_PX = 310` を追加

### `app/sankey-svg/page.tsx`
- `useDeferredValue(zoom)` を追加（ズーム操作中の応答性を維持）
- ギャップ計算を上限クランプに変更:
  ```
  変更前: extraRecipientGapSVG = 360 / fitZoom
  変更後: extraRecipientGapSVG = min(360 / fitZoom, 360 / zoom)
  ```
- 結果: どの zoom レベルでも画面上の列間隔が最大 360/310px に収まる

## テスト方法

```bash
npm run dev
# localhost:3002/sankey-svg を開く
# ズームインして事業列と支出先列の間隔を確認
# 一定以上ズームしても間隔が広がらないことを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draggable, persisted horizontal column layout (stored locally) with adjustable column offsets
  * Zoom now anchors pan to the cursor for smoother scroll-zoom interaction
  * Increased default TopN for projects/recipients and raised node label truncation thresholds

* **Bug Fixes / Behavior**
  * View reset and focus behavior simplified to preserve horizontal pan and center vertically

* **Documentation**
  * Added design specs for zoom-linked column gap limits and screen-fixed column layout approach
<!-- end of auto-generated comment: release notes by coderabbit.ai -->