### PR TITLE
Add touch-first interactions to Sankey SVG

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2352,7 +2352,8 @@ export default function RealDataSankeyPage() {
     x: number,
     centerY: number,
     width: number,
-    anchor: 'start' | 'end' = 'start'
+    anchor: 'start' | 'end' = 'start',
+    clipPath?: string
   ) => {
     const hitX = anchor === 'end' ? x - width : x;
     return (
@@ -2361,6 +2362,7 @@ export default function RealDataSankeyPage() {
         y={centerY - innerLabelHitH / 2}
         width={width}
         height={innerLabelHitH}
+        clipPath={clipPath}
         fill="transparent"
         style={{ cursor: 'pointer', pointerEvents: 'all' }}
         onMouseEnter={(e) => {
@@ -2724,7 +2726,7 @@ export default function RealDataSankeyPage() {
                                 onClick={(e) => handleNodeClick(node, e)}>
                                 {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                               </text>
-                              {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + bH / 2, getRightLabelHitW(getColumn(node), false))}
+                              {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + bH / 2, getRightLabelHitW(getColumn(node), false), 'start', `url(#clip-col-${getColumn(node)})`)}
                             </>)}
                           </g>
                         );
@@ -2768,7 +2770,7 @@ export default function RealDataSankeyPage() {
                               onClick={(e) => handleNodeClick(node, e)}>
                               {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
                             </text>
-                            {renderLabelHitRect(node, getNodeInnerX1(spendingNode) + innerLabelGap, topShift + Math.max(bH, sH) / 2, getRightLabelHitW(getColumn(node), false))}
+                            {renderLabelHitRect(node, getNodeInnerX1(spendingNode) + innerLabelGap, topShift + Math.max(bH, sH) / 2, getRightLabelHitW(getColumn(node), false), 'start', `url(#clip-col-${getColumn(node)})`)}
                           </>)}
                         </g>
                       );
@@ -2826,7 +2828,7 @@ export default function RealDataSankeyPage() {
                           >
                             {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                           </text>
-                          {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + h / 2, getRightLabelHitW(col, isLastCol))}
+                          {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + h / 2, getRightLabelHitW(col, isLastCol), 'start', isLastCol ? undefined : `url(#clip-col-${col})`)}
                         </>)}
                       </g>
                     );

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -544,6 +544,7 @@ export default function RealDataSankeyPage() {
   const touchPanOriginRef = useRef<{ x: number; y: number } | null>(null);
   const pinchLastDistanceRef = useRef<number | null>(null);
   const didPinchRef = useRef(false);
+  const touchActivatedNodeIdRef = useRef<string | null>(null);
   const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
   const hoverSuppressTimerRef = useRef<number | null>(null);
   const suppressHoverPopup = isPanning || isHoverSuppressed;
@@ -2022,9 +2023,7 @@ export default function RealDataSankeyPage() {
     if (nodeId) pendingConnectionNodeId.current = nodeId;
   }, [setPinnedRecipientId, setPinnedMinistryName]);
 
-  const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (didPanRef.current) return;
+  const activateNode = useCallback((node: LayoutNode) => {
     // 省庁ノード × filterOnMinistryClick 連動: 未設定時だけ単独フィルタを設定する。
     // 解除はフィルタ解除ボタンに一本化し、再クリックはサイドパネル表示を優先する。
     if (filterOnMinistryClick && node.type === 'ministry' && !node.aggregated) {
@@ -2068,6 +2067,29 @@ export default function RealDataSankeyPage() {
     }
     selectNode(newId);
   }, [selectedNodeId, selectNode, focusRelated, autoFocusRelated, exitFocusRelated, graphData, filterOnMinistryClick, filterMinistryNames]);
+
+  const handleNodeClick = useCallback((node: LayoutNode, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (touchActivatedNodeIdRef.current === node.id) {
+      touchActivatedNodeIdRef.current = null;
+      return;
+    }
+    if (didPanRef.current) return;
+    activateNode(node);
+  }, [activateNode]);
+
+  const handleNodeTouchPointerUp = useCallback((node: LayoutNode, e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    e.stopPropagation();
+    const shouldActivate = !didPanRef.current && !didPinchRef.current;
+    handleTouchPointerEnd(e);
+    if (!shouldActivate) return;
+    touchActivatedNodeIdRef.current = node.id;
+    window.setTimeout(() => {
+      if (touchActivatedNodeIdRef.current === node.id) touchActivatedNodeIdRef.current = null;
+    }, 500);
+    activateNode(node);
+  }, [activateNode, handleTouchPointerEnd]);
 
   // focusRelated=ON 中に別ノードをクリックした後、フルレイアウト更新後にオフセット調整
   useEffect(() => {
@@ -2652,16 +2674,18 @@ export default function RealDataSankeyPage() {
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                               onMouseLeave={() => setHoveredNode(null)}
+                              onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                               onClick={(e) => handleNodeClick(node, e)}
                             />
                             {labelVisible && (
                               <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                                style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
+                                style={{ userSelect: 'none', cursor: 'pointer', pointerEvents: 'all' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                                 onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                                 onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                                 onMouseLeave={() => setHoveredNode(null)}
                                 onMouseDown={(e) => e.preventDefault()}
+                                onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                                 onClick={(e) => handleNodeClick(node, e)}>
                                 {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                               </text>
@@ -2679,28 +2703,31 @@ export default function RealDataSankeyPage() {
                             onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                             onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                             onMouseLeave={() => setHoveredNode(null)}
+                            onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                             onClick={(e) => handleNodeClick(node, e)}
                           />
                           {labelVisible && (<>
                             {/* Left label: budget amount */}
                             <text x={getNodeInnerX0(node) - innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle" textAnchor="end"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                              style={{ userSelect: 'none', cursor: 'pointer' }}
+                              style={{ userSelect: 'none', cursor: 'pointer', pointerEvents: 'all' }}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                               onMouseLeave={() => setHoveredNode(null)}
                               onMouseDown={(e) => e.preventDefault()}
+                              onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                               onClick={(e) => handleNodeClick(node, e)}>
                               {formatYen(node.value)}{node.isScaled && node.rawValue != null && <tspan fill="#888"> / {formatYen(node.rawValue)}</tspan>}
                             </text>
                             {/* Right label: project name + spending amount */}
                             <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                              style={{ userSelect: 'none', cursor: 'pointer' }} clipPath={`url(#clip-col-${getColumn(node)})`}
+                              style={{ userSelect: 'none', cursor: 'pointer', pointerEvents: 'all' }} clipPath={`url(#clip-col-${getColumn(node)})`}
                               onMouseEnter={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); setHoveredNode(node); }}
                               onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) setMousePos({ x: e.clientX - r.left, y: e.clientY - r.top }); }}
                               onMouseLeave={() => setHoveredNode(null)}
                               onMouseDown={(e) => e.preventDefault()}
+                              onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                               onClick={(e) => handleNodeClick(node, e)}>
                               {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
                             </text>
@@ -2740,6 +2767,7 @@ export default function RealDataSankeyPage() {
                             if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
                           }}
                           onMouseLeave={() => setHoveredNode(null)}
+                          onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                           onClick={(e) => handleNodeClick(node, e)}
                         />
                         {labelVisible && (
@@ -2749,12 +2777,13 @@ export default function RealDataSankeyPage() {
                             fontSize={colFontPx / zoom}
                             dominantBaseline="middle"
                             fill={connectedNodeIds && !connectedNodeIds.has(node.id) ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
-                            style={{ userSelect: 'none', cursor: 'pointer' }}
+                            style={{ userSelect: 'none', cursor: 'pointer', pointerEvents: 'all' }}
                             clipPath={isLastCol ? undefined : `url(#clip-col-${col})`}
                             onMouseEnter={(e) => { const rect = containerRef.current?.getBoundingClientRect(); if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top }); setHoveredNode(node); }}
                             onMouseMove={(e) => { const rect = containerRef.current?.getBoundingClientRect(); if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top }); }}
                             onMouseLeave={() => setHoveredNode(null)}
                             onMouseDown={(e) => e.preventDefault()}
+                            onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                             onClick={(e) => handleNodeClick(node, e)}
                           >
                             {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -993,7 +993,6 @@ export default function RealDataSankeyPage() {
 
   const handleTouchPointerDown = useCallback((e: React.PointerEvent) => {
     if (e.pointerType === 'mouse' || isOverlayControlTarget(e.target)) return;
-    e.preventDefault();
     const point = getTouchPoint(e);
     activePointersRef.current.set(e.pointerId, point);
     setIsPanning(true);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -58,6 +58,9 @@ interface SankeyUrlState {
 
 const SCREEN_LEFT_PADDING_PX = 32;
 const SCREEN_HORIZONTAL_FIT_RATIO = 0.82;
+const SCREEN_MIN_TOTAL_LABEL_GAP_PX = 112;
+const SCREEN_MIN_MINISTRY_LABEL_WIDTH_PX = 128;
+const SCREEN_MAX_MINISTRY_LABEL_GAP_PX = 72;
 const E2E_TEST_IDS_ENABLED = process.env.NODE_ENV !== 'production' || process.env.NEXT_PUBLIC_PLAYWRIGHT === '1';
 const testId = (id: string): string | undefined => E2E_TEST_IDS_ENABLED ? id : undefined;
 
@@ -98,6 +101,7 @@ const BUDGET_EXECUTION_LIST_HEIGHT_MIN = 96;
 const BUDGET_EXECUTION_LIST_HEIGHT_MAX = 600;
 const HOVER_SUPPRESS_AFTER_INTERACTION_MS = 500;
 const HOVER_ENTER_DELAY_MS = 220;
+const TOUCH_PAN_SLOP_PX = 10;
 const FIT_TOP_PAD_PX = 32;
 const ZOOM_FONT_MAX_RATIO = 1.8;   // zoom-in でフォントを最大で元の何倍まで拡大するか
 const AGGREGATE_BOUNDARY_GAP_PX = 6;
@@ -531,8 +535,15 @@ export default function RealDataSankeyPage() {
     };
   }, [showAccountDropdown]);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  const panRef = useRef(pan);
+  useEffect(() => { panRef.current = pan; }, [pan]);
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef({ x: 0, y: 0 });
+  const activePointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const touchPanStartRef = useRef<{ x: number; y: number } | null>(null);
+  const touchPanOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const pinchLastDistanceRef = useRef<number | null>(null);
+  const didPinchRef = useRef(false);
   const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
   const hoverSuppressTimerRef = useRef<number | null>(null);
   const suppressHoverPopup = isPanning || isHoverSuppressed;
@@ -842,6 +853,12 @@ export default function RealDataSankeyPage() {
     target instanceof Element &&
     !!target.closest('[data-pan-disabled],button,input,select,textarea,label');
 
+  const beginHoverSuppressCooldown = useCallback(() => {
+    setIsHoverSuppressed(true);
+    if (hoverSuppressTimerRef.current) window.clearTimeout(hoverSuppressTimerRef.current);
+    hoverSuppressTimerRef.current = window.setTimeout(() => setIsHoverSuppressed(false), HOVER_SUPPRESS_AFTER_INTERACTION_MS);
+  }, []);
+
   // Debounced zoom URL write — called only on explicit user zoom (wheel / buttons)
   const scheduleZoomUrlWrite = useCallback(() => {
     if (zoomUrlDebounceRef.current) clearTimeout(zoomUrlDebounceRef.current);
@@ -922,10 +939,137 @@ export default function RealDataSankeyPage() {
     setIsPanning(false);
     // 実際にパンが発生したときだけクールダウン（単なるクリックでは抑制しない）
     if (!didPanRef.current) return;
-    setIsHoverSuppressed(true);
-    if (hoverSuppressTimerRef.current) window.clearTimeout(hoverSuppressTimerRef.current);
-    hoverSuppressTimerRef.current = window.setTimeout(() => setIsHoverSuppressed(false), HOVER_SUPPRESS_AFTER_INTERACTION_MS);
+    beginHoverSuppressCooldown();
+  }, [beginHoverSuppressCooldown]);
+
+  const getTouchPoint = useCallback((e: React.PointerEvent): { x: number; y: number } => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    return {
+      x: e.clientX - (rect?.left ?? 0),
+      y: e.clientY - (rect?.top ?? 0),
+    };
   }, []);
+
+  const getPinchState = useCallback((): { distance: number; midpoint: { x: number; y: number } } | null => {
+    const points = Array.from(activePointersRef.current.values());
+    if (points.length < 2) return null;
+    const [a, b] = points;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    return {
+      distance: Math.max(1, Math.hypot(dx, dy)),
+      midpoint: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+    };
+  }, []);
+
+  const getTouchZoomAnchoredPanY = useCallback((
+    anchorY: number,
+    nextZoom: number,
+    fromZoom: number,
+    fromPanY: number,
+  ): number => {
+    const l = layoutRef.current;
+    if (!l) return anchorY - (anchorY - fromPanY) * (nextZoom / fromZoom);
+    const currentTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, fromZoom, baseZoom);
+    const nextTotalH = MARGIN.top + l.contentH + calcShiftExtraH(l.nodes, nextZoom, baseZoom);
+    const currentScreenH = Math.max(1, currentTotalH * fromZoom);
+    const nextScreenH = Math.max(1, nextTotalH * nextZoom);
+    const ratioFromTop = (anchorY - fromPanY) / currentScreenH;
+    return anchorY - ratioFromTop * nextScreenH;
+  }, [baseZoom, calcShiftExtraH]);
+
+  const setTouchViewport = useCallback((nextZoom: number, nextPan: { x: number; y: number }) => {
+    zoomRef.current = nextZoom;
+    panRef.current = nextPan;
+    setZoom(nextZoom);
+    setPan(nextPan);
+  }, []);
+
+  const resetTouchPanOriginToRemainingPointer = useCallback(() => {
+    const remaining = Array.from(activePointersRef.current.values())[0] ?? null;
+    touchPanStartRef.current = remaining;
+    touchPanOriginRef.current = remaining ? { ...panRef.current } : null;
+  }, []);
+
+  const handleTouchPointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' || isOverlayControlTarget(e.target)) return;
+    e.preventDefault();
+    const point = getTouchPoint(e);
+    activePointersRef.current.set(e.pointerId, point);
+    setIsPanning(true);
+    setHoveredNode(null);
+    setHoveredLink(null);
+
+    if (activePointersRef.current.size === 1) {
+      didPanRef.current = false;
+      didPinchRef.current = false;
+      pinchLastDistanceRef.current = null;
+      touchPanStartRef.current = point;
+      touchPanOriginRef.current = { ...panRef.current };
+      return;
+    }
+
+    const pinch = getPinchState();
+    if (pinch) {
+      didPanRef.current = true;
+      didPinchRef.current = true;
+      pinchLastDistanceRef.current = pinch.distance;
+      touchPanStartRef.current = null;
+      touchPanOriginRef.current = null;
+    }
+  }, [getPinchState, getTouchPoint]);
+
+  const handleTouchPointerMove = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' || !activePointersRef.current.has(e.pointerId)) return;
+    e.preventDefault();
+    const point = getTouchPoint(e);
+    activePointersRef.current.set(e.pointerId, point);
+
+    if (activePointersRef.current.size >= 2) {
+      const pinch = getPinchState();
+      if (!pinch) return;
+      const lastDistance = pinchLastDistanceRef.current ?? pinch.distance;
+      const ratio = pinch.distance / Math.max(1, lastDistance);
+      const fromZoom = zoomRef.current;
+      const fromPan = panRef.current;
+      const minZoom = Math.max(ZOOM_MIN_ABS, baseZoom * ZOOM_MIN_MULTIPLIER);
+      const maxZoom = Math.min(ZOOM_MAX_ABS, baseZoom * ZOOM_MAX_MULTIPLIER);
+      const nextZoom = Math.max(minZoom, Math.min(maxZoom, fromZoom * ratio));
+      const nextPanY = getTouchZoomAnchoredPanY(pinch.midpoint.y, nextZoom, fromZoom, fromPan.y);
+      didPanRef.current = true;
+      didPinchRef.current = true;
+      pinchLastDistanceRef.current = pinch.distance;
+      setTouchViewport(nextZoom, { x: fromPan.x, y: nextPanY });
+      return;
+    }
+
+    const start = touchPanStartRef.current;
+    const origin = touchPanOriginRef.current;
+    if (!start || !origin) return;
+    const dx = point.x - start.x;
+    const dy = point.y - start.y;
+    if (Math.abs(dx) > TOUCH_PAN_SLOP_PX || Math.abs(dy) > TOUCH_PAN_SLOP_PX) didPanRef.current = true;
+    const nextPan = { x: origin.x + dx, y: origin.y + dy };
+    panRef.current = nextPan;
+    setPan(nextPan);
+  }, [baseZoom, getPinchState, getTouchPoint, getTouchZoomAnchoredPanY, setTouchViewport]);
+
+  const handleTouchPointerEnd = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    activePointersRef.current.delete(e.pointerId);
+    pinchLastDistanceRef.current = null;
+
+    if (activePointersRef.current.size === 0) {
+      setIsPanning(false);
+      touchPanStartRef.current = null;
+      touchPanOriginRef.current = null;
+      if (didPinchRef.current) scheduleZoomUrlWrite();
+      if (didPanRef.current) beginHoverSuppressCooldown();
+      return;
+    }
+
+    resetTouchPanOriginToRemainingPointer();
+  }, [beginHoverSuppressCooldown, resetTouchPanOriginToRemainingPointer, scheduleZoomUrlWrite]);
 
   // Converge on fit zoom accounting for label shifts (shifts grow as zoom shrinks → iterate)
   const fitZoomWithShifts = useCallback((
@@ -2134,6 +2278,29 @@ export default function RealDataSankeyPage() {
     if (!layout) return 1;
     return Math.max(0.2, Math.min(10, (svgWidth / (MARGIN.left + layout.contentW + SCREEN_LEFT_PADDING_PX)) * SCREEN_HORIZONTAL_FIT_RATIO));
   }, [layout, svgWidth]);
+  const totalLabelGapPx = useMemo(() => {
+    if (!layout) return 0;
+    return Math.max(0, SCREEN_MIN_TOTAL_LABEL_GAP_PX - layout.colSpacing * horizontalScale);
+  }, [horizontalScale, layout]);
+  const ministryLabelGapPx = useMemo(() => {
+    if (!layout) return 0;
+    const leftLabelChars = layout.nodes
+      .filter(n => n.type === 'project-budget')
+      .reduce((m, n) => {
+        const main = formatYen(n.value);
+        const raw = n.isScaled && n.rawValue != null ? ` / ${formatYen(n.rawValue)}` : '';
+        return Math.max(m, (main + raw).length);
+      }, 0);
+    const labelScale = getZoomLabelScale(zoom, baseZoom);
+    const leftLabelReservePx = leftLabelChars > 0
+      ? 6 + leftLabelChars * mapLabelFontPx * labelScale * 0.7
+      : 0;
+    const ministryLabelWidthPx = layout.colSpacing * horizontalScale - NODE_W - leftLabelReservePx;
+    return Math.min(
+      SCREEN_MAX_MINISTRY_LABEL_GAP_PX,
+      Math.max(0, SCREEN_MIN_MINISTRY_LABEL_WIDTH_PX - ministryLabelWidthPx)
+    );
+  }, [baseZoom, horizontalScale, layout, mapLabelFontPx, zoom]);
   const screenNodeW = NODE_W;
   const screenToInnerX = useCallback((screenX: number) => screenX / zoom - MARGIN.left, [zoom]);
   const screenWToInner = useCallback((screenW: number) => screenW / zoom, [zoom]);
@@ -2144,10 +2311,12 @@ export default function RealDataSankeyPage() {
         ? '__agg-project-budget'
         : node.projectId != null ? `project-budget-${node.projectId}` : null;
       const budgetNode = budgetId ? nodeByLayoutId.get(budgetId) : null;
-      if (budgetNode) return left + budgetNode.x0 * horizontalScale + screenNodeW;
+      if (budgetNode) return left + budgetNode.x0 * horizontalScale + totalLabelGapPx + ministryLabelGapPx + screenNodeW;
     }
-    return left + node.x0 * horizontalScale;
-  }, [horizontalScale, nodeByLayoutId, screenNodeW]);
+    const totalLabelOffset = node.type === 'total' ? 0 : totalLabelGapPx;
+    const ministryLabelOffset = node.type === 'total' || node.type === 'ministry' ? 0 : ministryLabelGapPx;
+    return left + node.x0 * horizontalScale + totalLabelOffset + ministryLabelOffset;
+  }, [horizontalScale, ministryLabelGapPx, nodeByLayoutId, screenNodeW, totalLabelGapPx]);
   const getNodeScreenX1 = useCallback((node: LayoutNode): number => getNodeScreenX0(node) + screenNodeW, [getNodeScreenX0, screenNodeW]);
   const getNodeInnerX0 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX0(node)), [getNodeScreenX0, screenToInnerX]);
   const getNodeInnerX1 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX1(node)), [getNodeScreenX1, screenToInnerX]);
@@ -2330,7 +2499,11 @@ export default function RealDataSankeyPage() {
               width={svgWidth}
               height={svgHeight}
               overflow="visible"
-              style={{ position: 'absolute', inset: 0, display: 'block' }}
+              onPointerDown={handleTouchPointerDown}
+              onPointerMove={handleTouchPointerMove}
+              onPointerUp={handleTouchPointerEnd}
+              onPointerCancel={handleTouchPointerEnd}
+              style={{ position: 'absolute', inset: 0, display: 'block', touchAction: 'none' }}
             >
               {/* Gradient defs for merged project nodes */}
               <defs>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2343,6 +2343,41 @@ export default function RealDataSankeyPage() {
   const getNodeInnerX1 = useCallback((node: LayoutNode): number => screenToInnerX(getNodeScreenX1(node)), [getNodeScreenX1, screenToInnerX]);
   const innerNodeW = screenWToInner(screenNodeW);
   const innerLabelGap = screenWToInner(3);
+  const innerLabelHitH = screenWToInner(14);
+  const getRightLabelHitW = (col: number, isLastCol: boolean) => screenWToInner(
+    isLastCol ? 220 : col === 0 ? 112 : col === 1 ? 140 : 160
+  );
+  const renderLabelHitRect = (
+    node: LayoutNode,
+    x: number,
+    centerY: number,
+    width: number,
+    anchor: 'start' | 'end' = 'start'
+  ) => {
+    const hitX = anchor === 'end' ? x - width : x;
+    return (
+      <rect
+        x={hitX}
+        y={centerY - innerLabelHitH / 2}
+        width={width}
+        height={innerLabelHitH}
+        fill="transparent"
+        style={{ cursor: 'pointer', pointerEvents: 'all' }}
+        onMouseEnter={(e) => {
+          const rect = containerRef.current?.getBoundingClientRect();
+          if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+          setHoveredNode(node);
+        }}
+        onMouseMove={(e) => {
+          const rect = containerRef.current?.getBoundingClientRect();
+          if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+        }}
+        onMouseLeave={() => setHoveredNode(null)}
+        onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
+        onClick={(e) => handleNodeClick(node, e)}
+      />
+    );
+  };
   const getMinimapRenderedYBounds = useCallback((node: LayoutNode): { top: number; bottom: number } => {
     let shiftNode = node;
     if (node.type === 'project-spending') {
@@ -2677,7 +2712,7 @@ export default function RealDataSankeyPage() {
                               onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                               onClick={(e) => handleNodeClick(node, e)}
                             />
-                            {labelVisible && (
+                            {labelVisible && (<>
                               <text x={getNodeInnerX1(node) + innerLabelGap} y={topShift + bH / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                                 fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
                                 style={{ userSelect: 'none', cursor: 'pointer', pointerEvents: 'all' }} clipPath={`url(#clip-col-${getColumn(node)})`}
@@ -2689,7 +2724,8 @@ export default function RealDataSankeyPage() {
                                 onClick={(e) => handleNodeClick(node, e)}>
                                 {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                               </text>
-                            )}
+                              {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + bH / 2, getRightLabelHitW(getColumn(node), false))}
+                            </>)}
                           </g>
                         );
                       }
@@ -2719,6 +2755,7 @@ export default function RealDataSankeyPage() {
                               onClick={(e) => handleNodeClick(node, e)}>
                               {formatYen(node.value)}{node.isScaled && node.rawValue != null && <tspan fill="#888"> / {formatYen(node.rawValue)}</tspan>}
                             </text>
+                            {renderLabelHitRect(node, getNodeInnerX0(node) - innerLabelGap, topShift + Math.max(bH, sH) / 2, screenWToInner(96), 'end')}
                             {/* Right label: project name + spending amount */}
                             <text x={getNodeInnerX1(spendingNode) + innerLabelGap} y={topShift + Math.max(bH, sH) / 2} fontSize={colFontPx / zoom} dominantBaseline="middle"
                               fill={connectedNodeIds && !isConnected ? '#bbb' : hoveredNodeIds && !hoveredNodeIds.has(node.id) ? '#bbb' : '#333'}
@@ -2731,6 +2768,7 @@ export default function RealDataSankeyPage() {
                               onClick={(e) => handleNodeClick(node, e)}>
                               {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(spendingNode.value)}){spendingNode.isScaled && spendingNode.rawValue != null && (<tspan fill="#777"> / {formatYen(spendingNode.rawValue)}</tspan>)}
                             </text>
+                            {renderLabelHitRect(node, getNodeInnerX1(spendingNode) + innerLabelGap, topShift + Math.max(bH, sH) / 2, getRightLabelHitW(getColumn(node), false))}
                           </>)}
                         </g>
                       );
@@ -2770,7 +2808,7 @@ export default function RealDataSankeyPage() {
                           onPointerUp={(e) => handleNodeTouchPointerUp(node, e)}
                           onClick={(e) => handleNodeClick(node, e)}
                         />
-                        {labelVisible && (
+                        {labelVisible && (<>
                           <text
                             x={getNodeInnerX1(node) + innerLabelGap}
                             y={topShift + h / 2}
@@ -2788,7 +2826,8 @@ export default function RealDataSankeyPage() {
                           >
                             {node.name.length > 40 ? node.name.slice(0, 40) + '…' : node.name} ({formatYen(node.value)}){node.isScaled && node.rawValue != null && (<tspan fill="#777"> / {formatYen(node.rawValue)}</tspan>)}
                           </text>
-                        )}
+                          {renderLabelHitRect(node, getNodeInnerX1(node) + innerLabelGap, topShift + h / 2, getRightLabelHitW(col, isLastCol))}
+                        </>)}
                       </g>
                     );
                   });


### PR DESCRIPTION
## Summary
- add touch pointer pan and pinch zoom directly to /sankey-svg
- reserve minimum readable space for the total and ministry labels on narrow mobile views
- keep the migrated diff aligned with the /sankey-svg-next2 experiment, without adding the separate next2 route

## Diff size
- app/sankey-svg/page.tsx: 180 insertions, 7 deletions

## Verification
- npx tsc --noEmit
- npm run lint (passes with existing warnings)
- Playwright mobile check on /sankey-svg: touch pan, pinch zoom, total label width, ministry label clip width

## Notes
- Supersedes the route-copy experiment in #220 if this direct /sankey-svg approach looks good.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added touch gesture support including pinch-zoom and panning capabilities
  * Enhanced label hover detection and click-to-select interactions
  * Improved touch interaction handling to distinguish between panning and tap gestures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->