### PR TITLE
docs: rs-vis 反映対応案ドキュメント追加 + README データソース復元

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ git push origin main
 
 - [行政事業レビューシステム](https://rssystem.go.jp/)（CSVデータ取得元）
 - [財務省 予算・決算](https://www.mof.go.jp/policy/budget/)（MOF予算データ）
+- [国税庁法人番号公表サイト](https://www.houjin-bangou.nta.go.jp/download/zenken/index.html)（法人番号照合用）
 
 ## ライセンス
 

--- a/docs/tasks/20260526_0602_rs-vis反映対応案.md
+++ b/docs/tasks/20260526_0602_rs-vis反映対応案.md
@@ -1,0 +1,197 @@
+# rs-vis 反映 対応案 — リリース整理同期
+
+作成日: 2026-05-26 06:02 (JST)
+
+## 目的
+
+marumie-rssystem の **リリース向けプロジェクト整理（PR #214）** を、リリース先である [rs-vis](https://github.com/team-mirai-volunteer/rs-vis) に反映する。
+
+公開対象は `/sankey-svg`・`/subcontracts`・`/mof-budget-overview`・`/quality` の4ページに絞り、それ以外のページ・API・コンポーネント・lib・types・scripts・public/data を rs-vis 側でも一括削除する。
+
+## 前提
+
+- marumie-rssystem 現 HEAD: `621c912`（main）。
+- rs-vis 側の最終同期: PR #5（`cbdc155`）= marumie `3fc5635..a5f7255`（#210〜#211）まで取り込み済み。
+- 同期方針は過去パターンと同じ：rs-vis 側に `team-mirai-volunteer/sync/YYYYMMDD` ブランチを切り、対象範囲を一括コピーした単一 PR で取り込む。
+- `docs/` は rs-vis 反映対象から除外（過去フローに準拠）。
+- 現状ソースは marumie 側で `archive/pre-release-20260525` タグ＋同名ブランチに保全済み。万一の復元が必要になればそこから取り出せる。
+
+## 今回の反映範囲
+
+```bash
+git log --oneline 3fc5635..HEAD
+git diff --shortstat 3fc5635 HEAD -- . ':!docs'
+```
+
+対象コミット（新規4件）:
+
+| コミット | PR | 区分 | 概要 |
+|---|---:|---|---|
+| `8674329` | #212 | chore | `.claude/settings.local.json` を `.gitignore` に追加 |
+| `248d194` | #213 | docs | リリース計画ドキュメント追加 + 旧 task docs を `docs/tasks/archive/` へ移動（→ docs 除外ポリシーにより反映対象外） |
+| `a5f7255` ※ | #211 | feat | （rs-vis PR #5 で取り込み済み、参考） |
+| `962b2ad` ※ | #210 | fix | （rs-vis PR #5 で取り込み済み、参考） |
+| `621c912` | #214 | chore | **リリース向けプロジェクト整理 - 公開4ページに絞り込み** |
+
+実質的な反映対象は **#212 と #214** の2つ。#213 は docs 除外、#210-#211 は既存反映済み。
+
+### 差分規模（`docs/` 除外、`3fc5635..HEAD`）
+
+```text
+110 files changed, 435 insertions(+), 126587 deletions(-)
+```
+
+ほぼすべてが削除。主な領域:
+
+- **ページ削除** (11): `app/{sankey, sankey2, sankey-lab, sankey-lab-d3, budget-drilldown, entities, entities-v2, entity-labels-csv, globe, map, spending-bottomup}/`
+- **API削除**: `app/api/{sankey/route.ts, entities, entities-v2, entity-labels-csv, map}/`
+- **コンポーネント削除**: `client/components/` から 12件（BudgetBoardView, GlobeView, ProjectDetailPanel, ProjectListModal, RecipientRangeSlider, Sankey2/, SankeyBudgetDrilldown, SankeySpendingBottomup, SpendingListModal, SubcontractDetailDialog, SummaryDialog, TopNSettingsPanel）
+- **lib/types削除**: `app/lib/sankey-generator.ts`, `types/{preset, view-state}.ts`
+- **scripts/ 削減**: 65ファイル → 9ファイル（直接生成 5 + ユーティリティ 3 + decompress-data.sh）
+- **package.json**: 削除済みスクリプトを指す entry を整理
+- **decompress-data.sh**: 不要 `.gz` 展開ブロック削除、ヘルパ関数化
+- **public/data**: 不要 .json/.gz 削除（rs2024-structured.json.gz, sankey2-*, entity-labels-csv, entity-normalization, houjin-lookup）
+- **app/page.tsx**: `/sankey-svg` への redirect Server Component に置換
+- **README.md / CLAUDE.md / .claude/commands/**: 公開4ページ前提に整合
+
+### 主な変更内容
+
+#### 1. トップページの動線変更
+
+- `/` は `/sankey-svg` へリダイレクト（Server Component）
+- `/mof-budget-overview` と `/quality` はトップから動線を張らず URL 直打ち想定
+
+#### 2. 公開4ページ以外の完全削除
+
+- 試作・実験・調査ページ（sankey, sankey2, sankey-lab*, entities*, globe, map, budget-drilldown, spending-bottomup, entity-labels-csv）を削除
+- 対応する API、サーバーロジック、UIコンポーネント、型定義を連動削除
+
+#### 3. データパイプライン整理
+
+- 公開4ページが消費する JSON だけを残し、生成スクリプトもそれを生成する5本＋ユーティリティ3本＋ prebuild の9本に縮小
+- 分析・調査系（analyze-\*, investigate-\*）と削除ページ専用スクリプト、辞書ジェネレータ群（`data/` 配下の Git 管理外中間成果物に依存）を削除
+- 辞書 CSV 自体は `public/data/dictionaries/` 配下に committed のため runtime には影響なし
+
+#### 4. ビルド連動修正
+
+- `package.json` の `scripts` セクションを生存スクリプトだけに整理
+- `scripts/decompress-data.sh` を必須2 + オプション6 のヘルパ関数構成に書き換え
+
+#### 5. agent 向けドキュメント更新
+
+- README.md / CLAUDE.md の Quick Reference・ページ一覧・プロジェクト構成を公開4ページ前提に書き換え
+- `.claude/commands/` 配下のスキルファイル（pipeline.md, data-update.md, sankey.md, plan.md, review.md）を整合
+- `.claude/commands/investigate.md` を削除（紹介できる調査スクリプトが無くなったため）
+
+#### 6. .gitignore（#212）
+
+- `.claude/settings.local.json` を `.gitignore` に追加
+
+## 反映方針 — 3案
+
+### 案A: 一括同期 PR（推奨）
+
+過去 PR #1〜#5 と同じスタイル。rs-vis 側に `team-mirai-volunteer/sync/20260526` ブランチを切り、marumie main の対象範囲（commits 8674329 + 621c912 + 既存範囲との差分）を丸ごとコピー、単一 PR にする。
+
+- **利点**: 過去フローと一致、レビューが一回で済む、ページ削除を含む大規模整理を一気に適用してリリース状態を rs-vis 側でも確定できる
+- **欠点**: 差分が極端に大きい（-126,587 行）。とはいえほぼすべて削除であり、レビュー粒度は粗くて問題ない
+- **適合度**: ◎
+
+### 案B: 機能単位で分割PR
+
+- chore: `.gitignore` 更新（#212）
+- chore: 公開4ページ以外のページ・API・コンポーネント削除（#214 の一部）
+- feat: トップページ redirect（#214 の一部）
+- chore: scripts/, package.json, decompress, public/data 整理（#214 の一部）
+- docs: README/CLAUDE/skill 更新（#214 の一部）
+
+- **利点**: marumie 側のコミット分割と対応する形で段階的にレビュー可能
+- **欠点**: rs-vis 側で 5PR 作成・マージが必要。マージ順依存があり手間が増える。大半が削除なので分割効果は薄い
+- **適合度**: △
+
+### 案C: 主要削除＋docs を別 PR に分離
+
+- PR 1: コード本体の整理（pages, APIs, components, lib, types, scripts, public/data, package.json, decompress, app/page.tsx）+ #212
+- PR 2: docs（README, CLAUDE, skill files）
+
+- **利点**: 動作影響のあるコード整理と、agent/onboarding 向けドキュメント更新を分けてレビューできる
+- **欠点**: rs-vis 側で 2PR、PR 1 マージ後の README は古い状態が一時的に残る
+- **適合度**: ○
+
+## 推奨
+
+**案A（一括同期 PR）** を推奨する。
+
+- 過去同期 PR と一貫したフロー
+- リリース整理は不可分（ページ削除と README/skill 更新を分けると agent が混乱するリスク）
+- 削除中心のため diff のレビュー負荷は表面的な数字より小さい
+
+## 反映手順（案A）
+
+### 0. 事前準備
+
+- rs-vis 側で現状 main を念のため `archive/pre-release-20260526` タグで保全（marumie 側と対応）
+- rs-vis 側ローカルを最新化（`git checkout main && git pull`）
+
+### 1. 同期ブランチ作成
+
+```bash
+cd /Users/igomuni/MyGitHub/rs-vis
+git checkout -b team-mirai-volunteer/sync/20260526 main
+```
+
+### 2. marumie main → rs-vis にコピー（docs 除外）
+
+代表的なやり方:
+
+```bash
+MARUMIE=/Users/igomuni/MyGitHub/marumie-rssystem
+
+# 削除対象（rs-vis 側にあって marumie main で消えたもの）を一括削除
+git -C "$MARUMIE" diff --name-only --diff-filter=D 3fc5635..HEAD -- . ':!docs' | \
+  while read -r f; do
+    [ -e "$f" ] && git rm -r "$f"
+  done
+
+# 残った変更ファイル（追加・変更）を marumie main から上書きコピー
+git -C "$MARUMIE" diff --name-only --diff-filter=AM 3fc5635..HEAD -- . ':!docs' | \
+  while read -r f; do
+    mkdir -p "$(dirname "$f")"
+    cp "$MARUMIE/$f" "$f"
+    git add "$f"
+  done
+```
+
+（実運用では `cp -a` で属性も保持する／ `.git` を含めない／ rs-vis 固有の差分があれば手動マージ、など細部調整）
+
+### 3. 動作確認
+
+```bash
+npm install
+npm run build           # prebuild の decompress 含めて通ること
+npm run dev             # /sankey-svg・/subcontracts・/mof-budget-overview・/quality を目視確認
+npx tsc --noEmit
+npm run lint
+```
+
+### 4. コミット・PR 作成
+
+```bash
+git commit -m "feat: marumie-rssystem のリリース整理を反映（公開4ページに絞り込み）"
+git push -u origin team-mirai-volunteer/sync/20260526
+gh pr create --repo team-mirai-volunteer/rs-vis \
+  --base main \
+  --title "feat: marumie-rssystem のリリース整理を反映（公開4ページに絞り込み）" \
+  --body "<本ドキュメントを基にした PR 本文>"
+```
+
+## 次回反映時の起点
+
+本反映が完了した時点での marumie HEAD `621c912` を、次回 rs-vis 反映時の起点とする。
+
+## 留意点
+
+- rs-vis 固有のファイル（LICENSE, `rs2024-preset-top3.json` 等の rs-vis 側にだけ存在するもの）は触らないこと
+- `.gitignore` 追加（#212）の `.claude/settings.local.json` 行は rs-vis 側でも有用なため反映する
+- 削除後、rs-vis 側にも残っている古いビルド成果物・依存（`node_modules/`、`.next/`）の影響でビルドが通らない場合は `rm -rf node_modules .next && npm install` でクリーンビルド
+- 削除対象に rs-vis 側からの不可逆な改修が混じっていないことを `git log --oneline -- <path>` で念のため確認


### PR DESCRIPTION
## Summary

- `docs/tasks/20260526_0602_rs-vis反映対応案.md` を追加（rs-vis 同期作業の記録）
- README のデータソース欄に **国税庁法人番号公表サイト** を復元

## 背景

リリース整理 PR #214 でデータソース欄から国税庁法人番号公表サイトの記載を削除したが、公開ページ `/quality` が依存する `public/data/dictionaries/recipient_dictionary.csv` の構築元データとして引き続き公開すべきため復元する。

## Test plan

- [x] README の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)