### PR TITLE
feat(sankey-svg): zoom連動ラベルフォント動的拡大・ツールチップ位置補正・設定UI固定フォント

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -685,6 +685,9 @@ export default function RealDataSankeyPage() {
   fitTopPadPxRef.current = fitTopPadPx;
 
   // Compute max extra height from label shifts at a given zoom level (2-pass helper)
+  // Uses mapLabelSlotPx (slot-based formula), not colFontPx/zoom. Intentional: this runs for
+  // fitZoomWithShifts (always near fit zoom where zoomedIn=false) and getZoomAnchoredPanY
+  // (sub-pixel drift at zoom-in is acceptable).
   const calcShiftExtraH = useCallback((nodes: { y0: number; y1: number; id: string; type: string; projectId?: number }[], zoomK: number): number => {
     if (!showLabelsRef.current) return 0;
     const colShifts = new Map<number, number>();
@@ -1106,6 +1109,7 @@ export default function RealDataSankeyPage() {
           const distPrev = i > 0 ? (centers[i] - centers[i - 1]) : Infinity;
           const distNext = i < sorted.length - 1 ? (centers[i + 1] - centers[i]) : Infinity;
           const gapMax = Math.min(distPrev, distNext) * zoom * LABEL_FIT_RATIO;
+          // floor at mapLabelFontPx: intentional readability safeguard — labels may still overlap at high density
           colFontPx = Math.max(mapLabelFontPx, Math.min(zoomedMax, gapMax));
           topShift = h < colFontPx / zoom ? Math.max(0, colFontPx / zoom - h) : 0;
         } else {
@@ -2438,7 +2442,7 @@ export default function RealDataSankeyPage() {
           {hoveredNode && layout && !suppressHoverPopup && (() => {
             const GAP = Math.round(8 * fontScale);
             const tipW = Math.round(240 * fontScale);
-            const { cumShift: hoverCumShift = 0, topShift: hoverTopShift = 0 } = nodeShiftInfo.get(hoveredNode.id) ?? {};
+            const { cumShift: hoverCumShift = 0, topShift: hoverTopShift = 0, colFontPx: hoverColFontPx = mapLabelFontPx } = nodeShiftInfo.get(hoveredNode.id) ?? {};
             const nodeScreenH = (hoveredNode.y1 - hoveredNode.y0) * zoom;
             const screenCx = pan.x + getNodeScreenX0(hoveredNode) + screenNodeW / 2;
             const screenTop = pan.y + (MARGIN.top + hoveredNode.y0 + hoverCumShift + hoverTopShift) * zoom;
@@ -2484,7 +2488,7 @@ export default function RealDataSankeyPage() {
             const both = budget != null && spending != null;
             const tipH = Math.round(((both ? 88 : 76) + (hoveredAcLabel ? 18 : 0)) * fontScale);
             // 大ノード: マウスY連動（カーソル上方）/ 小ノード: ラベル上端-GAPにポップアップ底辺を固定
-            const labelFontPx = mapLabelFontPx;
+            const labelFontPx = hoverColFontPx;
             const labelTopScreenY = screenTop + nodeScreenH / 2 - labelFontPx / 2;
             const cursorGap = Math.round(12 * fontScale);
             const lyAboveCursor = mousePos.y - tipH - cursorGap;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -95,6 +95,8 @@ const PROJECT_OVERVIEW_PREVIEW_HEIGHT_MAX = 600;
 const HOVER_SUPPRESS_AFTER_INTERACTION_MS = 500;
 const HOVER_ENTER_DELAY_MS = 220;
 const FIT_TOP_PAD_PX = 32;
+const ZOOM_FONT_MAX_RATIO = 1.3;   // zoom-in でフォントを最大で元の何倍まで拡大するか
+const LABEL_FIT_RATIO = 0.85;      // ノード表示高さに対してフォントが占める割合の上限
 
 function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const p = new URLSearchParams(search);
@@ -1062,9 +1064,9 @@ export default function RealDataSankeyPage() {
     return result;
   }, [filtered, svgWidth, svgHeight, SEARCH_BOX_RESERVE]);
 
-  // Cumulative shift per node: { cumShift: slot-level offset, topShift: rect-within-slot offset }
+  // Cumulative shift per node: { cumShift: slot-level offset, topShift: rect-within-slot offset, colFontPx: label font px }
   const nodeShiftInfo = useMemo(() => {
-    const info = new Map<string, { cumShift: number; topShift: number }>();
+    const info = new Map<string, { cumShift: number; topShift: number; colFontPx: number }>();
     if (!layout || !showLabels) return info;
     const nodesByColumn = new Map<number, typeof layout.nodes[0][]>();
     for (const node of layout.nodes) {
@@ -1081,22 +1083,41 @@ export default function RealDataSankeyPage() {
         spendingH.set('__agg-project-budget', Math.max(1, n.y1 - n.y0));
       }
     }
+    const zoomedIn = zoom > baseZoom + 0.001;
     for (const nodes of nodesByColumn.values()) {
       const sorted = [...nodes].sort((a, b) => a.y0 - b.y0);
+      // Pre-compute each node's effective height and label center (SVG units) for gap calculation
+      const heights = sorted.map(n => {
+        const bH = Math.max(1, n.y1 - n.y0);
+        return n.type === 'project-budget' || n.id === '__agg-project-budget'
+          ? Math.max(bH, spendingH.get(n.id) ?? bH)
+          : bH;
+      });
+      const centers = sorted.map((n, i) => n.y0 + heights[i] / 2);
       let cumShift = 0;
-      for (const node of sorted) {
-        // For project-budget nodes, base topShift on the larger of budget/spending height
-        const budgetH = Math.max(1, node.y1 - node.y0);
-        const h = node.type === 'project-budget' || node.id === '__agg-project-budget'
-          ? Math.max(budgetH, spendingH.get(node.id) ?? budgetH)
-          : budgetH;
-        const topShift = h * zoom < mapLabelSlotPx ? Math.max(0, mapLabelSlotPx / zoom - h) : 0;
-        info.set(node.id, { cumShift, topShift });
+      for (let i = 0; i < sorted.length; i++) {
+        const node = sorted[i];
+        const h = heights[i];
+        let colFontPx: number;
+        let topShift: number;
+        if (zoomedIn) {
+          const zoomedMax = mapLabelFontPx * Math.min(zoom / baseZoom, ZOOM_FONT_MAX_RATIO);
+          // Limit font by the shorter of the two neighbor center-to-center gaps
+          const distPrev = i > 0 ? (centers[i] - centers[i - 1]) : Infinity;
+          const distNext = i < sorted.length - 1 ? (centers[i + 1] - centers[i]) : Infinity;
+          const gapMax = Math.min(distPrev, distNext) * zoom * LABEL_FIT_RATIO;
+          colFontPx = Math.max(mapLabelFontPx, Math.min(zoomedMax, gapMax));
+          topShift = h < colFontPx / zoom ? Math.max(0, colFontPx / zoom - h) : 0;
+        } else {
+          colFontPx = mapLabelFontPx;
+          topShift = h * zoom < mapLabelSlotPx ? Math.max(0, mapLabelSlotPx / zoom - h) : 0;
+        }
+        info.set(node.id, { cumShift, topShift, colFontPx });
         cumShift += topShift;
       }
     }
     return info;
-  }, [layout, showLabels, zoom, mapLabelSlotPx]);
+  }, [layout, showLabels, zoom, mapLabelSlotPx, mapLabelFontPx, baseZoom]);
 
   const selectedNode = useMemo(() => {
     if (!selectedNodeId) return null;
@@ -2192,7 +2213,7 @@ export default function RealDataSankeyPage() {
                         : null;
                       const isSelectedMerged = node.id === selectedNodeId || spendingNode?.id === selectedNodeId;
                       const maxH = Math.max(bH, sH);
-                      const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
+                      const { cumShift = 0, topShift = 0, colFontPx = mapLabelFontPx } = nodeShiftInfo.get(node.id) ?? {};
                       const labelVisible = topShift > 0 || maxH * zoom > mapLabelVisibleMinHPx || isSelectedMerged;
                       const nodeOpacity = connectedNodeIds
                         ? (isConnected ? 1 : 0.3)
@@ -2210,7 +2231,7 @@ export default function RealDataSankeyPage() {
                               onClick={(e) => handleNodeClick(node, e)}
                             />
                             {labelVisible && (
-                              <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={mapLabelFontPx / zoom} dominantBaseline="middle"
+                              <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                                 style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                                 onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -2238,7 +2259,7 @@ export default function RealDataSankeyPage() {
                           />
                           {labelVisible && (<>
                             {/* Left label: budget amount */}
-                            <text x={getNodeInnerX0(node) - innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={mapLabelFontPx / zoom} dominantBaseline="middle" textAnchor="end"
+                            <text x={getNodeInnerX0(node) - innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle" textAnchor="end"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                               style={{ userSelect: 'none', cursor: 'pointer' }}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -2249,7 +2270,7 @@ export default function RealDataSankeyPage() {
                               {formatYen(node.value)}{node.isScaled && node.rawValue != null && <tspan fill="#888"> / {formatYen(node.rawValue)}</tspan>}
                             </text>
                             {/* Right label: project name + spending amount */}
-                            <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={mapLabelFontPx / zoom} dominantBaseline="middle"
+                            <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                               style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
@@ -2266,7 +2287,7 @@ export default function RealDataSankeyPage() {
                     // Regular node (total, ministry, recipient)
                     const h = node.y1 - node.y0;
                     const isSelected = node.id === selectedNodeId;
-                    const { cumShift = 0, topShift = 0 } = nodeShiftInfo.get(node.id) ?? {};
+                    const { cumShift = 0, topShift = 0, colFontPx = mapLabelFontPx } = nodeShiftInfo.get(node.id) ?? {};
                     const labelVisible = topShift > 0 || (h + NODE_PAD) * zoom > mapLabelVisibleMinHPx || isSelected;
                     const col = getColumn(node);
                     const isLastCol = col === lastCol;
@@ -2301,7 +2322,7 @@ export default function RealDataSankeyPage() {
                           <text
                             x={getNodeInnerX1(node) + innerLabelGap}
                             y={topShift + h / 2}
-                            fontSize={mapLabelFontPx / zoom}
+                            fontSize={colFontPx / zoom}
                             dominantBaseline="middle"
                             fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                             style={{ userSelect: 'none', cursor: 'pointer' }}
@@ -2417,9 +2438,10 @@ export default function RealDataSankeyPage() {
           {hoveredNode && layout && !suppressHoverPopup && (() => {
             const GAP = Math.round(8 * fontScale);
             const tipW = Math.round(240 * fontScale);
+            const { cumShift: hoverCumShift = 0, topShift: hoverTopShift = 0 } = nodeShiftInfo.get(hoveredNode.id) ?? {};
             const nodeScreenH = (hoveredNode.y1 - hoveredNode.y0) * zoom;
             const screenCx = pan.x + getNodeScreenX0(hoveredNode) + screenNodeW / 2;
-            const screenTop = pan.y + (MARGIN.top + hoveredNode.y0) * zoom;
+            const screenTop = pan.y + (MARGIN.top + hoveredNode.y0 + hoverCumShift + hoverTopShift) * zoom;
             const screenBottom = screenTop + nodeScreenH;
             const lx = Math.max(4, Math.min(screenCx - tipW / 2, svgWidth - tipW - 4));
             // ノードタイプ別に予算・支出を解決
@@ -3565,7 +3587,7 @@ export default function RealDataSankeyPage() {
         {showSettings && (
           <>
             <div style={{ position: 'fixed', inset: 0, zIndex: 18 }} onMouseDown={() => setShowSettings(false)} />
-            <div id="sankey-topn-settings" role="dialog" aria-label="表示設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: CONTROL_SMALL_FONT_PX, minWidth: Math.round(240 * fontScale), maxWidth: 'calc(100vw - 24px)', display: 'flex', flexDirection: 'column', gap: 10, colorScheme: 'light', color: '#333' }}>
+            <div id="sankey-topn-settings" role="dialog" aria-label="表示設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, minWidth: 240, maxWidth: 'calc(100vw - 24px)', display: 'flex', flexDirection: 'column', gap: 10, colorScheme: 'light', color: '#333' }}>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showLabels} onChange={e => { pendingHistoryAction.current = 'replace'; setShowLabels(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>
@@ -3580,7 +3602,7 @@ export default function RealDataSankeyPage() {
               </label>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <span style={{ color: '#555' }}>事業ノードの並び順:</span>
-                <select value={projectSortBy} onChange={e => { pendingHistoryAction.current = 'replace'; setProjectSortBy(e.target.value as 'budget' | 'spending'); }} style={{ fontSize: CONTROL_SMALL_FONT_PX, padding: '2px 4px', borderRadius: 4, border: '1px solid #ccc', cursor: 'pointer' }} data-pan-disabled>
+                <select value={projectSortBy} onChange={e => { pendingHistoryAction.current = 'replace'; setProjectSortBy(e.target.value as 'budget' | 'spending'); }} style={{ fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, padding: '2px 4px', borderRadius: 4, border: '1px solid #ccc', cursor: 'pointer' }} data-pan-disabled>
                   <option value="budget">予算額</option>
                   <option value="spending">支出額</option>
                 </select>
@@ -3614,14 +3636,14 @@ export default function RealDataSankeyPage() {
                           setBaseFontPx(Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, v)));
                         }
                       }}
-                      style={{ width: 48, fontSize: CONTROL_SMALL_FONT_PX, padding: '2px 4px', border: '1px solid #ccc', borderRadius: 4, textAlign: 'center' }}
+                      style={{ width: 48, fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, padding: '2px 4px', border: '1px solid #ccc', borderRadius: 4, textAlign: 'center' }}
                       data-pan-disabled
                       aria-label="基準フォントサイズ(数値)"
                     />
                     <button
                       onClick={() => { pendingHistoryAction.current = 'replace'; setBaseFontPx(BASE_FONT_PX_DEFAULT); }}
                       title="既定値に戻す"
-                      style={{ background: 'transparent', border: '1px solid #ddd', borderRadius: 4, color: '#888', cursor: 'pointer', fontSize: META_FONT_PX, padding: '2px 6px' }}
+                      style={{ background: 'transparent', border: '1px solid #ddd', borderRadius: 4, color: '#888', cursor: 'pointer', fontSize: META_FONT_PX_DEFAULT, padding: '2px 6px' }}
                       data-pan-disabled
                     >既定</button>
                   </div>

--- a/docs/tasks/20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md
+++ b/docs/tasks/20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md
@@ -1,0 +1,247 @@
+# sankey-svg：zoom 連動ラベルサイズの設計検討
+
+作成日: 2026-05-14 08:03 (Asia/Tokyo)
+対象: [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx)
+
+## 背景
+
+「基準フォントサイズ」設定の追加と高フォント時の全体表示問題への対応のなかで、列ごとの **adaptive slot/font** を導入した。
+
+- Fit zoom 時: 列内すべてのラベルが viewport に収まるよう、列ごとに slot/font を縮小
+- ユーザーがズームインしたとき (`zoom > baseZoom`): adaptive を停止し base 値へ戻す → 元のドリルダウン体験を維持
+
+このベースをさらに「zoom 率に応じてラベルが動的に変わる」方向へ拡張するための検討用ドキュメント。
+
+---
+
+## 現状の関係式
+
+```
+fontScale       = baseFontPx / 12
+mapLabelFontPx  = round(11 × fontScale)   ≈ baseFontPx × 11/12      (screen px)
+mapLabelSlotPx  = round(12 × fontScale)   = baseFontPx              (screen px)
+
+useAdaptive     = zoom <= baseZoom + 0.001
+
+slotPxEffective = useAdaptive
+                ? clamp(labelBudgetScreen / nShort, 6, mapLabelSlotPx)   // 列ごと
+                : mapLabelSlotPx
+
+labelBudgetScreen = availH × 0.85 − tallContribSvg × zoom
+
+colFontPx       = useAdaptive ? min(mapLabelFontPx, slotPxEffective) : mapLabelFontPx
+
+text fontSize   = colFontPx / zoom   (SVG units、画面では colFontPx px に見える)
+```
+
+### スクリーン上のラベル高さ範囲
+
+| baseFontPx | Max (= mapLabelFontPx) | Min (床値) |
+|-----------:|-----------------------:|-----------:|
+|  8         |  7                     | 6          |
+| 12 (既定)  | 11                     | 6          |
+| 16         | 15                     | 6          |
+| 20         | 18                     | 6          |
+| 24         | 22                     | 6          |
+
+---
+
+## UI 全体のフォントサイズ一覧
+
+`scaleFont(px) = max(1, round(px × baseFontPx / 12))` ですべての UI 要素が比例スケール。
+
+### Sankey 図本体
+
+| 用途 | 定数 (DEFAULT) | baseFontPx=8 | 12 (既定) | 16 | 20 | 24 |
+|------|---------------:|----:|----:|----:|----:|----:|
+| ノードラベル | MAP_LABEL_FONT_PX (11) | 7 | 11 | 15 | 18 | 22 |
+| ラベルスロット高 | MAP_LABEL_SLOT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| ラベル可視判定閾値 | MAP_LABEL_VISIBLE_MIN_H_PX (11) | 7 | 11 | 15 | 18 | 22 |
+| 列ラベル（タイトル） | COLUMN_LABEL_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| 列ラベル（金額） | COLUMN_AMOUNT_FONT_PX (11) | 7 | 11 | 15 | 18 | 22 |
+
+### 検索 / コントロール類（画面右上の Row 1, TopN パネル, 設定ダイアログ）
+
+| 用途 | 定数 (DEFAULT) | 8 | 12 | 16 | 20 | 24 |
+|------|---------------:|---:|---:|---:|---:|---:|
+| 検索入力 | SEARCH_FONT_PX (14) | 9 | 14 | 19 | 23 | 28 |
+| 通常コントロール | CONTROL_FONT_PX (13) | 9 | 13 | 17 | 22 | 26 |
+| 小コントロール（会計/省庁/予算/支出 など） | CONTROL_SMALL_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| メタ表示（× / カウント / 補足） | META_FONT_PX (11) | 7 | 11 | 15 | 18 | 22 |
+
+設定ダイアログ・TopN ダイアログのテキストは原則 `CONTROL_SMALL_FONT_PX` と `META_FONT_PX` を併用。`minWidth` も `240 × fontScale` でスケールするため横幅も連動。
+
+### サイドパネル（ノード詳細）
+
+| 用途 | 定数 (DEFAULT) | 8 | 12 | 16 | 20 | 24 |
+|------|---------------:|---:|---:|---:|---:|---:|
+| パネルタイトル（ノード名） | PANEL_TITLE_FONT_PX (14) | 9 | 14 | 19 | 23 | 28 |
+| 主指標値（予算 or 支出） | PANEL_PRIMARY_VALUE_FONT_PX (15) | 10 | 15 | 20 | 25 | 30 |
+| リスト名（事業・支出先 名前） | PANEL_LIST_NAME_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| リスト金額 | PANEL_LIST_VALUE_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| パネル内メタ・事業概要本文 | PANEL_META_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+
+### ホバーツールチップ（ノード / リンク / 列ヘッダ）
+
+| 用途 | 定数 (DEFAULT) | 8 | 12 | 16 | 20 | 24 |
+|------|---------------:|---:|---:|---:|---:|---:|
+| Tooltip タイトル | TOOLTIP_TITLE_FONT_PX (12) | 8 | 12 | 16 | 20 | 24 |
+| Tooltip 値（兆/億表記） | TOOLTIP_VALUE_FONT_PX (11) | 7 | 11 | 15 | 18 | 22 |
+| Tooltip メタ（円/件数/補足） | TOOLTIP_META_FONT_PX (10) | 7 | 10 | 13 | 17 | 20 |
+
+ツールチップは `tipW = 240 × fontScale`, `tipH = (88 or 76 + 18) × fontScale`, `GAP = 8 × fontScale`, `cursorGap = 12 × fontScale` で外形寸法も比例スケール。配置時は cumShift+topShift を考慮した実描画位置基準で計算（[app/sankey-svg/page.tsx:2417 付近](../../app/sankey-svg/page.tsx)）。
+
+### サイズ感の比較（base=12 で全体最小〜最大）
+
+base=12 のときの screen px ベース最小〜最大: 10 px (Tooltip メタ) 〜 15 px (パネル主指標) と、目視で 1.5 倍程度のレンジに収まる。base を上げてもこの相対比は維持される。
+
+### いつ Max / Min か
+
+| 状況 | colFontPx |
+|------|-----------|
+| Fit zoom、short ノード少 | Max |
+| Fit zoom、short ノード過剰 | adaptive 縮小 (Min まで) |
+| ズームイン (`zoom > baseZoom`) | Max 固定 |
+| ズームアウト (`zoom < baseZoom`) | adaptive 適用（実質 Max 近辺） |
+
+---
+
+## 検討課題
+
+現在の挙動には次の改善余地がある。
+
+1. ズームイン時にラベルが「base 固定」で、rect は大きくなるのにラベルだけ変わらず**密度差が強調されすぎる**。
+2. Adaptive の床値が絶対値 6 px。`baseFontPx` の意図に反する小さい値になり得る。
+3. Fit ⇄ ズームイン の境界 (`zoom = baseZoom`) で**ラベルサイズが不連続に切り替わる**（境目で見た目が瞬時に変化）。
+4. Adaptive は列ごと独立。列をまたいだ視覚的な統一感が薄い。
+5. `availH × 0.85` の 0.85 が固定。タイトル/コントロール領域が増えるとマージンが不足するかも。
+
+---
+
+## 修正案
+
+### 案 A: zoom 倍率に連動する Max（ズームインで拡大）
+
+ズームインしたとき、ラベルもある程度大きくしたい。
+
+```
+zoomFactor = clamp(zoom / baseZoom, 1, ZOOM_FONT_MAX_RATIO)   // 1〜2 倍程度
+colFontPx_max = mapLabelFontPx × zoomFactor                     // ズームインで成長
+```
+
+- メリット: ズームインで rect とラベルの相対バランス維持。詳細閲覧で読みやすい。
+- 注意: 大きくしすぎるとラベル同士がぶつかる。`ZOOM_FONT_MAX_RATIO` の妥当値要検討（1.5〜2.0 が候補）。
+
+### 案 B: Min を相対値に変える
+
+```
+COLFONT_MIN_RATIO = 0.5   // base の半分
+fontMinPx = max(6, baseFontPx × COLFONT_MIN_RATIO)
+slotPxEffective = clamp(labelBudgetScreen / nShort, fontMinPx, mapLabelSlotPx)
+```
+
+- メリット: 「base=24 なのに 6px は小さすぎる」を回避。`baseFontPx` の意図を尊重。
+- 注意: base 大かつノード多列の場合、Min 引き上げによって fit zoom が小さくなり全体縮小される（トレードオフ）。
+
+### 案 C: Fit ⇄ ズームインの遷移を線形ブレンド
+
+```
+TRANSITION_END = 1.5            // baseZoom の何倍まででブレンドするか
+t = clamp((zoom − baseZoom) / (baseZoom × (TRANSITION_END − 1)), 0, 1)
+colFontPx = lerp(adaptiveColFontPx, mapLabelFontPx, t)
+```
+
+- メリット: ズームの境目でラベルサイズがピョコンと変わらず滑らか。
+- 注意: 中間域では「adaptive と base のあいだ」のサイズ。ピクセル単位の計算なのでアンチエイリアスは綺麗。
+
+### 案 D: 列ごとではなくグローバルな adapt スケール
+
+すべての列で最も厳しい列の縮小率に合わせる：
+
+```
+globalScale = min(列ごとの slotPxEffective / mapLabelSlotPx)
+colFontPx = mapLabelFontPx × globalScale   // 全列同じ
+```
+
+- メリット: 列をまたいで font サイズ統一、視覚的に整う。
+- 注意: 余裕のある列まで縮小される（情報密度はやや低下）。
+
+### 案 E: `availH 占有率` を baseFontPx に応じて可変
+
+`0.85` を hard-code でなく、baseFontPx が大きいほど大きめ（labels 専有を許容）にする:
+
+```
+availHRatio = clamp(0.7 + (baseFontPx − 12) × 0.015, 0.7, 0.9)
+```
+
+- メリット: 大フォント時にラベル領域を確保しやすい。
+- 注意: 効果はやや軽微。他案と組み合わせで採用したい。
+
+---
+
+## 推奨組み合わせ案
+
+| Tier | 案 | 理由 |
+|------|----|------|
+| 必須 | B (Min を相対値) | baseFontPx の意図を尊重するための基本 |
+| 推奨 | C (線形ブレンド) | 境界の見た目をなめらかにする副作用が少なく実装も明快 |
+| 検討 | A (zoom 連動 Max) | ドリルダウン UX を強化したい場合 |
+| 任意 | D (グローバル統一) | 視覚的一体感を優先したい場合（A と相反する設計判断） |
+| 補助 | E (availH 比率可変) | A/B のフォロー |
+
+ベースラインとしては **B + C** を最初に入れ、効果を見て A もしくは D を追加採用する流れが安全。
+
+---
+
+## 実装ポイント
+
+主に [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx) の `nodeShiftInfo` useMemo を改修。
+
+- 案 A: `colFontPx` の上限を `mapLabelFontPx × min(zoom/baseZoom, MAX_RATIO)` に変更
+- 案 B: `fontMinPx = max(6, baseFontPx × MIN_RATIO)` を定数化、`slotPxEffective` の下限へ
+- 案 C: `t` 遷移係数で adaptive / base を `lerp`
+- 案 D: 列ループ後にもう一段の reduce で `globalScale` を計算、各列に再代入
+- 案 E: `availH × ratio` の係数を関数化
+
+定数追加箇所（[app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx#L85) 付近に既存定数群あり）:
+
+```ts
+const COLFONT_MIN_RATIO = 0.5;           // 案 B
+const ZOOM_FONT_TRANSITION_END = 1.5;    // 案 C
+const ZOOM_FONT_MAX_RATIO = 1.4;         // 案 A
+```
+
+---
+
+## 検証指針
+
+`tmp/` 配下のスクショ撮影と Playwright スクリプトで:
+
+1. base × 5 段階 (8, 12, 16, 20, 24)
+2. fit / +1zoom / +3zoom / −1zoom の 4 状態
+3. 検証項目:
+   - 全ラベル可視数（target = 191）
+   - 最大 `text.fontSize`（SVG units → screen 換算）
+   - 最大 `getBoundingClientRect().bottom` (target < viewport height)
+   - ラベル相互の overlap 件数（隣接 text 矩形の交差判定）
+
+→ 4 × 5 = 20 ケースを自動チェックして合否マトリクス化。
+
+---
+
+## 不変条件
+
+fit zoom（= baseZoom）の状態は修正前後で同じであること。具体的には：
+
+- 全体表示時の TopN 収容上限 `N_max ≈ availH × 0.9 / mapLabelSlotPx`（Full HD baseFontPx=12 で約76ノード）
+- `topShift` 計算・`calcShiftExtraH`・`fitZoomWithShifts` の結果
+
+この上限は意図的な仕様であり、いずれの案を採用しても fit zoom 時の基準値を変えてはならない。
+
+---
+
+## 関連
+
+- 既存実装: [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx)（`nodeShiftInfo`, `calcShiftExtraH`, label 描画 4 箇所）
+- 関連メモ: [docs/tasks/archive/](../tasks/archive/)（既存タスク群）
+- 実装計画: [docs/tasks/20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md](./20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md)

--- a/docs/tasks/20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md
+++ b/docs/tasks/20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md
@@ -16,7 +16,7 @@
 
 ## 現状の関係式
 
-```
+```text
 fontScale       = baseFontPx / 12
 mapLabelFontPx  = round(11 × fontScale)   ≈ baseFontPx × 11/12      (screen px)
 mapLabelSlotPx  = round(12 × fontScale)   = baseFontPx              (screen px)
@@ -124,7 +124,7 @@ base=12 のときの screen px ベース最小〜最大: 10 px (Tooltip メタ) 
 
 ズームインしたとき、ラベルもある程度大きくしたい。
 
-```
+```text
 zoomFactor = clamp(zoom / baseZoom, 1, ZOOM_FONT_MAX_RATIO)   // 1〜2 倍程度
 colFontPx_max = mapLabelFontPx × zoomFactor                     // ズームインで成長
 ```
@@ -134,7 +134,7 @@ colFontPx_max = mapLabelFontPx × zoomFactor                     // ズームイ
 
 ### 案 B: Min を相対値に変える
 
-```
+```text
 COLFONT_MIN_RATIO = 0.5   // base の半分
 fontMinPx = max(6, baseFontPx × COLFONT_MIN_RATIO)
 slotPxEffective = clamp(labelBudgetScreen / nShort, fontMinPx, mapLabelSlotPx)
@@ -145,7 +145,7 @@ slotPxEffective = clamp(labelBudgetScreen / nShort, fontMinPx, mapLabelSlotPx)
 
 ### 案 C: Fit ⇄ ズームインの遷移を線形ブレンド
 
-```
+```text
 TRANSITION_END = 1.5            // baseZoom の何倍まででブレンドするか
 t = clamp((zoom − baseZoom) / (baseZoom × (TRANSITION_END − 1)), 0, 1)
 colFontPx = lerp(adaptiveColFontPx, mapLabelFontPx, t)
@@ -158,7 +158,7 @@ colFontPx = lerp(adaptiveColFontPx, mapLabelFontPx, t)
 
 すべての列で最も厳しい列の縮小率に合わせる：
 
-```
+```text
 globalScale = min(列ごとの slotPxEffective / mapLabelSlotPx)
 colFontPx = mapLabelFontPx × globalScale   // 全列同じ
 ```
@@ -170,7 +170,7 @@ colFontPx = mapLabelFontPx × globalScale   // 全列同じ
 
 `0.85` を hard-code でなく、baseFontPx が大きいほど大きめ（labels 専有を許容）にする:
 
-```
+```text
 availHRatio = clamp(0.7 + (baseFontPx − 12) × 0.015, 0.7, 0.9)
 ```
 

--- a/docs/tasks/20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md
+++ b/docs/tasks/20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md
@@ -1,0 +1,158 @@
+# sankey-svg：zoom 連動ラベルフォントサイズ動的拡大
+
+作成日: 2026-05-15 06:24 (Asia/Tokyo)
+対象: [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx)
+
+## 目的
+
+ズームインしたとき、拡大されたノード rect に対してラベルが小さいまま（固定画面サイズ）で密度差が強調されすぎる問題を解消する。ズームインするほどノードが大きく見えるので、ラベルもノードの表示高さに収まる範囲でスケールアップし、読みやすさとバランスを改善する。
+
+---
+
+## スコープ（今回の変更範囲）
+
+- **zoom > baseZoom（ズームイン）のときのみ** フォントサイズを拡大する
+- **zoom ≤ baseZoom（初期状態・ズームアウト）** は既存の挙動を維持（変更なし）
+- 列ごとではなく **ノードごと** に上限を設ける（ノードの高さに余裕を持って収まる範囲）
+- ラベルの y 位置補正は `topShift` ロジックで対応（既存の仕組みを拡張）
+
+---
+
+## 現状の実装
+
+### フォントサイズ
+
+すべてのノードラベルで固定：
+
+```
+fontSize = mapLabelFontPx / zoom   (SVG units)
+```
+
+画面上では常に `mapLabelFontPx` px に見える（zoom に関わらず不変）。
+
+### topShift（小ノードへの位置補正）
+
+[app/sankey-svg/page.tsx:1093](../../app/sankey-svg/page.tsx#L1093) の `nodeShiftInfo` useMemo 内：
+
+```
+topShift = h * zoom < mapLabelSlotPx
+         ? Math.max(0, mapLabelSlotPx / zoom - h)
+         : 0
+```
+
+ノードの表示高さがラベルスロット未満のとき、ノードを下にずらして「スロット高分の上余白」を確保する。
+ラベルは `y = topShift + h / 2`（`dominantBaseline="middle"`）で配置 → ラベルの中点 = ノードの中点。
+
+### ラベルの y 座標
+
+```
+y = topShift + h / 2
+```
+
+`dominantBaseline="middle"` なのでこの値がテキストの中央。
+topShift が 0 のとき → ノードの中点にラベルの中点が来る。
+topShift > 0 のとき（ノード < スロット）→ `topShift = slotH/zoom - h` なので `y = slotH/zoom - h/2`、ここでもラベルの中点 = ノードの中点が維持される。
+
+---
+
+## 変更設計
+
+### フォントサイズ計算の変更
+
+ノードごとに `colFontPx` を計算し、`fontSize = colFontPx / zoom` に変える。
+
+```
+// zoom ≤ baseZoom: 変更なし
+colFontPx = mapLabelFontPx
+
+// zoom > baseZoom: ノードごとに拡大上限を決定
+zoomedMax    = mapLabelFontPx × min(zoom / baseZoom, ZOOM_FONT_MAX_RATIO)
+nodeMaxFont  = (h × zoom) × LABEL_FIT_RATIO         // ノードの表示高さ × 余裕係数
+colFontPx    = max(mapLabelFontPx, min(zoomedMax, nodeMaxFont))
+```
+
+| 変数 | 意味 |
+|------|------|
+| `zoomedMax` | ズーム比率による上限（ZOOM_FONT_MAX_RATIO 倍が天井） |
+| `nodeMaxFont` | ノードの表示高さに収まるフォントの上限（LABEL_FIT_RATIO で余裕確保） |
+| `colFontPx` | 実際に使うフォントサイズ（screen px 相当）。base より小さくはしない |
+
+`nodeMaxFont` の制約により、小さいノードではほとんど拡大されず、大きいノードほど大きくなる。
+
+### topShift の変更
+
+現状は `mapLabelSlotPx` 基準だが、新しいフォントサイズ（`colFontPx`）基準に変更する：
+
+```
+labelHSvg = colFontPx / zoom   // ラベル高さ（SVG units）
+topShift  = h < labelHSvg
+          ? Math.max(0, labelHSvg - h)
+          : 0
+```
+
+ラベル y 座標は変更なし（`y = topShift + h / 2`）。
+
+**位置補正の正しさの確認：**
+
+- ノード高さ ≥ ラベル高さ（`h ≥ labelHSvg`）: `topShift = 0` → `y = h/2` → ノードのmiddle = ラベルのmiddle ✓
+- ノード高さ < ラベル高さ（`h < labelHSvg`）: `topShift = labelHSvg - h` → `y = labelHSvg - h/2` → ラベルのmiddle（= y）= ノードのmiddle（= topShift + h/2 = labelHSvg - h/2）と一致 ✓
+
+### 新規定数
+
+[app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx#L85) 付近の定数群に追加：
+
+```ts
+const ZOOM_FONT_MAX_RATIO = 2.0;   // ズームインでフォントを最大で元の何倍まで拡大するか
+const LABEL_FIT_RATIO = 0.85;      // ノード表示高さに対してフォントが占める割合の上限
+```
+
+---
+
+## 実装箇所
+
+### 1. `nodeShiftInfo` useMemo の拡張
+
+[app/sankey-svg/page.tsx:1066](../../app/sankey-svg/page.tsx#L1066)
+
+返り値の型を `{ cumShift: number; topShift: number; colFontPx: number }` に拡張。
+依存配列に `baseZoom` を追加。
+ループ内でノードごとの `colFontPx` と新しい `topShift` を計算してMapに格納。
+
+### 2. ラベル描画箇所（4箇所）
+
+`fontSize={mapLabelFontPx / zoom}` → `fontSize={nodeInfo.colFontPx / zoom}` に変更。
+
+| 行番号（目安） | 対象 |
+|---------------|------|
+| [~2213](../../app/sankey-svg/page.tsx#L2213) | project-budget（spendingNode なし）の右ラベル |
+| [~2241](../../app/sankey-svg/page.tsx#L2241) | project-budget（spendingNode あり）の左ラベル（金額） |
+| [~2252](../../app/sankey-svg/page.tsx#L2252) | project-budget（spendingNode あり）の右ラベル（事業名） |
+| [~2304](../../app/sankey-svg/page.tsx#L2304) | 通常ノード（total / ministry / recipient） |
+
+---
+
+## 不変条件（修正前後で同じであること）
+
+fit zoom（= baseZoom）の状態では `colFontPx = mapLabelFontPx` が維持されるため、以下は変わらない：
+
+- 全体表示時の TopN 収容上限 `N_max ≈ availH × 0.9 / mapLabelSlotPx`（Full HD baseFontPx=12 で約76ノード）
+- `topShift` の計算結果（= `max(0, mapLabelSlotPx/zoom - h)` と同値）
+- `calcShiftExtraH` → `fitZoomWithShifts` の結果（baseZoom の確定値）
+
+この上限はユーザーが意図的に定めた仕様であり、修正後も同じ基準を維持する。
+
+---
+
+## スコープ外（今回変更しない）
+
+- zoom ≤ baseZoom のフォントサイズ（adaptive ロジックを含む既存の挙動）
+- 列ラベル（タイトル・金額）のサイズ
+- ツールチップ・サイドパネルのフォント
+- `mapLabelVisibleMinHPx` による可視判定閾値
+
+---
+
+## 関連
+
+- 背景ドキュメント: [docs/tasks/20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md](./20260514_0803_sankey-svg-zoom連動ラベルサイズ修正案.md)
+- 実装対象: [app/sankey-svg/page.tsx](../../app/sankey-svg/page.tsx)（`nodeShiftInfo`、ラベル描画 4 箇所）

--- a/docs/tasks/20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md
+++ b/docs/tasks/20260515_0624_sankey-svg-zoom連動ラベルフォントサイズ動的拡大.md
@@ -24,7 +24,7 @@
 
 すべてのノードラベルで固定：
 
-```
+```text
 fontSize = mapLabelFontPx / zoom   (SVG units)
 ```
 
@@ -34,7 +34,7 @@ fontSize = mapLabelFontPx / zoom   (SVG units)
 
 [app/sankey-svg/page.tsx:1093](../../app/sankey-svg/page.tsx#L1093) の `nodeShiftInfo` useMemo 内：
 
-```
+```ts
 topShift = h * zoom < mapLabelSlotPx
          ? Math.max(0, mapLabelSlotPx / zoom - h)
          : 0
@@ -45,7 +45,7 @@ topShift = h * zoom < mapLabelSlotPx
 
 ### ラベルの y 座標
 
-```
+```text
 y = topShift + h / 2
 ```
 
@@ -61,7 +61,7 @@ topShift > 0 のとき（ノード < スロット）→ `topShift = slotH/zoom -
 
 ノードごとに `colFontPx` を計算し、`fontSize = colFontPx / zoom` に変える。
 
-```
+```text
 // zoom ≤ baseZoom: 変更なし
 colFontPx = mapLabelFontPx
 
@@ -83,7 +83,7 @@ colFontPx    = max(mapLabelFontPx, min(zoomedMax, nodeMaxFont))
 
 現状は `mapLabelSlotPx` 基準だが、新しいフォントサイズ（`colFontPx`）基準に変更する：
 
-```
+```ts
 labelHSvg = colFontPx / zoom   // ラベル高さ（SVG units）
 topShift  = h < labelHSvg
           ? Math.max(0, labelHSvg - h)


### PR DESCRIPTION
## Summary

- zoom-in 時にノードラベルのフォントサイズを動的に拡大（隣接ノード中心間距離を基準）
- ホバーツールチップの位置を `cumShift` / `topShift` 補正後の実描画位置に合わせて修正
- 設定ダイアログのフォントを固定値化（基準フォントサイズスライダー操作中にUIがズレない）

## 変更詳細

### zoom連動ラベルフォント拡大

- `zoom > baseZoom` のときのみ発動（fit zoom 時の挙動は変更なし）
- 上限: `mapLabelFontPx × min(zoom/baseZoom, ZOOM_FONT_MAX_RATIO=1.3)` かつ `隣接ノード中心間距離 × zoom × LABEL_FIT_RATIO=0.85)` の小さい方
- `nodeShiftInfo` に `colFontPx` を追加し、ラベル描画 4 箇所で参照

### ツールチップ位置補正

- `screenTop` 計算に `cumShift + topShift` を加算
- topShift でノード位置が補正されたノードにもツールチップが正確に追従

### 設定ダイアログ固定フォント

- `fontSize: CONTROL_SMALL_FONT_PX` → `CONTROL_SMALL_FONT_PX_DEFAULT (12)`
- `minWidth: Math.round(240 * fontScale)` → `minWidth: 240`

## 不変条件

fit zoom（baseZoom）時の TopN 収容上限 `N_max ≈ availH × 0.9 / mapLabelSlotPx` は変更なし。

## Test plan

- [ ] 初期表示（fit zoom）でラベルサイズが変わっていないことを確認
- [ ] ズームインするとラベルが大きくなることを確認（特に TopN の密な事業列）
- [ ] ノードホバー時のツールチップがノード上に正確に表示されることを確認（topShift が発生する小ノードを含む）
- [ ] 設定ダイアログを開いた状態で基準フォントサイズスライダーを動かしてもダイアログ位置がズレないことを確認

## 関連

- Closes なし（フォーカスズレ issue は #205 として別途追跡）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic label font scaling when zoomed in, capping font to node height to keep labels readable.

* **Bug Fixes**
  * Tooltip position and label font now align with shifted/zoomed labels.
  * Improved label fitting for merged project and regular nodes across zoom levels.
  * Adjusted settings dialog and control font sizing for consistent UI.

* **Documentation**
  * Added design and task docs describing zoom-linked label sizing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/igomuni/marumie-rssystem/pull/206)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->