### PR TITLE
feat(sankey-svg): スマホ幅でズーム系コントロールを非表示

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -67,6 +67,9 @@ const testId = (id: string): string | undefined => E2E_TEST_IDS_ENABLED ? id : u
 const MAP_LABEL_FONT_PX_DEFAULT = 11;
 const MAP_LABEL_SLOT_PX_DEFAULT = 12;
 const MAP_LABEL_VISIBLE_MIN_H_PX_DEFAULT = 11;
+// この幅（px）以下では、タッチ操作で代替できるズーム系コントロールを非表示にする。
+// 767 = 「タブレット未満」境界。iPad縦(768px〜)ではコントロールを残し、スマホ幅でのみ隠す。
+const COMPACT_CONTROL_MAX_WIDTH = 767;
 const ZOOM_MIN_ABS = 0.05;
 const ZOOM_MAX_ABS = 20;
 const ZOOM_MIN_MULTIPLIER = 0.25;
@@ -315,6 +318,11 @@ export default function RealDataSankeyPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [svgWidth, setSvgWidth] = useState(1200);
   const [svgHeight, setSvgHeight] = useState(800);
+  // 幅ベースのコンパクト判定。閾値以下では、ピンチズーム/2本指パンで代替できる
+  // ズーム系コントロール（スライダー・±ボタン・スクロールモード切替）を非表示にする。
+  // 入力デバイス（pointer:coarse）ではなく幅で判定することで、タッチ対応ノートPC等の
+  // 誤判定を避け、初期値1200=デスクトップ表示から安全側に倒す。
+  const isCompactWidth = svgWidth <= COMPACT_CONTROL_MAX_WIDTH;
 
   useEffect(() => {
     const updateSize = () => {
@@ -4668,7 +4676,8 @@ export default function RealDataSankeyPage() {
 
       {/* Zoom controls — bottom right (sankey2 style) */}
       <div style={{ position: 'absolute', bottom: 12, right: 12, zIndex: 15, display: 'flex', flexDirection: 'column', gap: 4 }}>
-        {/* スクロールモード切替ボタン */}
+        {/* スクロールモード切替ボタン（狭幅では2本指パンで代替できるため非表示） */}
+        {!isCompactWidth && (
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44 }}>
           <button
             aria-label={scrollMode === 'pan' ? 'スクロール移動モード（クリックでズームモードへ）' : 'スクロール移動モードに切替'}
@@ -4679,7 +4688,9 @@ export default function RealDataSankeyPage() {
             <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 -960 960 960" fill={scrollMode === 'pan' ? '#1a73e8' : '#bbb'}><path d="M480-80 310-250l57-57 73 73v-166H274l73 74-57 57L120-440l170-170 57 57-74 73h166v-166l-73 73-57-57 170-170 170 170-57 57-73-73v166h166l-74-73 57-57 170 170-170 170-57-57 74-74H520v166l73-73 57 57L480-80Z"/></svg>
           </button>
         </div>
-        {/* + / vertical slider / - */}
+        )}
+        {/* + / vertical slider / -（狭幅ではピンチズームで代替できるため非表示） */}
+        {!isCompactWidth && (
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           {/* Material Icons: add */}
           <button data-testid={testId('zoom-in')} aria-label="ズームイン" onClick={() => applyZoom(1.5)} title="ズームイン" style={{ width: '100%', padding: '5px 0', display: 'flex', justifyContent: 'center', background: 'transparent', border: 'none', borderBottom: '1px solid #e5e7eb', cursor: 'pointer' }}>
@@ -4703,6 +4714,7 @@ export default function RealDataSankeyPage() {
             <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 24 24" fill="#555"><path d="M19 13H5v-2h14v2z"/></svg>
           </button>
         </div>
+        )}
         {/* Zoom% — 非編集時は "N%" 表示、クリックで数値入力 */}
         <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44 }}>
           {isEditingZoom ? (


### PR DESCRIPTION
## 概要

`/sankey-svg` で、スマホ幅（幅 **767px以下**）のときに、タッチ操作で代替できるズーム系コントロールを非表示にする。

## 非表示にするコントロール（幅767px以下）

| コントロール | 代替手段 |
|---|---|
| スクロールモード切替ボタン | 2本指パン |
| ズームスライダー＋ ＋／− ボタン | ピンチズーム |

**Zoom%表示・全体表示ボタンは全幅で残す。**

## 判定方式

- 既存の `svgWidth`（コンテナ幅・ResizeObserver追従）を再利用し、派生フラグ `isCompactWidth = svgWidth <= 767` で制御。
- 当初 `matchMedia('(pointer: coarse)')` の入力デバイス判定を検討したが、タッチ対応ノートPCでの誤判定・SSRチラつきを避けるため**幅ベース**に変更（安全側）。
- 初期値 `svgWidth=1200`（デスクトップ表示）のため、初回レンダリングでコントロールが消える方向のチラつきは出ない。

## 閾値

`COMPACT_CONTROL_MAX_WIDTH = 767`（「タブレット未満」境界）。**iPad縦（768px〜）ではコントロールを維持**し、スマホ幅でのみ非表示。

## 確認

- `npx tsc --noEmit` 通過
- `npm run lint` 新規エラーなし（既存warningのみ）
- DevTools で幅 767/768 跨ぎのリサイズで切り替わりを確認

## 補足

`app/sankey-svg-next/` は別アプローチで削除予定のため本PRでは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Enhanced responsive layout for screens 767px and below
  * Zoom and navigation controls optimized for mobile devices with improved touch gesture support (pinch zoom and two-finger pan)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->