### PR TITLE
feat(sankey-svg): 省庁ノードクリックでフィルタ操作を連動

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -34,6 +34,7 @@ interface SankeyUrlState {
   scaleBudgetToVisible: boolean;
   focusRelated: boolean;
   autoFocusRelated: boolean;
+  filterOnMinistryClick: boolean;
   year: '2024' | '2025';
   zoom?: number;
   filterActive?: boolean;
@@ -98,6 +99,7 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const sb = p.get('sb'); if (sb !== null) result.scaleBudgetToVisible = sb !== '0';
   const fr = p.get('fr'); if (fr !== null) result.focusRelated = fr === '1';
   const afr = p.get('afr'); if (afr !== null) result.autoFocusRelated = afr === '1';
+  const fmc = p.get('fmc'); if (fmc !== null) result.filterOnMinistryClick = fmc !== '0';
   const yr = p.get('yr'); if (yr === '2024' || yr === '2025') result.year = yr;
   const z = p.get('z'); if (z !== null) { const n = parseFloat(z); if (!isNaN(n) && n >= ZOOM_MIN_ABS && n <= ZOOM_MAX_ABS) result.zoom = n; }
   const f = p.get('f'); if (f === '1') result.filterActive = true;
@@ -218,7 +220,9 @@ export default function RealDataSankeyPage() {
   const [projectSortBy, setProjectSortBy] = useState<'budget' | 'spending'>('budget');
   const [scaleBudgetToVisible, setScaleBudgetToVisible] = useState(true);
   const [focusRelated, setFocusRelated] = useState(false);
-  const [autoFocusRelated, setAutoFocusRelated] = useState(true);
+  const [autoFocusRelated, setAutoFocusRelated] = useState(false);
+  const [filterOnMinistryClick, setFilterOnMinistryClick] = useState(true);
+  const ministryFilterSnapshotRef = useRef<{ filterMinistryNames: string[]; filterActive: boolean; selectedNodeId: string | null } | null>(null);
   const [year, setYear] = useState<'2024' | '2025'>('2025');
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
@@ -324,6 +328,7 @@ export default function RealDataSankeyPage() {
     if (parsed.scaleBudgetToVisible !== undefined) setScaleBudgetToVisible(parsed.scaleBudgetToVisible);
     if (parsed.focusRelated !== undefined) setFocusRelated(parsed.focusRelated);
     if (parsed.autoFocusRelated !== undefined) setAutoFocusRelated(parsed.autoFocusRelated);
+    if (parsed.filterOnMinistryClick !== undefined) setFilterOnMinistryClick(parsed.filterOnMinistryClick);
     if (parsed.year !== undefined) setYear(parsed.year);
     // Restore zoom only when no sel= (focusOnNeighborhood will handle zoom for sel= case)
     if (parsed.zoom !== undefined && parsed.selectedNodeId === undefined) {
@@ -368,7 +373,8 @@ export default function RealDataSankeyPage() {
       setProjectSortBy(parsed.projectSortBy ?? 'budget');
       setScaleBudgetToVisible(parsed.scaleBudgetToVisible ?? true);
       setFocusRelated(parsed.focusRelated ?? false);
-      setAutoFocusRelated(parsed.autoFocusRelated ?? true);
+      setAutoFocusRelated(parsed.autoFocusRelated ?? false);
+      setFilterOnMinistryClick(parsed.filterOnMinistryClick ?? true);
       if (parsed.year !== undefined) setYear(parsed.year);
       setFilterActive(parsed.filterActive ?? false);
       if (parsed.filterTarget !== undefined) setFilterTarget(parsed.filterTarget); else setFilterTarget('recipient');
@@ -410,7 +416,8 @@ export default function RealDataSankeyPage() {
     if (projectSortBy === 'spending') p.set('ps', 's');
     if (!scaleBudgetToVisible) p.set('sb', '0');
     if (focusRelated) p.set('fr', '1');
-    if (!autoFocusRelated) p.set('afr', '0');
+    if (autoFocusRelated) p.set('afr', '1');
+    if (!filterOnMinistryClick) p.set('fmc', '0');
     if (year !== '2025') p.set('yr', year);
     if (filterActive) p.set('f', '1');
     if (filterTarget === 'project') p.set('nft', 'p');
@@ -430,7 +437,7 @@ export default function RealDataSankeyPage() {
     } else {
       window.history.replaceState(null, '', url);
     }
-  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, year, filterActive, filterTarget, filterMinistryNames, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, acGeneral, acSpecial, acBoth, acNone]);
+  }, [selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, filterOnMinistryClick, year, filterActive, filterTarget, filterMinistryNames, searchQuery, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, acGeneral, acSpecial, acBoth, acNone]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -1507,6 +1514,33 @@ export default function RealDataSankeyPage() {
   const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
     e.stopPropagation();
     if (didPanRef.current) return;
+    // 省庁ノード × filterOnMinistryClick 連動: 単独設定 ⇄ 直前スナップショット復元
+    // 「単独設定状態」= フィルタが当該省庁単独で active（選択ノードの状態は問わない）
+    if (filterOnMinistryClick && node.type === 'ministry' && !node.aggregated) {
+      const isSingleFilterMatch = filterActive && filterMinistryNames.length === 1 && filterMinistryNames[0] === node.name;
+      if (isSingleFilterMatch && ministryFilterSnapshotRef.current) {
+        pendingHistoryAction.current = 'push';
+        const snap = ministryFilterSnapshotRef.current;
+        ministryFilterSnapshotRef.current = null;
+        setFilterMinistryNames(snap.filterMinistryNames);
+        setFilterActive(snap.filterActive);
+        setPinnedProjectId(null);
+        setPinnedRecipientId(null);
+        setPinnedMinistryName(null);
+        setFocusRelated(false);
+        selectNode(snap.selectedNodeId);
+        return;
+      }
+      if (!isSingleFilterMatch) {
+        ministryFilterSnapshotRef.current = {
+          filterMinistryNames: [...filterMinistryNames],
+          filterActive,
+          selectedNodeId,
+        };
+        setFilterMinistryNames([node.name]);
+        setFilterActive(true);
+      }
+    }
     const newId = selectedNodeId === node.id ? null : node.id;
     if (newId === null && focusRelated) {
       // Pin中ノードを再クリック → フィルターのみOFF（Pin解除しない）
@@ -1541,7 +1575,7 @@ export default function RealDataSankeyPage() {
       setPinnedMinistryName(null);
     }
     selectNode(newId);
-  }, [selectedNodeId, selectNode, focusRelated, autoFocusRelated, exitFocusRelated, graphData]);
+  }, [selectedNodeId, selectNode, focusRelated, autoFocusRelated, exitFocusRelated, graphData, filterOnMinistryClick, filterMinistryNames, filterActive]);
 
   // focusRelated=ON 中に別ノードをクリックした後、フルレイアウト更新後にオフセット調整
   useEffect(() => {
@@ -3321,6 +3355,10 @@ export default function RealDataSankeyPage() {
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={autoFocusRelated} onChange={e => { pendingHistoryAction.current = 'replace'; setAutoFocusRelated(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>選択時に関連ノードのみ表示</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <input type="checkbox" checked={filterOnMinistryClick} onChange={e => { pendingHistoryAction.current = 'replace'; setFilterOnMinistryClick(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
+                <span style={{ color: '#555' }}>省庁ノード選択でフィルタ</span>
               </label>
             </div>
           </>

--- a/docs/tasks/20260508_0610_sankey-svg省庁ノードクリック_フィルタ連動設計.md
+++ b/docs/tasks/20260508_0610_sankey-svg省庁ノードクリック_フィルタ連動設計.md
@@ -1,0 +1,107 @@
+# /sankey-svg 省庁ノードクリック ⇄ フィルタ連動設計
+
+## 背景
+
+`/sankey-svg` のノードクリックは、選択 + （`autoFocusRelated` ON 時）関連ノードのみ表示にフォーカスする挙動だった。一方、ヘッダの省庁フィルタ（`filterMinistryNames`）は手動操作のみで、Sankey 図上の省庁ノードと連動していなかった。
+
+省庁ノードを起点に「特定の省庁にフィルタ → 戻す」を 1 クリックで行えるようにする。
+
+## 仕様変更サマリ
+
+| 項目 | 変更前 | 変更後 |
+|------|--------|--------|
+| `autoFocusRelated` デフォルト | `true`（選択即フォーカス） | `false`（クリックは普通の選択） |
+| 省庁ノードクリック | 単純な選択トグル | フィルタ連動（オプション制） |
+| 設定項目 | （なし） | `省庁ノード選択でフィルタ`（デフォルト ON） |
+
+## 詳細仕様
+
+### 1. `autoFocusRelated` のデフォルトを `false`
+
+ノードクリック時に勝手に「関連のみ表示」へ移行しなくなる。ユーザーは右下のトグルボタンか設定で必要なときだけ ON にする。
+
+URL パラメータ書き込み規則も反転：
+- 旧: `afr=0` を非デフォルト時に書き込み（デフォルト true）
+- 新: `afr=1` を非デフォルト時に書き込み（デフォルト false）
+
+### 2. 新設定 `filterOnMinistryClick`（デフォルト `true`）
+
+設定ダイアログ内の「選択時に関連ノードのみ表示」直下にチェックボックスを追加。
+URL パラメータ `fmc`（`fmc=0` で OFF。デフォルト true なので true 時は書き込みなし）。
+
+### 3. 省庁ノードクリック時の状態遷移
+
+`filterOnMinistryClick = ON` のときのみ以下を適用。集約ノード（`__agg-*`）は対象外。
+
+#### 状態の定義
+
+- **単独設定状態**: `filterActive && filterMinistryNames === [当該省庁名]`
+- それ以外: 「初期状態」「副選択状態」「複数省庁フィルタ中」「他省庁フィルタ中」を含む
+
+> 注: 「単独設定状態」は **フィルタの状態のみ**で判定し、`selectedNodeId` の値には依存しない。これにより「省庁A 選択 → 空白クリックで非選択 → 省庁A 再クリック」でフィルタ解除になる挙動を保証する。
+
+#### スナップショットスロット
+
+`useRef<{ filterMinistryNames, filterActive, selectedNodeId } | null>`
+
+- フィルタを単独設定する直前の状態を保持
+- 復元時にクリア（1 段スロットのみ・履歴スタックではない）
+
+#### クリック時の処理
+
+```
+省庁ノード クリック
+  ├─ 単独設定状態 かつ snapshot あり
+  │    → snapshot 復元（filter / filterActive / selectedNodeId）
+  │      pinned* / focusRelated もリセット
+  │      snapshot をクリア
+  │      → return（通常選択フローには進まない）
+  │
+  ├─ 単独設定状態 かつ snapshot なし（手動でフィルタ設定後の単独）
+  │    → スナップショット保存しない・filter 変更しない
+  │      → 通常選択フロー（toggle deselect 等）にフォールスルー
+  │
+  └─ 単独設定状態でない（初期 / 副選択 / 複数 / 他省庁単独）
+       → snapshot に現状を保存
+         filterMinistryNames = [当該省庁名]
+         filterActive = true
+       → 通常選択フローにフォールスルー（ノード選択処理）
+```
+
+### 4. 通常選択フローとの関係
+
+省庁ノード処理後は既存の `handleNodeClick` ロジックにフォールスルーする：
+- `selectedNodeId` の更新（`selectNode`）
+- `pinnedProjectId` 等のクリア
+- `autoFocusRelated` ON 時のフォーカス処理
+
+これにより、フィルタ変更と選択が 1 クリックで一体的に行われる。
+
+## 想定シナリオ
+
+| # | 操作 | 結果 |
+|---|------|------|
+| 1 | 初期 → 省庁A クリック | filter=[A], filterActive=true, sel=A, snap={[], false, null} |
+| 2 | 続けて 省庁A クリック | snap 復元: filter=[], filterActive=false, sel=null, snap=null |
+| 3 | 省庁A クリック → 空白クリック → 省庁A クリック | 1 で snap 保存 / 2 で sel=null / 3 で **snap 復元（フィルタ解除）** |
+| 4 | 省庁A クリック → 省庁B クリック | snap={[A], true, A} に上書き、filter=[B], sel=B |
+| 5 | 4 から 省庁B クリック | snap 復元: filter=[A], filterActive=true, sel=A |
+| 6 | 手動でフィルタ=[A] に設定 → 省庁A クリック | 単独状態 ＆ snap=null → フィルタ変更なし、通常選択（sel=A） |
+| 7 | 手動でフィルタ=[A,B] → 省庁A クリック | 複数 → snap 保存、filter=[A]、通常選択（sel=A） |
+
+## 実装箇所
+
+- [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx)
+  - 型定義 `SankeyUrlState` に `filterOnMinistryClick: boolean`
+  - `parseSearchParams` に `fmc` パラメータ
+  - state: `autoFocusRelated` 初期値 `false`、`filterOnMinistryClick` (init `true`)、`ministryFilterSnapshotRef`
+  - 初期/popstate 復元と URL 書き込みの分岐
+  - `handleNodeClick` 冒頭に省庁ノード分岐を追加
+  - 設定ダイアログにチェックボックス追加
+
+## 設計判断メモ
+
+- **「単独設定状態」を選択ノードではなくフィルタ状態で判定**: 空白クリックで sel=null になっても、フィルタが当該省庁単独なら復元できるようにするため。
+- **`filterActive=true` も含めて操作**: 「フィルタ設定」が機能しないと UX 上意味がないため、クリック時に有効化、復元時に元の状態へ戻す。
+- **履歴スタックではなく 1 段スロット**: ユーザー要望が「クリック直前のスナップショット」だったため、簡素な 1 段で実装。多段が必要になれば差し替え可能。
+- **集約ノード（`__agg-*`）は対象外**: ドリルダウン不可ノードは除外（既存パターンに合わせる）。


### PR DESCRIPTION
## 目的（Why）

`/sankey-svg` のユーザーが省庁単位の絞り込みを Sankey 図上から 1 クリックで行えるようにし、かつ「うっかり絞った」状態を簡単に戻せるようにする。

これまでは以下が課題だった：
- ノードをクリックすると `autoFocusRelated` により即「関連のみ表示」へ移行してしまい、軽く詳細を見たいだけのケースでも操作感が重い
- 省庁フィルタはヘッダのドロップダウンからのみで、Sankey 図上の省庁ノードと連動していなかった

## 変更概要

### 1. `autoFocusRelated` のデフォルトを `false`
ノードクリックは普通に「選択」だけ行う。関連のみ表示は右下のトグル or 設定で必要なときだけ ON。
URL パラメータ `afr` の書き込み規則も反転（非デフォルト時のみ書き込み）。

### 2. 新設定「省庁ノード選択でフィルタ」（`filterOnMinistryClick`、デフォルト ON、URL: `fmc`）
省庁ノードクリックで以下を実行：
- **単独設定状態でない場合**: 直前状態（`filterMinistryNames` / `filterActive` / `selectedNodeId`）を 1 段スナップショットに保存し、フィルタを当該省庁単独 + active に
- **単独設定状態（フィルタが当該省庁のみ）**: スナップショット復元

「単独設定状態」は **フィルタの状態のみで判定**（選択ノードには依存しない）。これにより以下の操作で確実にフィルタ解除できる：

```
省庁A クリック → 空白クリック（選択解除）→ 省庁A クリック → フィルタ解除
```

### 3. 設計ドキュメント追加
`docs/tasks/20260508_0610_sankey-svg省庁ノードクリック_フィルタ連動設計.md`
仕様の状態遷移、シナリオ表、設計判断を記載。

## テスト方法

- [ ] `npm run dev` で `localhost:3002/sankey-svg` を開く
- [ ] 初期状態でノードをクリックしても「関連のみ表示」にならないことを確認
- [ ] 省庁ノードをクリック → ヘッダのフィルタが当該省庁単独 + filter active になることを確認
- [ ] そのまま再度同じ省庁ノードをクリック → フィルタが解除（元の状態に復帰）されることを確認
- [ ] 省庁A クリック → 空白クリック → 省庁A クリック でフィルタ解除されることを確認
- [ ] 省庁A → 省庁B → 省庁B（再クリック）で `filter=[A]` に戻ることを確認
- [ ] 設定ダイアログから「省庁ノード選択でフィルタ」を OFF にすると、省庁ノードクリックがフィルタに連動しないことを確認
- [ ] URL に `?fmc=0` を付けて開くと OFF 状態で起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ministry click filtering for the Sankey diagram—click a ministry node to filter by that ministry
  * Smart restore: click the same ministry again to return to your previous filter state
  * New settings toggle to enable/disable this feature (enabled by default)
  * Adjusted default display behavior for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->