### PR TITLE
feat(sankey-svg-next): スマホのタッチで zoom/pan 対応 (Issue #195)

### DIFF
--- a/app/sankey-svg-next/page.tsx
+++ b/app/sankey-svg-next/page.tsx
@@ -80,6 +80,10 @@ const ZOOM_MIN_ABS = 0.05;
 const ZOOM_MAX_ABS = 20;
 const ZOOM_MIN_MULTIPLIER = 0.25;
 const ZOOM_MAX_MULTIPLIER = 30;
+// タッチUI（スマホ/タブレット）では描画キャンバスをウインドウ幅で詰めず、
+// 固定のフルHD領域として描画し zoom/pan で閲覧する。
+const FIXED_CANVAS_WIDTH = 1920;
+const FIXED_CANVAS_HEIGHT = 1080;
 const COLUMN_AMOUNT_FONT_PX_DEFAULT = 11;
 const SEARCH_FONT_PX_DEFAULT = 14;
 const CONTROL_FONT_PX_DEFAULT = 13;
@@ -830,6 +834,14 @@ export default function RealDataSankeyNextPage() {
   // 廃止し、デスクトップと同一描画（ズーム/パンで読む前提）に統一した。
   // タッチ前提（compact-mobile/tablet）。controlIconMinHitPx>0 のとき主要操作を 44px 化（Phase 6）。
   const isCompactTouch = tokens.controlIconMinHitPx > 0;
+  // タッチUIでは描画領域を固定フルHDにし、列詰めをやめて zoom/pan で閲覧する。
+  // 描画ジオメトリは canvasWidth/canvasHeight を使い、UIモード判定・ツールチップ等の
+  // ビューポート系は引き続き svgWidth/svgHeight（コンテナ実寸）を使う。
+  const useFixedCanvas = isCompactTouch;
+  const canvasWidth = useFixedCanvas ? FIXED_CANVAS_WIDTH : svgWidth;
+  const canvasHeight = useFixedCanvas ? FIXED_CANVAS_HEIGHT : svgHeight;
+  const useFixedCanvasRef = useRef(false);
+  useFixedCanvasRef.current = useFixedCanvas;
   const TOUCH_HIT_PX = tokens.controlIconMinHitPx; // 44 (compact) / 0 (desktop)
   const SHEET_HIT_PX = Math.max(44, tokens.controlIconMinHitPx);    // タップ最小 44px
   const SHEET_PAD_PX = 8;                                           // バー左右の内側余白
@@ -1139,7 +1151,8 @@ export default function RealDataSankeyNextPage() {
   // Converge on fit zoom accounting for label shifts (shifts grow as zoom shrinks → iterate)
   const fitZoomWithShifts = useCallback((
     nodes: ShiftLayoutNode[],
-    contentW: number, contentH: number, cW: number, availH: number
+    contentW: number, contentH: number, cW: number, availH: number,
+    fitHorizontal = false,
   ): { k: number; totalH: number } => {
     let k = Math.max(ZOOM_MIN_ABS, Math.min(ZOOM_MAX_ABS, (availH / (MARGIN.top + contentH)) * 0.9));
     let totalH = MARGIN.top + contentH;
@@ -1149,6 +1162,14 @@ export default function RealDataSankeyNextPage() {
       const newK = Math.max(ZOOM_MIN_ABS, Math.min(ZOOM_MAX_ABS, (availH / totalH) * 0.9));
       if (Math.abs(newK - k) < 0.0005) { k = newK; break; }
       k = newK;
+    }
+    // 固定キャンバス時は横方向にも収め、初期表示で全体が見えるようにする
+    if (fitHorizontal) {
+      const kH = Math.max(ZOOM_MIN_ABS, Math.min(ZOOM_MAX_ABS, (cW / (MARGIN.left + contentW + MARGIN.right)) * 0.9));
+      if (kH < k) {
+        k = kH;
+        totalH = MARGIN.top + contentH + calcShiftExtraH(nodes, k);
+      }
     }
     return { k, totalH };
   }, [calcShiftExtraH]);
@@ -1161,7 +1182,7 @@ export default function RealDataSankeyNextPage() {
       const cW = container.clientWidth;
       const reserve = searchBoxReserveRef.current;
       const availH = container.clientHeight - reserve;
-      const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
+      const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH, useFixedCanvasRef.current);
       setZoom(k);
       setBaseZoom(k);
       setPan({ x: 0, y: reserve + Math.min((availH - totalH * k) / 2, fitTopPadPxRef.current) });
@@ -1180,7 +1201,7 @@ export default function RealDataSankeyNextPage() {
       const cW = container.clientWidth;
       const reserve = searchBoxReserveRef.current;
       const availH = container.clientHeight - reserve;
-      const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
+      const { k, totalH } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH, useFixedCanvasRef.current);
       setZoom(k);
       setBaseZoom(k);
       setPan({ x: 0, y: reserve + Math.min((availH - totalH * k) / 2, fitTopPadPxRef.current) });
@@ -1193,7 +1214,7 @@ export default function RealDataSankeyNextPage() {
 
   // Minimap refs (hooks must be unconditional)
   const MINIMAP_W = 200;
-  const minimapH = Math.round(MINIMAP_W * (svgHeight / (svgWidth || 1)));
+  const minimapH = Math.round(MINIMAP_W * (canvasHeight / (canvasWidth || 1)));
   const minimapRef = useRef<HTMLCanvasElement>(null);
   const minimapDragging = useRef(false);
   const [showMinimap, setShowMinimap] = useState(false);
@@ -1391,18 +1412,18 @@ export default function RealDataSankeyNextPage() {
   const layout = useMemo(() => {
     if (!filtered) return null;
     // fitZoom を求めるための第1パス（ギャップなし）
-    const noGap = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight);
-    const availH = Math.max(100, svgHeight - SEARCH_BOX_RESERVE);
+    const noGap = computeLayout(filtered.nodes, filtered.edges, canvasWidth, canvasHeight);
+    const availH = Math.max(100, canvasHeight - SEARCH_BOX_RESERVE);
     const fitZoom = Math.max(0.1, Math.min(10,
-      Math.min(svgWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
+      Math.min(canvasWidth / (MARGIN.left + noGap.contentW), availH / (MARGIN.top + noGap.contentH)) * 0.9
     ));
-    // Horizontal rendering is screen-fixed; compute x layout once from the fit scale.
+    // Horizontal rendering is canvas-fixed; compute x layout once from the fit scale.
     const extraRecipientGapSVG = MAX_RECIPIENT_GAP_PX / fitZoom;
     const extraMinistryGapSVG  = MAX_MINISTRY_GAP_PX  / fitZoom;
-    const result = computeLayout(filtered.nodes, filtered.edges, svgWidth, svgHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
+    const result = computeLayout(filtered.nodes, filtered.edges, canvasWidth, canvasHeight, NODE_PAD, extraRecipientGapSVG, extraMinistryGapSVG);
     layoutRef.current = { contentW: result.contentW, contentH: result.contentH, nodes: result.nodes };
     return result;
-  }, [filtered, svgWidth, svgHeight, SEARCH_BOX_RESERVE]);
+  }, [filtered, canvasWidth, canvasHeight, SEARCH_BOX_RESERVE]);
 
   // Cumulative shift per node: { cumShift: slot-level offset, topShift: rect-within-slot offset, colFontPx: label font px }
   const nodeShiftInfo = useMemo(() => {
@@ -2307,7 +2328,7 @@ export default function RealDataSankeyNextPage() {
           const cW = container.clientWidth;
           const reserve = searchBoxReserveRef.current;
           const availH = container.clientHeight - reserve;
-          const { k: fitK } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH);
+          const { k: fitK } = fitZoomWithShifts(l.nodes, l.contentW, l.contentH, cW, availH, useFixedCanvasRef.current);
           const restoredTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, k, fitK);
           setBaseZoom(fitK);
           setZoom(k);
@@ -2341,11 +2362,15 @@ export default function RealDataSankeyNextPage() {
 
   const horizontalScale = useMemo(() => {
     if (!layout) return 1;
+    // 固定キャンバス時は x0 をそのままユーザー座標として使い、zoom と一様に連動させる
+    // （デスクトップは横を画面幅にフィットさせる screen-fixed のまま）。
+    if (useFixedCanvas) return 1;
     return Math.max(0.2, Math.min(10, (svgWidth / (MARGIN.left + layout.contentW + SCREEN_LEFT_PADDING_PX)) * SCREEN_HORIZONTAL_FIT_RATIO));
-  }, [layout, svgWidth]);
+  }, [layout, svgWidth, useFixedCanvas]);
   const screenNodeW = NODE_W;
-  const screenToInnerX = useCallback((screenX: number) => screenX / zoom - MARGIN.left, [zoom]);
-  const screenWToInner = useCallback((screenW: number) => screenW / zoom, [zoom]);
+  // 固定キャンバス時は横も zoom 連動にするため /zoom の打ち消しを行わない。
+  const screenToInnerX = useCallback((screenX: number) => useFixedCanvas ? screenX - MARGIN.left : screenX / zoom - MARGIN.left, [zoom, useFixedCanvas]);
+  const screenWToInner = useCallback((screenW: number) => useFixedCanvas ? screenW : screenW / zoom, [zoom, useFixedCanvas]);
   const getNodeScreenX0 = useCallback((node: LayoutNode): number => {
     const left = MARGIN.left + SCREEN_LEFT_PADDING_PX;
     if (node.type === 'project-spending') {
@@ -2376,10 +2401,10 @@ export default function RealDataSankeyNextPage() {
     return { top, bottom: top + Math.max(1, node.y1 - node.y0) };
   }, [nodeByLayoutId, nodeShiftInfo]);
   const minimapWorldH = useMemo(() => {
-    if (!layout || layout.nodes.length === 0) return svgHeight;
+    if (!layout || layout.nodes.length === 0) return canvasHeight;
     const renderedBottom = Math.max(...layout.nodes.map(node => getRenderedYBounds(node).bottom));
-    return Math.max(svgHeight, MARGIN.top + renderedBottom + MARGIN.bottom);
-  }, [layout, svgHeight, getRenderedYBounds]);
+    return Math.max(canvasHeight, MARGIN.top + renderedBottom + MARGIN.bottom);
+  }, [layout, canvasHeight, getRenderedYBounds]);
 
   // Draw minimap
   useEffect(() => {
@@ -2394,7 +2419,7 @@ export default function RealDataSankeyNextPage() {
     // Nodes are at (MARGIN.left + x0, MARGIN.top + shiftedY0) in SVG coords.
     // The SVG transform: translate(pan.x, pan.y) scale(zoom) then translate(MARGIN, MARGIN)
     // So a node at inner (x0,shiftedY0) appears at screen (pan.x + (MARGIN.left+x0)*zoom, pan.y + (MARGIN.top+shiftedY0)*zoom)
-    const worldW = svgWidth;
+    const worldW = canvasWidth;
     const worldH = minimapWorldH;
     const scaleX = MINIMAP_W / worldW;
     const scaleY = minimapH / worldH;
@@ -2433,7 +2458,7 @@ export default function RealDataSankeyNextPage() {
     ctx.strokeRect(mX, mY, mW, mH);
     ctx.fillStyle = 'rgba(59, 130, 246, 0.08)';
     ctx.fillRect(mX, mY, mW, mH);
-  }, [showMinimap, layout, zoom, pan, svgWidth, minimapWorldH, minimapH, getNodeScreenX0, getMinimapRenderedYBounds, screenNodeW]);
+  }, [showMinimap, layout, zoom, pan, canvasWidth, minimapWorldH, minimapH, getNodeScreenX0, getMinimapRenderedYBounds, screenNodeW]);
 
   const minimapNavigate = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = minimapRef.current;
@@ -2443,7 +2468,7 @@ export default function RealDataSankeyNextPage() {
     const mx = e.clientX - rect.left;
     const my = e.clientY - rect.top;
     // Minimap coord to SVG world coord
-    const scaleX = MINIMAP_W / svgWidth;
+    const scaleX = MINIMAP_W / canvasWidth;
     const scaleY = minimapH / minimapWorldH;
     const svgX = mx / scaleX;
     const svgY = my / scaleY;
@@ -2451,7 +2476,7 @@ export default function RealDataSankeyNextPage() {
     const cW = container.clientWidth;
     const cH = container.clientHeight;
     setPan({ x: cW / 2 - svgX, y: cH / 2 - svgY * zoom });
-  }, [svgWidth, minimapWorldH, minimapH, zoom]);
+  }, [canvasWidth, minimapWorldH, minimapH, zoom]);
 
   // Escape key: focusRelated ON → フィルターのみOFF、OFF → 選択解除
   useEffect(() => {
@@ -2840,9 +2865,11 @@ export default function RealDataSankeyNextPage() {
               return COL_LABELS.map((label, i) => {
                 // Use actual node x0 from layout (accounts for extraMinistryGapSVG / extraRecipientGapSVG)
                 const colNodes = layout.nodes.filter(n => n.type === colNodeTypes[i]);
-                const screenX = pan.x + (colNodes.length > 0
+                // 固定キャンバス時 getNodeScreenX0 はユーザー座標を返すので zoom を掛けて画面座標へ。
+                const colCanvasX = colNodes.length > 0
                   ? Math.min(...colNodes.map(n => getNodeScreenX0(n))) + screenNodeW / 2
-                  : MARGIN.left + SCREEN_LEFT_PADDING_PX + (i / maxCol) * (svgWidth - MARGIN.left - MARGIN.right - SCREEN_LEFT_PADDING_PX - screenNodeW) + screenNodeW / 2);
+                  : MARGIN.left + SCREEN_LEFT_PADDING_PX + (i / maxCol) * ((useFixedCanvas ? canvasWidth : svgWidth) - MARGIN.left - MARGIN.right - SCREEN_LEFT_PADDING_PX - screenNodeW) + screenNodeW / 2;
+                const screenX = pan.x + (useFixedCanvas ? zoom * colCanvasX : colCanvasX);
                 const total = colAmounts[i];
                 const amountLine = !showColumnAmount ? ''
                   : i === 2 && total != null
@@ -2879,7 +2906,8 @@ export default function RealDataSankeyNextPage() {
               });
             })()}
 
-            {/* Minimap */}
+            {/* Minimap（固定キャンバスのタッチUIでは screen-fixed 前提の座標が合わないため非表示）*/}
+            {!useFixedCanvas && (
             <MinimapOverlay
               show={showMinimap}
               onShow={() => setShowMinimap(true)}
@@ -2891,6 +2919,7 @@ export default function RealDataSankeyNextPage() {
               navigate={minimapNavigate}
               dragging={minimapDragging}
             />
+            )}
 
             {/* Font size controls（sheet 時は設定シートへ集約するため非表示） */}
             <div
@@ -3104,7 +3133,8 @@ export default function RealDataSankeyNextPage() {
             const tipW = Math.round(240 * fontScale);
             const { cumShift: hoverCumShift = 0, topShift: hoverTopShift = 0, colFontPx: hoverColFontPx = mapLabelFontPx } = nodeShiftInfo.get(hoveredNode.id) ?? {};
             const nodeScreenH = (hoveredNode.y1 - hoveredNode.y0) * zoom;
-            const screenCx = pan.x + getNodeScreenX0(hoveredNode) + screenNodeW / 2;
+            // 固定キャンバス時は getNodeScreenX0 がユーザー座標なので zoom を掛ける。
+            const screenCx = pan.x + (useFixedCanvas ? zoom * (getNodeScreenX0(hoveredNode) + screenNodeW / 2) : getNodeScreenX0(hoveredNode) + screenNodeW / 2);
             const screenTop = pan.y + (MARGIN.top + hoveredNode.y0 + hoverCumShift + hoverTopShift) * zoom;
             const screenBottom = screenTop + nodeScreenH;
             const lx = Math.max(4, Math.min(screenCx - tipW / 2, svgWidth - tipW - 4));

--- a/app/sankey-svg-next/page.tsx
+++ b/app/sankey-svg-next/page.tsx
@@ -108,6 +108,8 @@ const BUDGET_EXECUTION_LIST_HEIGHT_MIN = 96;
 const BUDGET_EXECUTION_LIST_HEIGHT_MAX = 600;
 const HOVER_SUPPRESS_AFTER_INTERACTION_MS = 500;
 const HOVER_ENTER_DELAY_MS = 220;
+// タッチの指ブレを pan と誤認しない移動しきい値（タップ選択を成立させるため mouse の 3px より緩める）
+const TOUCH_PAN_SLOP_PX = 10;
 const FIT_TOP_PAD_PX = 32;
 const ZOOM_FONT_MAX_RATIO = 1.8;   // zoom-in でフォントを最大で元の何倍まで拡大するか
 const AGGREGATE_BOUNDARY_GAP_PX = 6;
@@ -1053,7 +1055,8 @@ export default function RealDataSankeyNextPage() {
     if (isOverlayControlTarget(e.target)) return;
     const pts = activePointersRef.current;
     pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* capture 不可なら無視 */ }
+    // setPointerCapture は付けない: 全画面コンテナへバブリングで届くうえ、capture すると
+    // タップで合成される click が capture 先（コンテナ）へ向きノードの onClick が発火しない。
     if (pts.size === 1) {
       // 1本指 pan 開始
       didPanRef.current = false;
@@ -1106,7 +1109,9 @@ export default function RealDataSankeyNextPage() {
       // ── 1本指 pan ──
       const dx = e.clientX - panStart.current.x;
       const dy = e.clientY - panStart.current.y;
-      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) didPanRef.current = true;
+      // slop 未満はタップ候補として pan を開始しない（didPanRef を立てず onClick を活かす）
+      if (!didPanRef.current && Math.hypot(dx, dy) < TOUCH_PAN_SLOP_PX) return;
+      didPanRef.current = true;
       const newPan = { x: panOrigin.current.x + dx, y: panOrigin.current.y + dy };
       panRef.current = newPan;
       setPan(newPan);
@@ -1119,7 +1124,6 @@ export default function RealDataSankeyNextPage() {
     const pts = activePointersRef.current;
     if (!pts.has(e.pointerId)) return;
     pts.delete(e.pointerId);
-    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* 解放不可なら無視 */ }
     if (pts.size === 1) {
       // pinch → pan: 残った指の現在位置で基準を取り直しジャンプを防ぐ
       const [only] = Array.from(pts.values());
@@ -4463,8 +4467,8 @@ export default function RealDataSankeyNextPage() {
         )}
       </div>
 
-      {/* Top-right panel: offset slider */}
-      {filtered && (() => {
+      {/* Top-right panel: offset slider（タッチUIでは常時表示が邪魔なので非表示）*/}
+      {filtered && !isCompactTouch && (() => {
         // Recipient offset mode
         const maxRecipOffset = Math.max(0, filtered.totalRecipientCount - topRecipient);
         const clampedOffset = Math.min(recipientOffset, maxRecipOffset);
@@ -4835,7 +4839,8 @@ export default function RealDataSankeyNextPage() {
 
       {/* Zoom controls — bottom right (sankey2 style) */}
       <div style={{ position: 'absolute', bottom: 12, right: 12, zIndex: 15, display: 'flex', flexDirection: 'column', gap: 4 }}>
-        {/* スクロールモード切替ボタン */}
+        {/* スクロールモード切替ボタン（ホイール前提のためタッチUIでは非表示）*/}
+        {!isCompactTouch && (
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44 }}>
           <button
             aria-label={scrollMode === 'pan' ? 'スクロール移動モード（クリックでズームモードへ）' : 'スクロール移動モードに切替'}
@@ -4846,6 +4851,7 @@ export default function RealDataSankeyNextPage() {
             <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 -960 960 960" fill={scrollMode === 'pan' ? '#1a73e8' : '#bbb'}><path d="M480-80 310-250l57-57 73 73v-166H274l73 74-57 57L120-440l170-170 57 57-74 73h166v-166l-73 73-57-57 170-170 170 170-57 57-73-73v166h166l-74-73 57-57 170 170-170 170-57-57 74-74H520v166l73-73 57 57L480-80Z"/></svg>
           </button>
         </div>
+        )}
         {/* + / vertical slider / - */}
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           {/* Material Icons: add */}

--- a/app/sankey-svg-next/page.tsx
+++ b/app/sankey-svg-next/page.tsx
@@ -547,6 +547,8 @@ export default function RealDataSankeyNextPage() {
   const [zoom, setZoom] = useState(1);
   // Keep zoomRef current for use in debounce timeouts
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
+  // Keep baseZoom mirror current for touch-gesture handlers
+  useEffect(() => { baseZoomRef.current = baseZoom; }, [baseZoom]);
   useEffect(() => {
     if (!showMinistryDropdown) return;
     const onMouseDown = (e: MouseEvent) => {
@@ -591,7 +593,16 @@ export default function RealDataSankeyNextPage() {
       window.removeEventListener('scroll', recompute, true);
     };
   }, [showAccountDropdown]);
+  // Live mirrors / pointer tracking for touch-gesture handlers (avoid stale closures across rapid pointermove events)
+  const panRef = useRef({ x: 0, y: 0 });
+  const baseZoomRef = useRef(1);
+  // Active touch/pen pointers keyed by pointerId → current client coords
+  const activePointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  // Distance between the two fingers at the previous pinch frame
+  const pinchLastDistRef = useRef(0);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  // Keep pan mirror current for touch-gesture handlers
+  useEffect(() => { panRef.current = pan; }, [pan]);
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef({ x: 0, y: 0 });
   const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
@@ -1015,6 +1026,112 @@ export default function RealDataSankeyNextPage() {
     if (hoverSuppressTimerRef.current) window.clearTimeout(hoverSuppressTimerRef.current);
     hoverSuppressTimerRef.current = window.setTimeout(() => setIsHoverSuppressed(false), HOVER_SUPPRESS_AFTER_INTERACTION_MS);
   }, []);
+
+  // ── Touch gestures: 1本指 pan + 2本指 pinch zoom (Pointer Events) ──
+  // マウスは上の onMouse* ハンドラ継続使用。ここは touch/pen のみ処理する。
+  const beginHoverSuppressCooldown = useCallback(() => {
+    setIsHoverSuppressed(true);
+    if (hoverSuppressTimerRef.current) window.clearTimeout(hoverSuppressTimerRef.current);
+    hoverSuppressTimerRef.current = window.setTimeout(() => setIsHoverSuppressed(false), HOVER_SUPPRESS_AFTER_INTERACTION_MS);
+  }, []);
+
+  // getZoomAnchoredPanY の ref ベース版（高頻度な pointermove 内でクロージャ陳腐化を避ける）
+  const anchoredPanYFromRefs = useCallback((anchorY: number, fromZoom: number, toZoom: number, fromPanY: number): number => {
+    const l = layoutRef.current;
+    if (!l) return anchorY - (anchorY - fromPanY) * (toZoom / fromZoom);
+    const baseK = baseZoomRef.current;
+    const currentTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, fromZoom, baseK);
+    const nextTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, toZoom, baseK);
+    const currentScreenH = Math.max(1, currentTotalH * fromZoom);
+    const nextScreenH = Math.max(1, nextTotalH * toZoom);
+    const ratioFromTop = (anchorY - fromPanY) / currentScreenH;
+    return anchorY - ratioFromTop * nextScreenH;
+  }, [calcShiftExtraH]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return; // mouse は onMouse* で処理
+    if (isOverlayControlTarget(e.target)) return;
+    const pts = activePointersRef.current;
+    pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* capture 不可なら無視 */ }
+    if (pts.size === 1) {
+      // 1本指 pan 開始
+      didPanRef.current = false;
+      setIsPanning(true);
+      panStart.current = { x: e.clientX, y: e.clientY };
+      panOrigin.current = { ...panRef.current };
+    } else if (pts.size === 2) {
+      // pinch 開始: 基準となる2指間距離を記録
+      const [a, b] = Array.from(pts.values());
+      pinchLastDistRef.current = Math.hypot(a.x - b.x, a.y - b.y);
+      didPanRef.current = true; // pinch はタップ扱いしない
+    }
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    const pts = activePointersRef.current;
+    if (!pts.has(e.pointerId)) return;
+    pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pts.size >= 2) {
+      // ── pinch zoom（2指中点をアンカーに増分ズーム）──
+      const [a, b] = Array.from(pts.values());
+      const dist = Math.hypot(a.x - b.x, a.y - b.y);
+      const prevDist = pinchLastDistRef.current;
+      if (prevDist <= 0) { pinchLastDistRef.current = dist; return; }
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const midX = (a.x + b.x) / 2 - rect.left;
+      const midY = (a.y + b.y) / 2 - rect.top;
+      const fromZoom = zoomRef.current;
+      const minZoom = Math.max(ZOOM_MIN_ABS, baseZoomRef.current * ZOOM_MIN_MULTIPLIER);
+      const maxZoom = Math.min(ZOOM_MAX_ABS, baseZoomRef.current * ZOOM_MAX_MULTIPLIER);
+      const newZoom = Math.max(minZoom, Math.min(maxZoom, fromZoom * (dist / prevDist)));
+      pinchLastDistRef.current = dist;
+      if (newZoom === fromZoom) return;
+      const fromPan = panRef.current;
+      const newPanX = midX - (midX - fromPan.x) * (newZoom / fromZoom);
+      const newPanY = anchoredPanYFromRefs(midY, fromZoom, newZoom, fromPan.y);
+      const newPan = { x: newPanX, y: newPanY };
+      zoomRef.current = newZoom;
+      panRef.current = newPan;
+      setZoom(newZoom);
+      setPan(newPan);
+      didPanRef.current = true;
+      beginHoverSuppressCooldown();
+      scheduleZoomUrlWrite();
+    } else if (pts.size === 1) {
+      // ── 1本指 pan ──
+      const dx = e.clientX - panStart.current.x;
+      const dy = e.clientY - panStart.current.y;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) didPanRef.current = true;
+      const newPan = { x: panOrigin.current.x + dx, y: panOrigin.current.y + dy };
+      panRef.current = newPan;
+      setPan(newPan);
+      beginHoverSuppressCooldown();
+    }
+  }, [anchoredPanYFromRefs, beginHoverSuppressCooldown, scheduleZoomUrlWrite]);
+
+  const handlePointerEnd = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    const pts = activePointersRef.current;
+    if (!pts.has(e.pointerId)) return;
+    pts.delete(e.pointerId);
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* 解放不可なら無視 */ }
+    if (pts.size === 1) {
+      // pinch → pan: 残った指の現在位置で基準を取り直しジャンプを防ぐ
+      const [only] = Array.from(pts.values());
+      panStart.current = { x: only.x, y: only.y };
+      panOrigin.current = { ...panRef.current };
+      pinchLastDistRef.current = 0;
+    } else if (pts.size === 0) {
+      setIsPanning(false);
+      pinchLastDistRef.current = 0;
+      if (didPanRef.current) beginHoverSuppressCooldown();
+    }
+  }, [beginHoverSuppressCooldown]);
 
   // Converge on fit zoom accounting for label shifts (shifts grow as zoom shrinks → iterate)
   const fitZoomWithShifts = useCallback((
@@ -2400,6 +2517,10 @@ export default function RealDataSankeyNextPage() {
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
     >
 
 
@@ -2429,7 +2550,7 @@ export default function RealDataSankeyNextPage() {
               width={svgWidth}
               height={svgHeight}
               overflow="visible"
-              style={{ position: 'absolute', inset: 0, display: 'block' }}
+              style={{ position: 'absolute', inset: 0, display: 'block', touchAction: 'none' }}
             >
               {/* Gradient defs for merged project nodes */}
               <defs>

--- a/app/sankey-svg-next/page.tsx
+++ b/app/sankey-svg-next/page.tsx
@@ -826,9 +826,8 @@ export default function RealDataSankeyNextPage() {
   // ── compact-mobile: 上部ツールバーを sheet（全幅の横並びバー）に切替（Phase 3）──
   // [ 検索(flex-1) ][ 年度ピル ][ ⚙ 設定 ] を全 44px ヒットエリアで配置する。
   const isSheetToolbar = tokens.topToolbarLayout === 'sheet';
-  // compact-mobile 専用のラベル衝突回避（Phase 3-6）。フォーカス/ホバー時に非対象の
-  // ノードラベルを非表示にして重なりを解消する。
-  const isCompactMobile = displayMode === 'compact-mobile';
+  // 注: compact-mobile 専用のラベル間引き（フォーカス時に非対象ラベルを opacity:0）は
+  // 廃止し、デスクトップと同一描画（ズーム/パンで読む前提）に統一した。
   // タッチ前提（compact-mobile/tablet）。controlIconMinHitPx>0 のとき主要操作を 44px 化（Phase 6）。
   const isCompactTouch = tokens.controlIconMinHitPx > 0;
   const TOUCH_HIT_PX = tokens.controlIconMinHitPx; // 44 (compact) / 0 (desktop)
@@ -2709,7 +2708,6 @@ export default function RealDataSankeyNextPage() {
                             {labelVisible && (
                               <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                                opacity={isCompactMobile && ((connectedNodeIds && !isConnected) || (hoveredNodeIds && !hoveredNodeIds.has(node.id))) ? 0 : 1}
                                 style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                                 onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                                 onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
@@ -2738,7 +2736,6 @@ export default function RealDataSankeyNextPage() {
                             {/* Left label: budget amount */}
                             <text x={getNodeInnerX0(node) - innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle" textAnchor="end"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                              opacity={isCompactMobile && ((connectedNodeIds && !isConnected) || (hoveredNodeIds && !hoveredNodeIds.has(node.id))) ? 0 : 1}
                               style={{ userSelect: 'none', cursor: 'pointer' }}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
@@ -2750,7 +2747,6 @@ export default function RealDataSankeyNextPage() {
                             {/* Right label: project name + spending amount */}
                             <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                              opacity={isCompactMobile && ((connectedNodeIds && !isConnected) || (hoveredNodeIds && !hoveredNodeIds.has(node.id))) ? 0 : 1}
                               style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
@@ -2804,7 +2800,6 @@ export default function RealDataSankeyNextPage() {
                             fontSize={colFontPx / zoom}
                             dominantBaseline="middle"
                             fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                            opacity={isCompactMobile && ((connectedNodeIds && !connectedNodeIds.has(node.id)) || (hoveredNodeIds && !hoveredNodeIds.has(node.id))) ? 0 : 1}
                             style={{ userSelect: 'none', cursor: 'pointer' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
                             onMouseEnter={(e) => { const rect = containerRef.current?.getBoundingClientRect(); if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top }); setHoveredNode(node); }}
@@ -4852,7 +4847,8 @@ export default function RealDataSankeyNextPage() {
           </button>
         </div>
         )}
-        {/* + / vertical slider / - */}
+        {/* + / vertical slider / -（ピンチズーム前提のためタッチUIでは非表示）*/}
+        {!isCompactTouch && (
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           {/* Material Icons: add */}
           <button data-testid={testId('zoom-in')} aria-label="ズームイン" onClick={() => applyZoom(1.5)} title="ズームイン" style={{ width: '100%', padding: isCompactTouch ? '13px 0' : '5px 0', display: 'flex', justifyContent: 'center', background: 'transparent', border: 'none', borderBottom: '1px solid #e5e7eb', cursor: 'pointer' }}>
@@ -4876,6 +4872,7 @@ export default function RealDataSankeyNextPage() {
             <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 24 24" fill="#555"><path d="M19 13H5v-2h14v2z"/></svg>
           </button>
         </div>
+        )}
         {/* Zoom% — 非編集時は "N%" 表示、クリックで数値入力 */}
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44 }}>
           {isEditingZoom ? (

--- a/docs/tasks/20260531_0709_スマホタッチzoom-pan対応設計.md
+++ b/docs/tasks/20260531_0709_スマホタッチzoom-pan対応設計.md
@@ -1,0 +1,120 @@
+# スマホのタッチでzoom/pan対応 設計
+
+対象ルート: **`/sankey-svg-next` のみ**（レスポンシブ作業 Issue #195 の一環）
+対応ジェスチャー: **1本指 pan + 2本指 pinch zoom**
+
+## 目的
+
+> スマホ（iOS + Safari）でアクセスしたユーザーが、タッチ操作で Sankey 図を zoom/pan できず探索できない状態を解消するため。
+
+デプロイ済みサイトに iOS Safari でアクセスしたところ、タッチでの zoom/pan が一切できなかった。本対応はレスポンシブ作業中の `/sankey-svg-next` にタッチジェスチャーを実装し、タッチデバイスでも PC（マウス + ホイール）と同等の探索操作を可能にする。
+
+## 現状分析（なぜ動かないか）
+
+### zoom/pan はマウス + ホイール専用
+
+`app/sankey-svg-next/page.tsx` の操作系は次の3経路のみで構成され、**タッチ／ポインタイベントのハンドラが一切存在しない**。
+
+| 操作 | 実装 | 行 |
+|------|------|----|
+| zoom（ホイール） | `handleWheel`（ネイティブ `wheel` リスナ、`{ passive: false }`） | 949–989 |
+| pan 開始 | `handleMouseDown`（左クリックのみ、`e.button !== 0` で除外） | 991–997 |
+| pan 移動 | `handleMouseMove`（`isPanning` 中のみ `clientX/Y` 差分） | 999–1008 |
+| pan 終了 | `handleMouseUp`（`onMouseUp` / `onMouseLeave`） | 1010–1017 |
+
+コンテナ要素（2396–2402行）には `onMouseDown/Move/Up/Leave` が直接バインドされている。
+
+### touch-action 未設定 → ブラウザがジェスチャーを奪う
+
+コンテナの style（2398行）は
+`position: fixed; inset: 0; overflow: hidden; background: #fff; ...`
+で **`touch-action` の指定が無い**。このためタッチ操作はブラウザのデフォルト（ページスクロール／ネイティブピンチ）に吸収され、`mousemove` 相当のドラッグも継続発火しない。iOS Safari ではタッチドラッグに対し `mousemove` がドラッグ追従で発火しないため、現状のマウス pan は成立しない。
+
+### viewport meta は未設定だが本質ではない
+
+`app/layout.tsx` に viewport meta は無く、Next.js デフォルトが適用される。コンテナが画面全面固定（`position: fixed; inset: 0; overflow: hidden`）のため、ネイティブのページピンチズームでは図の続きが見えるわけではなく、根本解決にはキャンバス内部の zoom/pan をタッチで駆動する必要がある。
+
+### 既に存在する流用可能な資産
+
+- **粗ポインタ検出**: `pointerCoarse`（`window.matchMedia('(pointer: coarse)')`、353–361行）。タッチデバイス判定にそのまま利用可。
+- **コンパクト UI 判定**: `isCompactTouch`（820行）。
+- **変換式**: SVG は `transform="translate(pan.x, pan.y) scale(zoom)"`（2456行）→ 内側で `translate(MARGIN.left, MARGIN.top)`（2457行）。zoom/pan 状態（`zoom` 547行・`pan` 594行）を更新すれば描画に反映される。
+- **Y 軸アンカー付き pan 計算**: `getZoomAnchoredPanY(anchorY, nextZoom)`（918–927行）。指定した画面 Y 座標を固定したまま zoom する。**ただし X 軸は対象外**（後述）。
+- **zoom クランプ定数**: `ZOOM_MIN_ABS`/`ZOOM_MAX_ABS`（79–80行）、`ZOOM_MIN_MULTIPLIER`/`ZOOM_MAX_MULTIPLIER`（81–82行）。`minZoom = max(ZOOM_MIN_ABS, baseZoom * ZOOM_MIN_MULTIPLIER)`、`maxZoom = min(ZOOM_MAX_ABS, baseZoom * ZOOM_MAX_MULTIPLIER)`。
+- **ホバー抑制**: `setIsHoverSuppressed` + `HOVER_SUPPRESS_AFTER_INTERACTION_MS`。pan/zoom 中はツールチップを抑制する既存の仕組み。
+- **タップ／パン誤判定防止**: `didPanRef`（698行）。実際に動いたときだけ pan 扱いし、単なるクリックではノード選択を許す（2454行で参照）。
+
+## 設計方針
+
+### 採用イベントモデル: Pointer Events
+
+タッチ専用の `touch*` イベントではなく **Pointer Events（`pointerdown` / `pointermove` / `pointerup` / `pointercancel`）** を採用する。
+
+- 理由: iOS Safari は Pointer Events 対応済み。マウス・タッチ・ペンを単一モデルで扱え、複数同時接触を `pointerId` で識別できる（pinch に必須）。
+- 既存マウスハンドラとの関係: マウス pan ロジック（`handleMouseDown/Move/Up`）は **残す or Pointer へ統合のいずれか**。本設計では「コンテナへ Pointer ハンドラを追加し、内部で接触点数により pan / pinch を分岐」する方式を基本とする。マウス（`pointerType === 'mouse'`）は左ボタンのみ pan を許可し、既存挙動を維持する。`wheel` リスナ（zoom／pan モード切替）は変更しない。
+
+### touch-action: none
+
+コンテナ style に **`touchAction: 'none'`** を追加し、ブラウザのネイティブジェスチャー（スクロール・ピンチ）を無効化してアプリ側で完全制御する。
+
+- 注意: コンテナ全面に `touch-action: none` を掛けると、オーバーレイ上のスクロール可能領域（検索結果リスト、サイドパネル等）のタッチスクロールも止まる恐れがある。**コンテナには `none` を、内部のスクロール領域には `touch-action: auto`（or `pan-y`）を個別指定**して打ち消す。対象は `isOverlayControlTarget`（930行）が拾う要素群に準ずる。
+
+### ジェスチャー判定ロジック
+
+`pointerId` をキーにアクティブ接触点を Map（ref）で管理し、接触点数で状態遷移する。
+
+| 接触点数 | 動作 |
+|---------|------|
+| 1 | **pan**: 開始点からの差分を既存 pan ロジックと同様に `pan` へ加算。`didPanRef` で移動量しきい値（既存 3px 相当）を判定し、タップ（ノード選択）と区別 |
+| 2 | **pinch zoom**: 2点間距離の比率で zoom を更新。2点の中点（midpoint）をアンカーとして zoom 前後で図上同一点を固定 |
+| 0 | 操作終了。実際に pan/zoom したときのみホバー抑制クールダウン |
+
+状態遷移の要点:
+
+- 1本指 → 2本指: pan を中断し pinch 開始。pinch 基準距離・基準中点を記録。
+- 2本指 → 1本指: pinch 終了。残った1本指で pan を再開（基準点を残指の現在位置で取り直し、ジャンプを防ぐ）。
+- `pointercancel` / `pointerleave`: 当該接触点を破棄し、残接触点数で再評価。
+- オーバーレイ操作（`isOverlayControlTarget`）上で始まった接触点は pan/zoom 対象から除外（既存マウス挙動と同様）。
+
+### pinch zoom のアンカー（X 軸対応が必要）
+
+既存 `getZoomAnchoredPanY` は **Y 軸のみ**アンカーする。pinch では2本指の中点を X/Y 双方で固定したいので、**X 軸アンカーを別途算出**する。
+
+- Y: 既存 `getZoomAnchoredPanY(midY, nextZoom)` を流用。
+- X: pan.x は `scale(zoom)` の素直な拡縮なので、
+  `nextPanX = midX - (midX - pan.x) * (nextZoom / zoom)`
+  で midX（コンテナ相対 X）を固定できる。
+- `midX` / `midY` は `containerRef` の `getBoundingClientRect()` で接触点 `clientX/Y` をコンテナ相対に変換して求める（既存 `handleWheel` の `my` 算出 866–869行と同方式）。
+
+zoom 値は既存と同じく `minZoom`/`maxZoom`（`ZOOM_MIN/MAX_*`）でクランプし、`scheduleZoomUrlWrite()` で URL（`?z=`）へ反映する（既存ホイール zoom と同じ後処理）。
+
+### ホバー／ツールチップ抑制との整合
+
+pinch・pan の発生中は既存の `setIsHoverSuppressed(true)` ＋ `HOVER_SUPPRESS_AFTER_INTERACTION_MS` クールダウンを流用し、タッチ中にツールチップが追従しないようにする。タッチデバイスではそもそもホバーが無いが、`pointermove` で hover 状態が誤って残らないよう操作後にクリアする。
+
+## 影響範囲
+
+| ファイル | 変更概要 |
+|---------|---------|
+| `app/sankey-svg-next/page.tsx` | コンテナへ Pointer ハンドラ追加、`touchAction: 'none'` 追加、接触点管理 ref とジェスチャー判定の追加、X 軸アンカー算出の追加。スクロール可能オーバーレイへ `touch-action` 個別指定。マウス系既存ロジック・`wheel` リスナは挙動維持 |
+
+- `app/sankey-svg/page.tsx`（本番）は**今回対象外**（スコープ確認済み）。将来 `-next` を本番反映する際にまとめて移植する。
+- `app/layout.tsx` の viewport meta は変更しない（固定全面キャンバスのため本質的影響なし）。
+- `app/lib/`・`scripts/`・API 層・型定義への変更は**不要**。
+
+## レイヤー設計ルール整合性チェック（CLAUDE.md）
+
+- 変更は `app/*/page.tsx`（ページ層）の **状態管理・レイアウト・操作ハンドラ**に閉じる。CLAUDE.md の「Pages = 状態管理・API 呼び出し・レイアウトのみ」に合致。
+- `scripts/`（UI ロジック禁止）・`app/lib/`（HTTP/React 禁止）・`client/components/`（直接 API コール禁止）への変更は無く、各レイヤー制約に抵触しない。
+- データ単位・ノード定義など Critical Notes に関わるロジックは触れない。
+
+## 受け入れ基準
+
+- iOS Safari（実機 or レスポンシブ確認）で `/sankey-svg-next` を開き、
+  - 1本指ドラッグでキャンバスが pan する。
+  - 2本指ピンチで、2本指中点を中心に zoom する（中点が図上で固定される）。
+  - ピンチ中にページ全体のネイティブズーム／スクロールが発生しない。
+  - タップ（移動なし）ではノード選択が従来どおり機能する。
+  - 検索結果リスト等のオーバーレイ内スクロールはタッチで操作できる。
+- PC（マウス + ホイール）の既存 zoom/pan 挙動が変わらない。
+- `npm run lint` / `npx tsc --noEmit` が新規エラー無しで通る。


### PR DESCRIPTION
## 目的（Why）

iOS Safari 等のタッチデバイスで利用するユーザーが、`/sankey-svg-next` の Sankey 図をタッチ操作で zoom/pan できず探索できない状態を解消するため。

デプロイ済みサイトに iOS Safari でアクセスした際、タッチでの zoom/pan が一切できなかった。レスポンシブ作業中の `/sankey-svg-next`（Issue #195）にタッチジェスチャーを実装し、タッチでも PC（マウス + ホイール）と同等の探索操作を可能にする。

対応ジェスチャー: **1本指 pan + 2本指 pinch zoom**

## 変更内容

`app/sankey-svg-next/page.tsx`（ページ層のみ）に閉じた変更：

- **Pointer Events 採用**: コンテナに `onPointerDown/Move/Up/Cancel` を追加。`e.pointerType === 'mouse'` は早期 return し、マウスは既存 `onMouse*` を継続使用（PC 挙動は不変）。
- **1本指 = pan**: 既存と同じ 3px しきい値で `didPanRef` 判定（タップ選択と区別）。`setPointerCapture` で指が要素外へ出ても追従。
- **2本指 = pinch zoom**: 2指間距離の増分比でズーム、2指中点をアンカーに X/Y 双方を固定。既存 `getZoomAnchoredPanY` は Y のみのため、ref ベースの Y アンカー（shift extra height 考慮）＋ X アンカー式を追加。
- **state 陳腐化対策**: `panRef`/`baseZoomRef` のライブミラーと接触点 `Map` を ref 管理し、高頻度な `pointermove` 内でのクロージャ陳腐化を回避。
- **touch-action**: ジェスチャー面である SVG に `touch-action: none` を付与し、ブラウザのネイティブズーム/スクロールを抑止。オーバーレイ（検索結果・パネル等）は既定の `auto` のままなのでタッチスクロールに影響しない。
- 既存の zoom クランプ（`ZOOM_MIN/MAX_*`）・URL 反映（`?z=`）・ホバー抑制・2→1指のジャンプ防止を流用。

`app/sankey-svg`（本番）・`app/layout.tsx`・`app/lib/`・`scripts/`・API・型定義への変更はなし。

設計ドキュメント: `docs/tasks/20260531_0709_スマホタッチzoom-pan対応設計.md`

## テスト方法

ローカル:
- `npx tsc --noEmit` … エラーなし
- `npm run lint` … 新規警告なし（既存警告のみ）
- `npm run dev` → `/sankey-svg-next` がコンパイル成功・HTTP 200

**デプロイ環境での実機確認が必要**（iOS Safari）:
1. 1本指ドラッグでキャンバスが pan する
2. 2本指ピンチで2指中点を中心に zoom する（中点が図上で固定される）
3. ピンチ中にページ全体のネイティブズーム/スクロールが発生しない
4. タップ（移動なし）でノード選択が従来どおり機能する
5. 検索結果リスト等のオーバーレイ内スクロールがタッチで操作できる
6. PC（マウス + ホイール）の既存 zoom/pan 挙動が不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Touch & pen gestures: one-finger pan and two-finger pinch-zoom with midpoint anchoring and suppressed hover during gestures.
  * Fixed "canvas" mode for compact touch: consistent coordinate/viewport behavior, stable label rendering, and minimap hidden in touch mode.
  * Controls adapted for touch (certain overlays/zoom controls hidden or adjusted).

* **Documentation**
  * Added design doc detailing the touch/pinch-pan gesture behavior and acceptance criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/igomuni/marumie-rssystem/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->