### PR TITLE
feat(sankey-svg): フィルタ解除ボタンを検索コントロール横に追加

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1802,8 +1802,10 @@ export default function RealDataSankeyPage() {
     pendingHistoryAction.current = 'push';
     setFilterMinistryNames([]);
     setFilterProjectName('');
+    setFilterProjectNameRegex(false);
     setDebouncedFilterProjectName('');
     setFilterRecipientName('');
+    setFilterRecipientNameRegex(false);
     setDebouncedFilterRecipientName('');
     setFilterMinBudgetText('');
     setFilterMaxBudgetText('');

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1789,6 +1789,33 @@ export default function RealDataSankeyPage() {
 
   const pendingSearchResetRef = useRef(false);
 
+  // フィルタが何か掛かっているか（会計区分は全選択が「掛かっていない」状態）
+  const hasActiveFilters =
+    filterMinistryNames.length > 0 ||
+    filterProjectName !== '' ||
+    filterRecipientName !== '' ||
+    filterMinBudgetText !== '' || filterMaxBudgetText !== '' ||
+    filterMinSpendingText !== '' || filterMaxSpendingText !== '' ||
+    !(acGeneral && acSpecial && acBoth && acNone);
+
+  const clearAllFilters = useCallback(() => {
+    pendingHistoryAction.current = 'push';
+    setFilterMinistryNames([]);
+    setFilterProjectName('');
+    setDebouncedFilterProjectName('');
+    setFilterRecipientName('');
+    setDebouncedFilterRecipientName('');
+    setFilterMinBudgetText('');
+    setFilterMaxBudgetText('');
+    setFilterMinSpendingText('');
+    setFilterMaxSpendingText('');
+    setAcGeneral(true);
+    setAcSpecial(true);
+    setAcBoth(true);
+    setAcNone(true);
+    ministryFilterSnapshotRef.current = null;
+  }, []);
+
   const handleSearchSelect = useCallback((nodeId: string) => {
     setShowSearchResults(false);
     handleConnectionClick(nodeId);
@@ -3221,6 +3248,32 @@ export default function RealDataSankeyPage() {
             );
           })()}
         </div>{/* end 検索セクション */}
+
+        {/* フィルタ解除ボタン（常に同じ幅を占有し、非フィルタ時は非表示） */}
+        <button
+          type="button"
+          onClick={clearAllFilters}
+          title="フィルタを解除"
+          aria-label="フィルタを解除"
+          aria-hidden={!hasActiveFilters}
+          tabIndex={hasActiveFilters ? 0 : -1}
+          data-testid={testId('clear-filters')}
+          data-pan-disabled
+          style={{
+            flexShrink: 0, width: 32, height: 32,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(255,255,255,0.95)', border: '1px solid #e0e0e0',
+            borderRadius: 6, boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
+            cursor: 'pointer', color: '#666', padding: 0,
+            visibility: hasActiveFilters ? 'visible' : 'hidden',
+            pointerEvents: hasActiveFilters ? 'auto' : 'none',
+          }}
+        >
+            {/* Material Icons: filter_list_off */}
+            <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 -960 960 960" fill="currentColor">
+              <path d="M791-55 55-791l57-57 736 736-57 57ZM633-440l-80-80h167v80h-87ZM433-640l-80-80h487v80H433Zm-33 400v-80h160v80H400ZM240-440v-80h166v80H240ZM120-640v-80h86v80h-86Z"/>
+            </svg>
+          </button>
 
         </div>{/* end Row 1 flex */}
 


### PR DESCRIPTION
## 目的（Why）

省庁ノードクリックなどでフィルタが掛かった状態から、ユーザーが「全フィルタを一発で解除して全体表示に戻したい」というニーズに応えるため。現状はフィルタを掛けた経路（省庁クリック・フィルタパネル）ごとに個別に解除操作が必要で煩雑だった。

## 変更内容

- 検索コントロールの右隣にフィルタ解除アイコンボタン（Material Icons `filter_list_off`、32×32）を配置
- 表示条件: `filterMinistryNames` / `filterProjectName` / `filterRecipientName` / 予算・支出 min/max / 会計区分（全選択でない）のいずれかが有効なとき
- クリックで全フィルタ状態を初期値にリセット（履歴は push なので戻るで復元可能）。`ministryFilterSnapshotRef` も破棄
- ボタンは常にレンダリングし `visibility: hidden` + `pointerEvents: none` で非表示にすることで、表示有無で検索コントロールの幅が変動しないようにした

## テスト方法

- [ ] `npm run dev` → http://localhost:3002/sankey-svg
- [ ] 何もフィルタが掛かっていない状態で、解除ボタンが非表示（幅は確保）であることを確認
- [ ] 省庁ノードをクリック → 検索コントロール横にフィルタ解除アイコンが現れる
- [ ] アイコンクリックで全フィルタが解除され、ノード/エッジが全表示に戻ることを確認
- [ ] フィルタパネルから予算/支出/会計区分/事業名/支出先名を設定し、解除ボタンで一括解除できることを確認
- [ ] 検索コントロールの幅がボタン表示状態に依存せず一定であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "clear all filters" button to the filter control area. The button becomes visible when any filters are active (including text searches, budget ranges, account categories, or ministry selections) and resets all constraints with a single click.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/igomuni/marumie-rssystem/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->