### PR TITLE
fix: sankey-svg offset button pan handling

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1617,12 +1617,15 @@ export default function RealDataSankeyPage() {
     }
   }, [layout, resetView, fitZoomWithShifts]);
 
-  // Safety: if content is entirely outside the visible area after a layout change, reset viewport
+  // Safety: reset viewport when content is largely outside the visible area after a layout change.
+  // Triggered by e.g. scaleBudgetToVisible causing a large ky jump on the first offset step.
   useEffect(() => {
     if (!layout || !initialCentered.current) return;
     const contentTop = pan.y + MARGIN.top * zoom;
     const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
-    if (contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE) {
+    const totalH = Math.max(contentBottom - contentTop, 1);
+    const visibleH = Math.max(0, Math.min(contentBottom, svgHeight) - Math.max(contentTop, SEARCH_BOX_RESERVE));
+    if (visibleH / totalH < 0.5) {
       resetViewport();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -670,6 +670,8 @@ export default function RealDataSankeyPage() {
       const cW = container.clientWidth;
       const availH = container.clientHeight - SEARCH_BOX_RESERVE;
       const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
+      // DEBUG
+      console.log('[resetViewport]', { cW, availH, k: k.toFixed(4), totalH: totalH.toFixed(1), newPanY: (SEARCH_BOX_RESERVE + (availH - totalH * k) / 2).toFixed(1) });
       setZoom(k);
       setBaseZoom(k);
       setPan({ x: (cW - (MARGIN.left + l.contentW) * k) / 2, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
@@ -870,6 +872,8 @@ export default function RealDataSankeyPage() {
     // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
+    // DEBUG
+    console.log('[layout] computed', { ky: result.ky.toFixed(6), contentH: result.contentH.toFixed(1), fitZoom: fitZoom.toFixed(4), svgW: svgWidth, svgH: svgHeight });
     return result;
   }, [filtered, svgWidth, svgHeight]);
 
@@ -1627,6 +1631,19 @@ export default function RealDataSankeyPage() {
     const entirelyOffScreen = contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE;
     const atFitZoom = zoom <= baseZoom * 1.1;
     const overflowsBelow = contentBottom > svgHeight + 10;
+    // DEBUG
+    console.log('[safety-check]', {
+      contentTop: contentTop.toFixed(1),
+      contentBottom: contentBottom.toFixed(1),
+      svgHeight,
+      panY: pan.y.toFixed(1),
+      zoom: zoom.toFixed(4),
+      baseZoom: baseZoom.toFixed(4),
+      atFitZoom,
+      overflowsBelow,
+      entirelyOffScreen,
+      willReset: entirelyOffScreen || (atFitZoom && overflowsBelow),
+    });
     if (entirelyOffScreen || (atFitZoom && overflowsBelow)) {
       resetViewport();
     }
@@ -3030,9 +3047,13 @@ export default function RealDataSankeyPage() {
                       onPointerDown={(e) => {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        let stepCount = 0;
                         const step = () => {
+                          stepCount++;
                           pendingHistoryAction.current = 'replace';
                           pendingFocusId.current = null;
+                          // DEBUG
+                          console.log(`[step #${stepCount}] delta=${delta}`, { zoom: zoomRef.current.toFixed(4), panY: pan.y.toFixed(1), svgH: svgHeight, isFullscreen: !!document.fullscreenElement });
                           if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                           else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                         };

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -917,6 +917,8 @@ export default function RealDataSankeyPage() {
       maxColExtraH = Math.max(maxColExtraH, cumShift);
     }
     shiftExtraHRef.current = maxColExtraH;
+    // DEBUG
+    console.log('[nodeShiftInfo]', { maxColExtraH: maxColExtraH.toFixed(1), zoom: zoom.toFixed(4), showLabels, nodeCount: layout.nodes.length });
     return info;
   }, [layout, showLabels, zoom]);
 
@@ -1622,12 +1624,13 @@ export default function RealDataSankeyPage() {
   }, [layout, resetView, fitZoomWithShifts]);
 
   // Safety: reset viewport when content position is off after a layout change.
-  // - Entirely off-screen: always reset
-  // - Any downward overflow while at fit zoom: reset (handles scaleBudgetToVisible ky jumps)
+  // Uses visual content height = layout.contentH + shiftExtraH (label slots).
   useEffect(() => {
     if (!layout || !initialCentered.current) return;
+    const shiftH = shiftExtraHRef.current;
+    const visualContentH = layout.contentH + shiftH;
     const contentTop = pan.y + MARGIN.top * zoom;
-    const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
+    const contentBottom = pan.y + (MARGIN.top + visualContentH) * zoom;
     const entirelyOffScreen = contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE;
     const atFitZoom = zoom <= baseZoom * 1.1;
     const overflowsBelow = contentBottom > svgHeight + 10;
@@ -1639,6 +1642,8 @@ export default function RealDataSankeyPage() {
       panY: pan.y.toFixed(1),
       zoom: zoom.toFixed(4),
       baseZoom: baseZoom.toFixed(4),
+      shiftH: shiftH.toFixed(1),
+      visualContentH: visualContentH.toFixed(1),
       atFitZoom,
       overflowsBelow,
       entirelyOffScreen,

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1617,15 +1617,17 @@ export default function RealDataSankeyPage() {
     }
   }, [layout, resetView, fitZoomWithShifts]);
 
-  // Safety: reset viewport when content is largely outside the visible area after a layout change.
-  // Triggered by e.g. scaleBudgetToVisible causing a large ky jump on the first offset step.
+  // Safety: reset viewport when content position is off after a layout change.
+  // - Entirely off-screen: always reset
+  // - Any downward overflow while at fit zoom: reset (handles scaleBudgetToVisible ky jumps)
   useEffect(() => {
     if (!layout || !initialCentered.current) return;
     const contentTop = pan.y + MARGIN.top * zoom;
     const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
-    const totalH = Math.max(contentBottom - contentTop, 1);
-    const visibleH = Math.max(0, Math.min(contentBottom, svgHeight) - Math.max(contentTop, SEARCH_BOX_RESERVE));
-    if (visibleH / totalH < 0.5) {
+    const entirelyOffScreen = contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE;
+    const atFitZoom = zoom <= baseZoom * 1.1;
+    const overflowsBelow = contentBottom > svgHeight + 10;
+    if (entirelyOffScreen || (atFitZoom && overflowsBelow)) {
       resetViewport();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1617,6 +1617,17 @@ export default function RealDataSankeyPage() {
     }
   }, [layout, resetView, fitZoomWithShifts]);
 
+  // Safety: if content is entirely outside the visible area after a layout change, reset viewport
+  useEffect(() => {
+    if (!layout || !initialCentered.current) return;
+    const contentTop = pan.y + MARGIN.top * zoom;
+    const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
+    if (contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE) {
+      resetViewport();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layout]);
+
   // Focus on node after selection — fires when node appears in layout (pinned TopN+1 case)
   // Also watches isPanelCollapsed: when panel opens, recalculate fit with updated panel width
   useEffect(() => {
@@ -3003,7 +3014,7 @@ export default function RealDataSankeyPage() {
                   >{activeRangeStart}</button>
                 )}
                 <span style={{ color: '#999', fontSize: 11 }}>〜{activeRangeEnd}</span>
-                <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => setActiveOffset(Number(e.target.value))} style={{ width: 60 }} />
+                <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
                 <span style={{ color: '#999', fontSize: 11 }}>/{activeTotalCount}件</span>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
                   {([
@@ -3013,8 +3024,10 @@ export default function RealDataSankeyPage() {
                     <button key={delta} title={title} aria-label={title}
                       onPointerDown={(e) => {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
+                        e.currentTarget.setPointerCapture(e.pointerId);
                         const step = () => {
                           pendingHistoryAction.current = 'replace';
+                          pendingFocusId.current = null;
                           if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                           else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                         };
@@ -3075,6 +3088,7 @@ export default function RealDataSankeyPage() {
                     <button key={delta} title={title} aria-label={title}
                       onPointerDown={(e) => {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
+                        e.currentTarget.setPointerCapture(e.pointerId);
                         const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
                         stopTopNRepeat(); step();
                         topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
@@ -3121,6 +3135,7 @@ export default function RealDataSankeyPage() {
                     <button key={delta} title={title} aria-label={title}
                       onPointerDown={(e) => {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
+                        e.currentTarget.setPointerCapture(e.pointerId);
                         const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
                         stopTopNRepeat(); step();
                         topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -532,7 +532,7 @@ export default function RealDataSankeyPage() {
 
   // Prevent overlay control interactions from bubbling into canvas pan/zoom
   const isOverlayControlTarget = (target: EventTarget | null) =>
-    target instanceof HTMLElement &&
+    target instanceof Element &&
     !!target.closest('[data-pan-disabled],button,input,select,textarea,label');
 
   // Debounced zoom URL write — called only on explicit user zoom (wheel / buttons)
@@ -670,8 +670,6 @@ export default function RealDataSankeyPage() {
       const cW = container.clientWidth;
       const availH = container.clientHeight - SEARCH_BOX_RESERVE;
       const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
-      // DEBUG
-      console.log('[resetViewport]', { cW, availH, k: k.toFixed(4), totalH: totalH.toFixed(1), newPanY: (SEARCH_BOX_RESERVE + (availH - totalH * k) / 2).toFixed(1) });
       setZoom(k);
       setBaseZoom(k);
       setPan({ x: (cW - (MARGIN.left + l.contentW) * k) / 2, y: SEARCH_BOX_RESERVE + (availH - totalH * k) / 2 });
@@ -872,19 +870,14 @@ export default function RealDataSankeyPage() {
     // ON: topShift あり、OFF: topShift なし — minNodeGap は両モードとも NODE_PAD
     const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
-    // DEBUG
-    console.log('[layout] computed', { ky: result.ky.toFixed(6), contentH: result.contentH.toFixed(1), fitZoom: fitZoom.toFixed(4), svgW: svgWidth, svgH: svgHeight });
     return result;
   }, [filtered, svgWidth, svgHeight]);
-
-  // Extra height (data units) added by node shifts — stored in ref for use in zoom/pan callbacks
-  const shiftExtraHRef = useRef(0);
 
   // Cumulative shift per node: { cumShift: slot-level offset, topShift: rect-within-slot offset }
   const nodeShiftInfo = useMemo(() => {
     const LABEL_SLOT = 12;
     const info = new Map<string, { cumShift: number; topShift: number }>();
-    if (!layout || !showLabels) { shiftExtraHRef.current = 0; return info; }
+    if (!layout || !showLabels) return info;
     const nodesByColumn = new Map<number, typeof layout.nodes[0][]>();
     for (const node of layout.nodes) {
       const col = getColumn(node);
@@ -900,7 +893,6 @@ export default function RealDataSankeyPage() {
         spendingH.set('__agg-project-budget', Math.max(1, n.y1 - n.y0));
       }
     }
-    let maxColExtraH = 0;
     for (const nodes of nodesByColumn.values()) {
       const sorted = [...nodes].sort((a, b) => a.y0 - b.y0);
       let cumShift = 0;
@@ -914,11 +906,7 @@ export default function RealDataSankeyPage() {
         info.set(node.id, { cumShift, topShift });
         cumShift += topShift;
       }
-      maxColExtraH = Math.max(maxColExtraH, cumShift);
     }
-    shiftExtraHRef.current = maxColExtraH;
-    // DEBUG
-    console.log('[nodeShiftInfo]', { maxColExtraH: maxColExtraH.toFixed(1), zoom: zoom.toFixed(4), showLabels, nodeCount: layout.nodes.length });
     return info;
   }, [layout, showLabels, zoom]);
 
@@ -1622,38 +1610,6 @@ export default function RealDataSankeyPage() {
       }
     }
   }, [layout, resetView, fitZoomWithShifts]);
-
-  // Safety: reset viewport when content position is off after a layout change.
-  // Uses visual content height = layout.contentH + shiftExtraH (label slots).
-  useEffect(() => {
-    if (!layout || !initialCentered.current) return;
-    const shiftH = shiftExtraHRef.current;
-    const visualContentH = layout.contentH + shiftH;
-    const contentTop = pan.y + MARGIN.top * zoom;
-    const contentBottom = pan.y + (MARGIN.top + visualContentH) * zoom;
-    const entirelyOffScreen = contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE;
-    const atFitZoom = zoom <= baseZoom * 1.1;
-    const overflowsBelow = contentBottom > svgHeight + 10;
-    // DEBUG
-    console.log('[safety-check]', {
-      contentTop: contentTop.toFixed(1),
-      contentBottom: contentBottom.toFixed(1),
-      svgHeight,
-      panY: pan.y.toFixed(1),
-      zoom: zoom.toFixed(4),
-      baseZoom: baseZoom.toFixed(4),
-      shiftH: shiftH.toFixed(1),
-      visualContentH: visualContentH.toFixed(1),
-      atFitZoom,
-      overflowsBelow,
-      entirelyOffScreen,
-      willReset: entirelyOffScreen || (atFitZoom && overflowsBelow),
-    });
-    if (entirelyOffScreen || (atFitZoom && overflowsBelow)) {
-      resetViewport();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layout]);
 
   // Focus on node after selection — fires when node appears in layout (pinned TopN+1 case)
   // Also watches isPanelCollapsed: when panel opens, recalculate fit with updated panel width
@@ -3051,14 +3007,11 @@ export default function RealDataSankeyPage() {
                     <button key={delta} title={title} aria-label={title}
                       onPointerDown={(e) => {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
+                        e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
-                        let stepCount = 0;
                         const step = () => {
-                          stepCount++;
                           pendingHistoryAction.current = 'replace';
                           pendingFocusId.current = null;
-                          // DEBUG
-                          console.log(`[step #${stepCount}] delta=${delta}`, { zoom: zoomRef.current.toFixed(4), panY: pan.y.toFixed(1), svgH: svgHeight, isFullscreen: !!document.fullscreenElement });
                           if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                           else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                         };
@@ -3068,8 +3021,14 @@ export default function RealDataSankeyPage() {
                           offsetRepeatRef.current = setInterval(step, 150);
                         }, 400);
                       }}
-                      onPointerUp={stopOffsetRepeat} onPointerLeave={stopOffsetRepeat} onPointerCancel={stopOffsetRepeat}
-                      onClick={(e) => { if (e.detail === 0) setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta))); }}
+                      onPointerUp={(e) => { e.stopPropagation(); stopOffsetRepeat(); }}
+                      onPointerLeave={stopOffsetRepeat}
+                      onPointerCancel={stopOffsetRepeat}
+                      onClick={(e) => {
+                        if (e.detail === 0) {
+                          setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));
+                        }
+                      }}
                       style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>

--- a/docs/tasks/20260501_2206_次へボタンPan不具合調査.md
+++ b/docs/tasks/20260501_2206_次へボタンPan不具合調査.md
@@ -1,0 +1,193 @@
+# 次へボタン押下時の画面外Panバグ調査
+
+## 目的
+
+`/sankey-svg` で offset ボタン「次へ」を押したとき図全体が画面下方向へ Panして見えなくなる問題の根本原因特定。
+
+## 症状
+
+- **再現条件**: 初期状態（recipientOffset=0）から「次へ(↑)」ボタンを単発クリック
+- **現象**: Sankey図全体が画面下の枠外へ Pan して見えなくなる
+- **回復**: 「全体表示」ボタン（resetViewport）を押すと戻る
+- **部分修正済み**: 長押し（リピート）は正常動作するようになった（後述）
+
+**ブランチ**: `fix/sankey-svg-fullscreen-offset-nav`
+
+---
+
+## 試したアプローチと結果
+
+### アプローチ1: `setPointerCapture` 追加（成功）
+
+**目的**: リピートが次へボタンだけ止まる問題の修正
+
+**コード変更**: `onPointerDown` に `e.currentTarget.setPointerCapture(e.pointerId)` を追加
+
+**結果**: ✅ **リピートは正常化した**。長押し中にポインタが少し動いても `onPointerLeave` が発火せずリピートが維持される。
+
+---
+
+### アプローチ2: `pendingFocusId.current = null` をステップ関数に追加（部分効果）
+
+**仮説**: 以前のノードクリックで設定された `pendingFocusId.current` が残っており、offset 変更でレイアウトが更新された際に `focusOnNeighborhood` が呼ばれてpanが変化する。
+
+**コード変更**: step関数内と range slider の onChange に `pendingFocusId.current = null` を追加
+
+**結果**: 部分的に有効だが、単発クリックの問題は残存。初期状態（pendingFocusIdがnullの状態）でも発生するため、これが根本原因ではない可能性が高い。
+
+---
+
+### アプローチ3: 安全リセット useEffect の追加（不十分）
+
+**仮説**: `layout` が変化したとき（offset変更でレイアウト再計算）、コンテンツが画面外に出た場合に `resetViewport` を呼ぶ。
+
+**実装** (`app/sankey-svg/page.tsx` 約1620行):
+```typescript
+useEffect(() => {
+  if (!layout || !initialCentered.current) return;
+  const contentTop = pan.y + MARGIN.top * zoom;
+  const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
+  const entirelyOffScreen = contentTop > svgHeight || contentBottom < SEARCH_BOX_RESERVE;
+  const atFitZoom = zoom <= baseZoom * 1.1;
+  const overflowsBelow = contentBottom > svgHeight + 10;
+  if (entirelyOffScreen || (atFitZoom && overflowsBelow)) {
+    resetViewport();
+  }
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [layout]);
+```
+
+**結果**: ❌ **単発クリックでは依然として発生**。長押しでは（複数ステップの後に）戻ってくる。
+
+**問題**: 安全チェックが発動するには `contentBottom > svgHeight + 10` が必要だが、実際の `layout.contentH` 変化が小さく（または0）でこの条件を満たさない可能性がある。
+
+---
+
+## 推測される要因（未確認）
+
+### 仮説A: `scaleBudgetToVisible=true` による `ky` 変化
+
+**メカニズム**:
+1. `scaleBudgetToVisible=true`（デフォルト）かつ `recipientOffset=0` のとき、`projectAboveWindowSpending` は空 → 全ノードの値がフル
+2. `recipientOffset=1` にすると、r-1（最上位支出先）が「window外」に入り `projectAboveWindowSpending` に追加される
+3. project-budget/spending ノードの値が `n.value - projectAboveWindowSpending` に削減される
+4. `computeLayout` の `colHeight` で使う `totalValue` が減少 → `ky` の binary search 上限 `hi = innerH / totalValue` が大きくなる
+5. ky が増加すると全ノードが縦に大きくなり `contentH` が増加
+
+**反論**: レシピエント列に集計ノード（`__agg-recipient`）があり、totalRecipientValue は offset に依存せず一定なのでレシピエント列の ky 制約は変わらない。ky は全列の最小なので変わらない可能性もある。
+
+**確認方法**: `layout.ky` と `layout.contentH` を offset=0/1 で実際にログ出力して比較する（未実施）。
+
+---
+
+### 仮説B: 安全チェックが `pan`/`zoom` の stale な値を参照している
+
+**メカニズム**: `useEffect([layout])` の closure は layout 変更時のレンダーから `pan`/`zoom`/`svgHeight` を参照するが、何らかの理由でこれらが正しい値でない可能性。
+
+**反論**: React の `useEffect` は常に最新レンダーのクロージャ値を使う。layout が変わったレンダーで pan/zoom は変化していないのでこれは正常のはず。
+
+---
+
+### 仮説C: `resetViewport` 呼び出し後に別の Effect が pan を上書きしている
+
+**メカニズム**:
+- `resetViewport` が `setZoom(k)`, `setBaseZoom(k)`, `setPan(...)` を呼ぶ
+- `baseZoom` 変更 → `focusOnNeighborhood` (deps に `baseZoom` 含む) が新しい参照になる
+- `focusOnNeighborhood` が新参照 → `handleConnectionClick` が新参照
+- `pendingConnectionNodeId` effect（deps: `[layout, handleConnectionClick]`）が発火
+- `pendingConnectionNodeId.current = null` → early return → 問題なし
+
+**現状**: ログなしで確認不能。
+
+---
+
+### 仮説D: 安全チェック自体が発動していない
+
+`layout.contentH` が offset=0→1 で変わらない（ky が変わらない）場合、`contentBottom` も変わらず `overflowsBelow` 条件を満たさない。この場合、安全チェックは発動しない。
+
+→ **Pan が変わる他の原因が存在する**か、または **contentH は変わるが閾値が足りない** かのどちらか。
+
+---
+
+### 仮説E: 安全チェック発動のタイミング問題
+
+`useEffect([layout])` の deps が `layout` だけなのに、クロージャ内の `pan`/`zoom` はレンダー時点の値を参照する。offset 変更 → layout 変更 → 安全チェック発動、この時点で `pan` は旧レイアウト用の値。`contentBottom = pan.y_old + (30 + contentH_new) * zoom_old`。contentH_new > contentH_old なら `overflowsBelow` が true になるはず。
+
+**問題**: contentH_new ≤ contentH_old（ky が変わらない）場合、条件不成立。
+
+---
+
+## 未解明の核心部分
+
+**「なぜ単発クリックだと Pan するのか」が未確認**:
+
+試した全アプローチは「offset=0→1 で contentH が増加する」という仮説に基づいているが、`showAggRecipient=true`（デフォルト）の場合はレシピエント列の合計値が一定に保たれ、ky は変わらないはずという反論がある。
+
+**「長押しだと戻ってくる」メカニズムも未確認**:
+- offset=2, 3, 4... で contentH が元に戻る（ky が下がる）から自然回復？
+- または安全チェックが高い offset で発動する？
+
+---
+
+## 次のステップ（未着手）
+
+### 確認1: contentH の実測値
+
+`layout` useMemo 内または安全チェック effect 内で `console.log` を追加し、offset=0/1/2 での `layout.contentH`、`layout.ky`、`pan.y`、`contentBottom` を実測する。
+
+```typescript
+// layout useMemo 内（デバッグ用）
+console.log('[layout]', { ky: result.ky, contentH: result.contentH, offset: recipientOffset });
+```
+
+### 確認2: 安全チェックの発動確認
+
+```typescript
+useEffect(() => {
+  if (!layout || !initialCentered.current) return;
+  const contentBottom = pan.y + (MARGIN.top + layout.contentH) * zoom;
+  console.log('[safety]', { contentBottom, svgHeight, atFitZoom: zoom <= baseZoom * 1.1 });
+  ...
+}, [layout]);
+```
+
+### アプローチ4（未試行）: offset ボタン押下時に pending reset フラグを立てる
+
+単発クリックの step 関数内で `pendingOffsetResetRef.current = true` を設定し、layout 変更後に必ず resetViewport を呼ぶ。ただし `zoom > baseZoom * 1.5` のとき（ユーザーが大幅ズームイン中）はスキップ。
+
+```typescript
+const pendingOffsetResetRef = useRef(false);
+
+// step 関数内
+pendingOffsetResetRef.current = true;
+
+// layout 変更を監視するEffect
+useEffect(() => {
+  if (!layout || !initialCentered.current || !pendingOffsetResetRef.current) return;
+  pendingOffsetResetRef.current = false;
+  if (zoom <= baseZoom * 1.5) resetViewport();
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [layout, resetViewport]);
+```
+
+**懸念**: 長押し中に毎 step（150ms ごと）resetViewport が呼ばれる → ズームが常にリセットされる。
+
+### アプローチ5（未試行）: offset=0→1 遷移を特別扱い
+
+`prevRecipientOffsetRef` で前回の offset を記録し、0→1 の遷移のみ resetViewport を呼ぶ。ただし「offset=0 が特別」の根拠が不明確（scaleBudgetToVisible の影響か？）。
+
+---
+
+## 関連ファイル
+
+- `app/sankey-svg/page.tsx` — ページコンポーネント（pan/zoom/offset 管理、安全チェック effect）
+- `app/lib/sankey-svg-filter.ts` — `filterTopN`（scaleBudgetToVisible による node 値スケール）、`computeLayout`（ky 計算）
+- `app/lib/sankey-svg-constants.ts` — MARGIN、NODE_W、SEARCH_BOX_RESERVE など
+
+## 現在のコミット
+
+```
+f36dcf2 fix: オフセット変更後の安全リセット条件を強化
+aa82f11 fix: 初期状態から次へを押したときの画面外Panを修正
+4bfd704 fix: フルスクリーン時のオフセットボタン不具合を修正
+```

--- a/docs/tasks/20260501_2206_次へボタンPan不具合調査.md
+++ b/docs/tasks/20260501_2206_次へボタンPan不具合調査.md
@@ -129,7 +129,102 @@ useEffect(() => {
 
 ---
 
-## 次のステップ（未着手）
+## Codex追加調査メモ（2026-05-02）
+
+### 受領ログから分かったこと
+
+- `docs/.ignore/localhost-1777669540602.log` と `docs/.ignore/localhost-1777670152740.log` では、`[step #1]` の `isFullscreen` がどちらも `false`。
+- `app/sankey-svg/page.tsx` 内にも `requestFullscreen` / `exitFullscreen` は存在しない。
+- したがって現時点のログ上では、「フルスクリーン」はアプリの Fullscreen API 状態ではなく、ブラウザ/OS 側の表示領域変更（`container.clientHeight` / `svgHeight` の変化）として扱う必要がある。
+- 通常表示ログでも `svgH: 836 → 957 → 1080` のようなリサイズが起きている。フルスクリーン差分を見るには `window.innerHeight` / `container.clientHeight` も同時に見る必要がある。
+- offset 0→1 後の `safety-check` は `contentTop: 130.7`, `contentBottom: 1006.5`, `svgHeight: 1080`, `overflowsBelow: false`, `entirelyOffScreen: false`。安全リセットが発動しないのは妥当。
+
+### レイアウト直接実行での確認
+
+`filterTopN` と `computeLayout` を Node/tsx で直接実行し、初期条件相当（2025, 1080x1080, Top省庁37/事業40/支出先40, recipient offset）を比較した。
+
+```text
+offset=0 contentH=1038.0 ky=6.4136e-12 nodes=161 edges=343
+offset=1 contentH=1038.0 ky=8.0280e-12 nodes=161 edges=357
+offset=2 contentH=1038.0 ky=1.0175e-11 nodes=161 edges=361
+offset=3 contentH=1038.0 ky=1.2229e-11 nodes=161 edges=327
+```
+
+`ky` は変化するが `contentH` はほぼ一定。既存ログでも `nodeShiftInfo.maxColExtraH` は offset 0→1 で `610.5 → 582.8` と減っている。
+
+このため、少なくとも初期条件では「offset 0→1 でレイアウト高さが急増し、下に押し出される」という仮説は弱い。
+
+### 現時点で濃い仮説
+
+1. `focusOnNode` / `focusOnNeighborhood` / `resetViewport` など、明示的に `setPan` する別経路が単発クリック後に走っている。
+2. Fullscreen API ではない表示領域変更により、`svgHeight` / `container.clientHeight` / `window.innerHeight` の更新順が通常表示と異なり、古い viewport 値で pan が計算されている。
+3. ボタン操作イベントがキャンバス操作系へ波及している可能性は低いが、切り分けのため offset ボタンの `pointerdown/up` に `stopPropagation()` を追加した。
+
+### 一時追加したデバッグログ
+
+原因特定のため、`app/sankey-svg/page.tsx` に以下のログを一時追加した。
+
+- `[pan-state]`: `pan`/viewport/offset/activeElement の状態変化
+- `[resetView]`, `[resetViewport]`: reset 系が計算した `k`, `totalH`, `newPanY`
+- `[layout] computed`: `recipientOffset`, `projectOffset`, `ky`, `contentH`, node/link count
+- `[focusOnNode]`, `[focusOnNeighborhood]`: focus 系が計算した `targetK`, `newPanY`
+- `[safety-check]`: 既存ログに viewport/offset snapshot を追加
+- `[step #n]`: `activeOffset`, `nextOffset`, pointer 情報、viewport snapshot を追加
+
+次のログで見るべきポイント:
+
+- 画面外へ Pan した直後に `[pan-state]` の `panY` が実際に大きく変化しているか
+- その直前に `[focusOnNode]` / `[focusOnNeighborhood]` / `[resetViewport]` のどれが出ているか
+- フルスクリーン時だけ `cH`, `svgH`, `winH` のどれかが一時的に不整合になっていないか
+- `activeTitle` が「次へ」のままか、他要素へ移っていないか
+
+原因特定後、これらの `console.log` とログ専用 helper は削除した。
+
+### 追加ログ `localhost-1777671793787.log` での原因特定
+
+ログ末尾で以下の順序を確認。
+
+```text
+[step #1] panY=122.0 recipientOffset=0 nextOffset=1
+[layout] recipientOffset=1 contentH=1038.0
+[safety-check] panY=122.0 willReset=false
+[pan-state] panY=1078.0 activeTag=BUTTON activeTitle=次へ
+```
+
+`focusOnNode` / `focusOnNeighborhood` / `resetViewport` は出ていないため、明示的な focus/reset 系ではなく、未ログだったキャンバス pan 操作系が `setPan` したと判断できる。
+
+根本原因は `isOverlayControlTarget` が `target instanceof HTMLElement` だけを許可していたこと。ボタン内の `<svg>` / `<path>` は `SVGElement` であり `HTMLElement` ではないため、`closest('button')` 判定に入らず、ボタン押下がキャンバスの `handleMouseDown` に誤って渡り、`handleMouseMove` で `panY` が大きく更新された。
+
+修正:
+
+```typescript
+const isOverlayControlTarget = (target: EventTarget | null) =>
+  target instanceof Element &&
+  !!target.closest('[data-pan-disabled],button,input,select,textarea,label');
+```
+
+これにより HTML 要素だけでなく SVG 要素から発火したイベントでも、祖先の `button` / `data-pan-disabled` を正しく検出できる。
+
+### 修正確認ログ `localhost-1777671975381.log`
+
+修正後ログでは、offset 更新後も `panY` が `95.0` のまま維持され、以前のような `panY=1078.0` へのジャンプは再現しなかった。
+
+```text
+[step #1] panY=95.0 recipientOffset=15 nextOffset=16
+[layout] recipientOffset=16 contentH=1038.0
+[pan-state] panY=95.0 activeTag=BUTTON
+```
+
+### コミット済み修正の見直し
+
+- `setPointerCapture`: 長押しリピートを安定させる修正として妥当。残す。
+- `pendingFocusId.current = null`: offset 操作時に過去の遅延 focus をキャンセルする保険として妥当。残す。
+- safety reset effect: 今回の根本原因ではなく、ユーザーの pan/zoom を layout 変更時に予期せず戻す可能性があるため削除。
+- `shiftExtraHRef` と `nodeShiftInfo` ログ: safety reset 用および調査用だったため削除。
+
+---
+
+## 当時の次のステップ（完了/不要）
 
 ### 確認1: contentH の実測値
 


### PR DESCRIPTION
## Summary
- Fix overlay control hit testing so SVG elements inside buttons are treated as control interactions
- Keep offset button repeat stable while preventing pointer events from starting canvas pan
- Remove temporary debug logging and the non-root-cause safety reset effect
- Document the investigation and confirmed root cause

## Verification
- npx tsc --noEmit
- Confirmed with docs/.ignore/localhost-1777671975381.log that panY stays stable after offset navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed unintended pan/zoom triggering when using offset slider and step navigation buttons in Sankey visualization
* Improved pointer interaction consistency for offset and TopN step controls

## Documentation
* Added detailed documentation detailing the investigation and resolution of Sankey offset navigation control interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->