### PR TITLE
fix(sankey-svg): スマホ幅でオフセットコントロールの重なりを解消

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2504,7 +2504,9 @@ export default function RealDataSankeyPage() {
       + `L${tx},${tBot}C${mx},${tBot} ${mx},${sBot} ${sx},${sBot}Z`;
   };
 
-  const searchLeftOffset = selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth : 0;
+  // スマホ幅では検索ボックスをサイドパネルで横シフトさせず、オフセットコントロールと
+  // 左端(8px)を揃える（どちらも前面表示）。デスクトップは従来どおりパネル分シフト。
+  const searchLeftOffset = !isCompactWidth && selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth : 0;
   // 右上の設定(⋮)ボタン領域(幅32+余白)に重ならないよう右側を確保。
   // これがないと文字拡大時に検索ボックスが設定ボタンを覆い、タップで開けなくなる。
   const searchMaxWidth = `calc(100vw - ${searchLeftOffset}px - 64px)`;
@@ -3970,7 +3972,7 @@ export default function RealDataSankeyPage() {
       <div
         ref={searchBoxRef}
         data-pan-disabled="true"
-        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12, zIndex: 100, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
+        style={{ position: 'absolute', top: 12, left: isCompactWidth ? 8 : (selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12), zIndex: 100, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
       >
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
@@ -4359,8 +4361,8 @@ export default function RealDataSankeyPage() {
         };
         return (
           <div style={ isCompactWidth
-            ? { position: 'absolute', bottom: 12, left: 8, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)' }
-            : { position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
+            ? { position: 'absolute', bottom: 12, left: 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)' }
+            : { position: 'absolute', top: 12, right: 52, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
             {/* Row 1: オフセットスライダー（2列スパン） */}
             <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 8, alignItems: 'center' }}>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1169,6 +1169,8 @@ export default function RealDataSankeyPage() {
   const minimapRef = useRef<HTMLCanvasElement>(null);
   const minimapDragging = useRef(false);
   const [showMinimap, setShowMinimap] = useState(false);
+  // スマホ幅ではミニマップを表示しない（実機の縦横ともに画面が狭く有用性が低いため）
+  const minimapVisible = showMinimap && !isCompactWidth;
   const searchBoxRef = useRef<HTMLDivElement>(null);
 
   // Layout constants for bottom-right widgets the dropdown must clear
@@ -1192,11 +1194,11 @@ export default function RealDataSankeyPage() {
   }, [showFilterPanel]);
 
   const searchDropdownMaxH = useMemo(() => {
-    const obstacleTop = showMinimap
+    const obstacleTop = minimapVisible
       ? svgHeight - MINIMAP_BOTTOM - MINIMAP_BUFFER - minimapH
       : svgHeight - MAP_ICON_BOTTOM - MAP_ICON_HEIGHT - MAP_ICON_GAP;
     return Math.max(120, obstacleTop - searchBoxBottom - DROPDOWN_GAP);
-  }, [svgHeight, minimapH, showMinimap, searchBoxBottom]);
+  }, [svgHeight, minimapH, minimapVisible, searchBoxBottom]);
 
   useEffect(() => {
     setGraphData(null);
@@ -2438,7 +2440,7 @@ export default function RealDataSankeyPage() {
 
   // Draw minimap
   useEffect(() => {
-    if (!showMinimap || !layout) return;
+    if (!minimapVisible || !layout) return;
     const canvas = minimapRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
@@ -2488,7 +2490,7 @@ export default function RealDataSankeyPage() {
     ctx.strokeRect(mX, mY, mW, mH);
     ctx.fillStyle = 'rgba(59, 130, 246, 0.08)';
     ctx.fillRect(mX, mY, mW, mH);
-  }, [showMinimap, layout, zoom, pan, svgWidth, minimapWorldH, minimapH, getNodeScreenX0, getMinimapRenderedYBounds, screenNodeW]);
+  }, [minimapVisible, layout, zoom, pan, svgWidth, minimapWorldH, minimapH, getNodeScreenX0, getMinimapRenderedYBounds, screenNodeW]);
 
   const minimapNavigate = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = minimapRef.current;
@@ -3124,7 +3126,8 @@ export default function RealDataSankeyPage() {
               });
             })()}
 
-            {/* Minimap */}
+            {/* Minimap（スマホ幅では非表示） */}
+            {!isCompactWidth && (
             <MinimapOverlay
               show={showMinimap}
               onShow={() => setShowMinimap(true)}
@@ -3136,6 +3139,7 @@ export default function RealDataSankeyPage() {
               navigate={minimapNavigate}
               dragging={minimapDragging}
             />
+            )}
 
             {/* Font size controls（スマホ幅では設定ダイアログへ移動するため非表示） */}
             {!isCompactWidth && (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2627,8 +2627,9 @@ export default function RealDataSankeyPage() {
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
               }}
               onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
+              onContextMenu={(e) => e.preventDefault()}
               onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
             >
               <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
             </button>
@@ -2675,8 +2676,9 @@ export default function RealDataSankeyPage() {
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
               }}
               onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
+              onContextMenu={(e) => e.preventDefault()}
               onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
             >
               <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
             </button>
@@ -2754,13 +2756,14 @@ export default function RealDataSankeyPage() {
             onPointerUp={(e) => { e.stopPropagation(); stopFontRepeat(); }}
             onPointerLeave={stopFontRepeat}
             onPointerCancel={stopFontRepeat}
+            onContextMenu={(e) => e.preventDefault()}
             onClick={(e) => {
               if (e.detail === 0) {
                 pendingHistoryAction.current = 'replace';
                 setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
               }
             }}
-            style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+            style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
             data-pan-disabled
           >
             <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
@@ -4663,12 +4666,13 @@ export default function RealDataSankeyPage() {
                       onPointerUp={(e) => { e.stopPropagation(); stopOffsetRepeat(); }}
                       onPointerLeave={stopOffsetRepeat}
                       onPointerCancel={stopOffsetRepeat}
+                      onContextMenu={(e) => e.preventDefault()}
                       onClick={(e) => {
                         if (e.detail === 0) {
                           setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));
                         }
                       }}
-                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
                     </button>
@@ -4676,7 +4680,8 @@ export default function RealDataSankeyPage() {
                 </div>
                 {/* Material Icons: vertical_align_top — オフセットリセット */}
                 <button onClick={e => { e.preventDefault(); setActiveOffset(0); }} title="先頭へリセット" aria-label="先頭へリセット"
-                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+                  onContextMenu={(e) => e.preventDefault()}
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555" style={{ transform: 'rotate(-90deg)' }}><path d="M8 11h3v10h2V11h3l-4-4-4 4zM4 3v2h16V3H4z"/></svg>
                 </button>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4563,7 +4563,7 @@ export default function RealDataSankeyPage() {
         };
         return (
           <div style={ isCompactWidth
-            ? { position: 'absolute', bottom: 12, left: 56, right: 64, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }
+            ? { position: 'absolute', bottom: 12, left: 8, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)' }
             : { position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
             {/* Row 1: オフセットスライダー（2列スパン） */}
@@ -4578,8 +4578,9 @@ export default function RealDataSankeyPage() {
                 <option value="project">事業</option>
                 <option value="recipient">支出先</option>
               </select>
-              <label style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
-                <span style={{ color: '#555', fontSize: META_FONT_PX }}>Top</span>
+              <label style={{ flex: isCompactWidth ? '0 0 auto' : 1, display: 'flex', alignItems: 'center', gap: 4 }}>
+                {/* スマホ幅では「Top」ラベルを省き数値だけ表示 */}
+                {!isCompactWidth && <span style={{ color: '#555', fontSize: META_FONT_PX }}>Top</span>}
                 {isEditingOffset ? (
                   <input
                     type="number"

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -323,9 +323,6 @@ export default function RealDataSankeyPage() {
   // 入力デバイス（pointer:coarse）ではなく幅で判定することで、タッチ対応ノートPC等の
   // 誤判定を避け、初期値1200=デスクトップ表示から安全側に倒す。
   const isCompactWidth = svgWidth <= COMPACT_CONTROL_MAX_WIDTH;
-  // 縦長（ポートレート）かつ狭幅のときのみ、オフセットコントロールを画面下部へ逃がす。
-  // 横長（ランドスケープ）は縦の余白が乏しく横に余裕があるため、コンパクト幅でも右上のまま。
-  const isPortraitCompact = isCompactWidth && svgHeight >= svgWidth;
 
   useEffect(() => {
     const updateSize = () => {
@@ -4565,7 +4562,7 @@ export default function RealDataSankeyPage() {
           if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
         };
         return (
-          <div style={ isPortraitCompact
+          <div style={ isCompactWidth
             ? { position: 'absolute', bottom: 12, left: 56, right: 64, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }
             : { position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
@@ -4603,7 +4600,8 @@ export default function RealDataSankeyPage() {
                 )}
                 <span style={{ color: '#999', fontSize: META_FONT_PX }}>〜{activeRangeEnd}</span>
                 <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
-                <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>
+                {/* 総件数表示は幅を取るためスマホ幅では非表示 */}
+                {!isCompactWidth && <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>}
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
                   {([
                     [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '次へ'],

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -318,6 +318,8 @@ export default function RealDataSankeyPage() {
   // 入力デバイス（pointer:coarse）ではなく幅で判定することで、タッチ対応ノートPC等の
   // 誤判定を避け、初期値1200=デスクトップ表示から安全側に倒す。
   const isCompactWidth = svgWidth <= COMPACT_CONTROL_MAX_WIDTH;
+  // スマホ横（コンパクト幅かつ横長）: オフセットコントロールをサイドパネルでスライドさせる
+  const isLandscapeCompact = isCompactWidth && svgWidth > svgHeight;
 
   useEffect(() => {
     const updateSize = () => {
@@ -2504,9 +2506,7 @@ export default function RealDataSankeyPage() {
       + `L${tx},${tBot}C${mx},${tBot} ${mx},${sBot} ${sx},${sBot}Z`;
   };
 
-  // スマホ幅では検索ボックスをサイドパネルで横シフトさせず、オフセットコントロールと
-  // 左端(8px)を揃える（どちらも前面表示）。デスクトップは従来どおりパネル分シフト。
-  const searchLeftOffset = !isCompactWidth && selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth : 0;
+  const searchLeftOffset = selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth : 0;
   // 右上の設定(⋮)ボタン領域(幅32+余白)に重ならないよう右側を確保。
   // これがないと文字拡大時に検索ボックスが設定ボタンを覆い、タップで開けなくなる。
   const searchMaxWidth = `calc(100vw - ${searchLeftOffset}px - 64px)`;
@@ -3972,7 +3972,7 @@ export default function RealDataSankeyPage() {
       <div
         ref={searchBoxRef}
         data-pan-disabled="true"
-        style={{ position: 'absolute', top: 12, left: isCompactWidth ? 8 : (selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12), zIndex: 100, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
+        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12, zIndex: 100, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
       >
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
@@ -4361,7 +4361,7 @@ export default function RealDataSankeyPage() {
         };
         return (
           <div style={ isCompactWidth
-            ? { position: 'absolute', bottom: 12, left: 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)' }
+            ? { position: 'absolute', bottom: 12, left: isLandscapeCompact && selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 8 : 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)', transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }
             : { position: 'absolute', top: 12, right: 52, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
             {/* Row 1: オフセットスライダー（2列スパン） */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4453,8 +4453,8 @@ export default function RealDataSankeyPage() {
         );
       })()}
 
-      {/* Settings button — independent, top right */}
-      <div style={{ position: 'absolute', top: 14, right: 12, zIndex: 15 }}>
+      {/* Settings button — independent, top right（ダイアログを最前面にするため高いzIndex） */}
+      <div style={{ position: 'absolute', top: 14, right: 12, zIndex: 200 }}>
         <button
           onClick={() => setShowSettings(s => !s)}
           aria-label="表示設定を開く"

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -323,6 +323,9 @@ export default function RealDataSankeyPage() {
   // 入力デバイス（pointer:coarse）ではなく幅で判定することで、タッチ対応ノートPC等の
   // 誤判定を避け、初期値1200=デスクトップ表示から安全側に倒す。
   const isCompactWidth = svgWidth <= COMPACT_CONTROL_MAX_WIDTH;
+  // 縦長（ポートレート）かつ狭幅のときのみ、オフセットコントロールを画面下部へ逃がす。
+  // 横長（ランドスケープ）は縦の余白が乏しく横に余裕があるため、コンパクト幅でも右上のまま。
+  const isPortraitCompact = isCompactWidth && svgHeight >= svgWidth;
 
   useEffect(() => {
     const updateSize = () => {
@@ -2653,6 +2656,100 @@ export default function RealDataSankeyPage() {
     </>
   );
 
+  // 基準フォントサイズ調整（デスクトップは左下フローティング、スマホ幅では設定ダイアログ内に表示）
+  const fontSizeControlsFragment = (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <input
+        type="range"
+        min={BASE_FONT_PX_MIN}
+        max={BASE_FONT_PX_MAX}
+        step={1}
+        value={baseFontPx}
+        onChange={e => { pendingHistoryAction.current = 'replace'; setBaseFontPx(Number(e.target.value)); }}
+        style={{ width: 60, boxSizing: 'border-box', margin: 0 }}
+        data-pan-disabled
+        aria-label="基準フォントサイズ"
+      />
+      {isEditingBaseFont ? (
+        <input
+          type="number"
+          autoFocus
+          min={BASE_FONT_PX_MIN}
+          max={BASE_FONT_PX_MAX}
+          step={1}
+          value={baseFontPxInput}
+          onChange={e => setBaseFontPxInput(e.target.value)}
+          onBlur={() => { commitBaseFontPxInput(); setIsEditingBaseFont(false); }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') { commitBaseFontPxInput(); setIsEditingBaseFont(false); }
+            else if (e.key === 'Escape') { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(false); }
+          }}
+          style={{ width: `${Math.max(40, String(BASE_FONT_PX_MAX).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: CONTROL_SMALL_FONT_PX }}
+          data-pan-disabled
+          aria-label="基準フォントサイズ(数値)"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(true); }}
+          title="クリックしてフォントサイズを入力"
+          style={{ color: '#999', fontSize: META_FONT_PX_DEFAULT, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
+          data-pan-disabled
+          aria-label="基準フォントサイズ編集を開始"
+        >{baseFontPx}</button>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+        {([
+          [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '大きく'],
+          [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '小さく'],
+        ] as [number, string, string][]).map(([delta, path, title]) => (
+          <button key={delta} type="button" title={title} aria-label={title}
+            onPointerDown={(e) => {
+              if (e.pointerType === 'mouse' && e.button !== 0) return;
+              e.stopPropagation();
+              e.currentTarget.setPointerCapture(e.pointerId);
+              const step = () => {
+                pendingHistoryAction.current = 'replace';
+                setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
+              };
+              stopFontRepeat();
+              step();
+              fontRepeatRef.current = setTimeout(() => {
+                fontRepeatRef.current = setInterval(step, 150);
+              }, 400);
+            }}
+            onPointerUp={(e) => { e.stopPropagation(); stopFontRepeat(); }}
+            onPointerLeave={stopFontRepeat}
+            onPointerCancel={stopFontRepeat}
+            onClick={(e) => {
+              if (e.detail === 0) {
+                pendingHistoryAction.current = 'replace';
+                setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
+              }
+            }}
+            style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+            data-pan-disabled
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => { pendingHistoryAction.current = 'replace'; setBaseFontPx(BASE_FONT_PX_DEFAULT); }}
+        title="既定値に戻す"
+        aria-label="既定値に戻す"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', color: '#555' }}
+        data-pan-disabled
+      >
+        {/* Material Icons: reset_settings */}
+        <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="currentColor">
+          <path d="M520-330v-60h160v60H520Zm60 210v-50h-60v-60h60v-50h60v160h-60Zm100-50v-60h160v60H680Zm40-110v-160h60v50h60v60h-60v50h-60Zm111-280h-83q-26-88-99-144t-169-56q-117 0-198.5 81.5T200-480q0 72 32.5 132t87.5 98v-110h80v240H160v-80h94q-62-50-98-122.5T120-480q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q129 0 226.5 79.5T831-560Z" />
+        </svg>
+      </button>
+    </div>
+  );
+
   return (
     <div
       ref={containerRef}
@@ -3040,7 +3137,8 @@ export default function RealDataSankeyPage() {
               dragging={minimapDragging}
             />
 
-            {/* Font size controls */}
+            {/* Font size controls（スマホ幅では設定ダイアログへ移動するため非表示） */}
+            {!isCompactWidth && (
             <div
               data-pan-disabled="true"
               style={{
@@ -3099,96 +3197,7 @@ export default function RealDataSankeyPage() {
                     alignItems: 'center',
                   }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <input
-                      type="range"
-                      min={BASE_FONT_PX_MIN}
-                      max={BASE_FONT_PX_MAX}
-                      step={1}
-                      value={baseFontPx}
-                      onChange={e => { pendingHistoryAction.current = 'replace'; setBaseFontPx(Number(e.target.value)); }}
-                      style={{ width: 60, boxSizing: 'border-box', margin: 0 }}
-                      data-pan-disabled
-                      aria-label="基準フォントサイズ"
-                    />
-                    {isEditingBaseFont ? (
-                      <input
-                        type="number"
-                        autoFocus
-                        min={BASE_FONT_PX_MIN}
-                        max={BASE_FONT_PX_MAX}
-                        step={1}
-                        value={baseFontPxInput}
-                        onChange={e => setBaseFontPxInput(e.target.value)}
-                        onBlur={() => { commitBaseFontPxInput(); setIsEditingBaseFont(false); }}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter') { commitBaseFontPxInput(); setIsEditingBaseFont(false); }
-                          else if (e.key === 'Escape') { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(false); }
-                        }}
-                        style={{ width: `${Math.max(40, String(BASE_FONT_PX_MAX).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: CONTROL_SMALL_FONT_PX }}
-                        data-pan-disabled
-                        aria-label="基準フォントサイズ(数値)"
-                      />
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(true); }}
-                        title="クリックしてフォントサイズを入力"
-                        style={{ color: '#999', fontSize: META_FONT_PX_DEFAULT, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
-                        data-pan-disabled
-                        aria-label="基準フォントサイズ編集を開始"
-                      >{baseFontPx}</button>
-                    )}
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-                      {([
-                        [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '大きく'],
-                        [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '小さく'],
-                      ] as [number, string, string][]).map(([delta, path, title]) => (
-                        <button key={delta} type="button" title={title} aria-label={title}
-                          onPointerDown={(e) => {
-                            if (e.pointerType === 'mouse' && e.button !== 0) return;
-                            e.stopPropagation();
-                            e.currentTarget.setPointerCapture(e.pointerId);
-                            const step = () => {
-                              pendingHistoryAction.current = 'replace';
-                              setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
-                            };
-                            stopFontRepeat();
-                            step();
-                            fontRepeatRef.current = setTimeout(() => {
-                              fontRepeatRef.current = setInterval(step, 150);
-                            }, 400);
-                          }}
-                          onPointerUp={(e) => { e.stopPropagation(); stopFontRepeat(); }}
-                          onPointerLeave={stopFontRepeat}
-                          onPointerCancel={stopFontRepeat}
-                          onClick={(e) => {
-                            if (e.detail === 0) {
-                              pendingHistoryAction.current = 'replace';
-                              setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
-                            }
-                          }}
-                          style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
-                          data-pan-disabled
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-                        </button>
-                      ))}
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => { pendingHistoryAction.current = 'replace'; setBaseFontPx(BASE_FONT_PX_DEFAULT); }}
-                      title="既定値に戻す"
-                      aria-label="既定値に戻す"
-                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', color: '#555' }}
-                      data-pan-disabled
-                    >
-                      {/* Material Icons: reset_settings */}
-                      <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="currentColor">
-                        <path d="M520-330v-60h160v60H520Zm60 210v-50h-60v-60h60v-50h60v160h-60Zm100-50v-60h160v60H680Zm40-110v-160h60v50h60v60h-60v50h-60Zm111-280h-83q-26-88-99-144t-169-56q-117 0-198.5 81.5T200-480q0 72 32.5 132t87.5 98v-110h80v240H160v-80h94q-62-50-98-122.5T120-480q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q129 0 226.5 79.5T831-560Z" />
-                      </svg>
-                    </button>
-                  </div>
+                  {fontSizeControlsFragment}
                   <button
                     type="button"
                     title="フォントサイズ設定を閉じる"
@@ -3221,6 +3230,7 @@ export default function RealDataSankeyPage() {
                 </div>
               )}
             </div>
+            )}
 
           {/* DOM tooltip — link hover */}
           {hoveredLink && !hoveredNode && !suppressHoverPopup && (() => {
@@ -4551,7 +4561,7 @@ export default function RealDataSankeyPage() {
           if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
         };
         return (
-          <div style={ isCompactWidth
+          <div style={ isPortraitCompact
             ? { position: 'absolute', bottom: 12, left: 56, right: 64, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }
             : { position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
@@ -4678,6 +4688,13 @@ export default function RealDataSankeyPage() {
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingBottom: 8, borderBottom: '1px solid #eee' }}>
                   <span style={{ color: '#555', fontWeight: 600 }}>表示件数（TopN）</span>
                   {topNSlidersFragment}
+                </div>
+              )}
+              {/* スマホ幅: 左下から移動した基準フォントサイズ調整 */}
+              {isCompactWidth && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingBottom: 8, borderBottom: '1px solid #eee' }}>
+                  <span style={{ color: '#555', fontWeight: 600 }}>文字サイズ</span>
+                  {fontSizeControlsFragment}
                 </div>
               )}
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2621,9 +2621,8 @@ export default function RealDataSankeyPage() {
               onPointerDown={(e) => {
                 if (e.pointerType === 'mouse' && e.button !== 0) return;
                 e.currentTarget.setPointerCapture(e.pointerId);
-                setSelectionSuppressed(true);
                 const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
-                stopTopNRepeat(); step();
+                stopTopNRepeat(); setSelectionSuppressed(true); step();
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
               }}
               onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
@@ -2670,9 +2669,8 @@ export default function RealDataSankeyPage() {
               onPointerDown={(e) => {
                 if (e.pointerType === 'mouse' && e.button !== 0) return;
                 e.currentTarget.setPointerCapture(e.pointerId);
-                setSelectionSuppressed(true);
                 const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
-                stopTopNRepeat(); step();
+                stopTopNRepeat(); setSelectionSuppressed(true); step();
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
               }}
               onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
@@ -2742,12 +2740,12 @@ export default function RealDataSankeyPage() {
               if (e.pointerType === 'mouse' && e.button !== 0) return;
               e.stopPropagation();
               e.currentTarget.setPointerCapture(e.pointerId);
-              setSelectionSuppressed(true);
               const step = () => {
                 pendingHistoryAction.current = 'replace';
                 setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
               };
               stopFontRepeat();
+              setSelectionSuppressed(true);
               step();
               fontRepeatRef.current = setTimeout(() => {
                 fontRepeatRef.current = setInterval(step, 150);
@@ -4650,7 +4648,6 @@ export default function RealDataSankeyPage() {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
-                        setSelectionSuppressed(true);
                         const step = () => {
                           pendingHistoryAction.current = 'replace';
                           pendingFocusId.current = null;
@@ -4658,6 +4655,7 @@ export default function RealDataSankeyPage() {
                           else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
                         };
                         stopOffsetRepeat();
+                        setSelectionSuppressed(true);
                         step();
                         offsetRepeatRef.current = setTimeout(() => {
                           offsetRepeatRef.current = setInterval(step, 150);

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -11,6 +11,9 @@ import {
   getColumn, getNodeColor, getLinkColor, ribbonPath, formatYen, sortPriority,
 } from '@/app/lib/sankey-svg-constants';
 import { MinimapOverlay } from '@/client/components/SankeySvg/MinimapOverlay';
+import { TopNSliders } from '@/client/components/SankeySvg/TopNSliders';
+import { FontSizeControls } from '@/client/components/SankeySvg/FontSizeControls';
+import { useRepeatPress } from '@/client/components/SankeySvg/useRepeatPress';
 import { filterTopN, computeLayout, getTopMinistriesInScope } from '@/app/lib/sankey-svg-filter';
 import { canonicalSelectableNodeId } from '@/app/lib/sankey-svg-ids';
 import { resolveYearSelectionSnapshot, type YearSelectionSnapshot } from '@/app/lib/sankey-svg-year-selection';
@@ -234,7 +237,6 @@ export default function RealDataSankeyPage() {
   const [showSettings, setShowSettings] = useState(false);
   const [showFontControls, setShowFontControls] = useState(false);
   const [baseFontPx, setBaseFontPx] = useState(BASE_FONT_PX_DEFAULT);
-  const [baseFontPxInput, setBaseFontPxInput] = useState(String(BASE_FONT_PX_DEFAULT));
   const [showLabels, setShowLabels] = useState(true);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
   const [showAggProject, setShowAggProject] = useState(true);
@@ -248,14 +250,7 @@ export default function RealDataSankeyPage() {
   const [isEditingZoom, setIsEditingZoom] = useState(false);
   const [zoomInputValue, setZoomInputValue] = useState('');
   const [isEditingOffset, setIsEditingOffset] = useState(false);
-  const [isEditingBaseFont, setIsEditingBaseFont] = useState(false);
   const [offsetInputValue, setOffsetInputValue] = useState('');
-  const [localTopProject, setLocalTopProject] = useState<number | null>(null);
-  const [localTopRecipient, setLocalTopRecipient] = useState<number | null>(null);
-  const [isEditingTopProject, setIsEditingTopProject] = useState(false);
-  const [isEditingTopRecipient, setIsEditingTopRecipient] = useState(false);
-  const [topProjectInputValue, setTopProjectInputValue] = useState('');
-  const [topRecipientInputValue, setTopRecipientInputValue] = useState('');
   const [showTopNSliders, setShowTopNSliders] = useState(true);
   const [scrollMode, setScrollMode] = useState<'zoom' | 'pan'>('zoom');
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -347,7 +342,6 @@ export default function RealDataSankeyPage() {
         if (!isNaN(parsed)) {
           const clamped = Math.min(BASE_FONT_PX_MAX, Math.max(BASE_FONT_PX_MIN, parsed));
           setBaseFontPx(clamped);
-          setBaseFontPxInput(String(clamped));
         }
       }
     } catch {
@@ -586,9 +580,6 @@ export default function RealDataSankeyPage() {
   const [hoveredLinkStable, setHoveredLinkStable] = useState<LayoutLink | null>(null);
   const hoverEnterTimerRef = useRef<number | null>(null);
   useEffect(() => {
-    setBaseFontPxInput(String(baseFontPx));
-  }, [baseFontPx]);
-  useEffect(() => {
     if (hoverEnterTimerRef.current) {
       window.clearTimeout(hoverEnterTimerRef.current);
       hoverEnterTimerRef.current = null;
@@ -681,54 +672,11 @@ export default function RealDataSankeyPage() {
   const hoveredNode = suppressHoverPopup ? null : hoveredNodeStable;
   const panOrigin = useRef({ x: 0, y: 0 });
   const didPanRef = useRef(false);
-  // リピートボタン長押し中の意図しないテキスト選択/コールアウト（特にモバイル）を抑止する。
-  const setSelectionSuppressed = useCallback((on: boolean) => {
-    if (typeof document === 'undefined') return;
-    const b = document.body;
-    if (on) {
-      b.style.userSelect = 'none';
-      b.style.setProperty('-webkit-user-select', 'none');
-      b.style.setProperty('-webkit-touch-callout', 'none');
-    } else {
-      b.style.userSelect = '';
-      b.style.removeProperty('-webkit-user-select');
-      b.style.removeProperty('-webkit-touch-callout');
-      const sel = typeof window !== 'undefined' ? window.getSelection?.() : null;
-      sel?.removeAllRanges();
-    }
-  }, []);
-  const offsetRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const stopOffsetRepeat = useCallback(() => {
-    if (offsetRepeatRef.current !== null) { clearTimeout(offsetRepeatRef.current); clearInterval(offsetRepeatRef.current); offsetRepeatRef.current = null; }
-    setSelectionSuppressed(false);
-  }, [setSelectionSuppressed]);
-  useEffect(() => {
-    const onBlur = () => stopOffsetRepeat();
-    window.addEventListener('blur', onBlur);
-    return () => { stopOffsetRepeat(); window.removeEventListener('blur', onBlur); };
-  }, [stopOffsetRepeat]);
-
-  const topNRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const stopTopNRepeat = useCallback(() => {
-    if (topNRepeatRef.current !== null) { clearTimeout(topNRepeatRef.current); clearInterval(topNRepeatRef.current); topNRepeatRef.current = null; }
-    setSelectionSuppressed(false);
-  }, [setSelectionSuppressed]);
-  useEffect(() => {
-    const onBlur = () => stopTopNRepeat();
-    window.addEventListener('blur', onBlur);
-    return () => { stopTopNRepeat(); window.removeEventListener('blur', onBlur); };
-  }, [stopTopNRepeat]);
-
-  const fontRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const stopFontRepeat = useCallback(() => {
-    if (fontRepeatRef.current !== null) { clearTimeout(fontRepeatRef.current); clearInterval(fontRepeatRef.current); fontRepeatRef.current = null; }
-    setSelectionSuppressed(false);
-  }, [setSelectionSuppressed]);
-  useEffect(() => {
-    const onBlur = () => stopFontRepeat();
-    window.addEventListener('blur', onBlur);
-    return () => { stopFontRepeat(); window.removeEventListener('blur', onBlur); };
-  }, [stopFontRepeat]);
+  // 押し続けで増減するリピートボタン用ハンドラ（オフセットコントロール）。
+  // TopN・フォントサイズのリピートは各コントロールコンポーネント側で同フックを使う。
+  const offsetRepeat = useRepeatPress();
+  // URL履歴を replace で更新するためのマーク（子コンポーネントにも渡す）
+  const markHistoryReplace = useCallback(() => { pendingHistoryAction.current = 'replace'; }, []);
 
   // Reset both offsets when offsetTarget switches
   // Reset offsets and sync URL when filter conditions change
@@ -837,19 +785,6 @@ export default function RealDataSankeyPage() {
   const fitTopPadPx = FIT_TOP_PAD_PX;
   const fitTopPadPxRef = useRef(fitTopPadPx);
   fitTopPadPxRef.current = fitTopPadPx;
-  const commitBaseFontPxInput = useCallback(() => {
-    const v = Number(baseFontPxInput);
-    if (!Number.isFinite(v)) {
-      setBaseFontPxInput(String(baseFontPx));
-      return;
-    }
-    const next = Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, v));
-    setBaseFontPxInput(String(next));
-    if (next !== baseFontPx) {
-      pendingHistoryAction.current = 'replace';
-      setBaseFontPx(next);
-    }
-  }, [baseFontPx, baseFontPxInput]);
 
   // Compute max extra height from label shifts at a given zoom level (2-pass helper).
   // During fit, pass baseZoomK=zoomK to keep the whole-view baseline unchanged.
@@ -2586,202 +2521,29 @@ export default function RealDataSankeyPage() {
 
   // 事業・支出先 TopN スライダー（デスクトップはオフセットパネル内、スマホ幅では設定ダイアログ内に表示）
   const topNSlidersFragment = (
-    <>
-      <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap', width: '3.5em', flexShrink: 0 }}>事業</span>
-        <input
-          type="range" min={1} max={300} step={1}
-          value={localTopProject ?? topProject}
-          onChange={e => { setLocalTopProject(Number(e.target.value)); }}
-          onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-          onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-          onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-          onBlur={e => { if (localTopProject === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-          style={{ flex: 1, minWidth: 0, width: 0 }}
-        />
-        {isEditingTopProject ? (
-          <input type="number" autoFocus min={1} max={300} step={1}
-            value={topProjectInputValue}
-            onChange={e => setTopProjectInputValue(e.target.value)}
-            onBlur={() => { const v = Number(topProjectInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); } setIsEditingTopProject(false); }}
-            onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
-            style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
-          />
-        ) : (
-          <button onClick={() => { setTopProjectInputValue(String(topProject)); setIsEditingTopProject(true); }} title="クリックして直接入力"
-            style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
-          >{localTopProject ?? topProject}</button>
-        )}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-          {([
-            [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
-            [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
-          ] as [number, string, string][]).map(([delta, path, title]) => (
-            <button key={delta} title={title} aria-label={title}
-              onPointerDown={(e) => {
-                if (e.pointerType === 'mouse' && e.button !== 0) return;
-                e.currentTarget.setPointerCapture(e.pointerId);
-                const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
-                stopTopNRepeat(); setSelectionSuppressed(true); step();
-                topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
-              }}
-              onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
-              onContextMenu={(e) => e.preventDefault()}
-              onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-            </button>
-          ))}
-        </div>
-      </label>
-      <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap', width: '3.5em', flexShrink: 0 }}>支出先</span>
-        <input
-          type="range" min={1} max={300} step={1}
-          value={localTopRecipient ?? topRecipient}
-          onChange={e => { setLocalTopRecipient(Number(e.target.value)); }}
-          onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-          onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-          onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-          onBlur={e => { if (localTopRecipient === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-          style={{ flex: 1, minWidth: 0, width: 0 }}
-        />
-        {isEditingTopRecipient ? (
-          <input type="number" autoFocus min={1} max={300} step={1}
-            value={topRecipientInputValue}
-            onChange={e => setTopRecipientInputValue(e.target.value)}
-            onBlur={() => { const v = Number(topRecipientInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); } setIsEditingTopRecipient(false); }}
-            onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
-            style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
-          />
-        ) : (
-          <button onClick={() => { setTopRecipientInputValue(String(topRecipient)); setIsEditingTopRecipient(true); }} title="クリックして直接入力"
-            style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
-          >{localTopRecipient ?? topRecipient}</button>
-        )}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-          {([
-            [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
-            [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
-          ] as [number, string, string][]).map(([delta, path, title]) => (
-            <button key={delta} title={title} aria-label={title}
-              onPointerDown={(e) => {
-                if (e.pointerType === 'mouse' && e.button !== 0) return;
-                e.currentTarget.setPointerCapture(e.pointerId);
-                const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
-                stopTopNRepeat(); setSelectionSuppressed(true); step();
-                topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
-              }}
-              onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
-              onContextMenu={(e) => e.preventDefault()}
-              onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-            </button>
-          ))}
-        </div>
-      </label>
-    </>
+    <TopNSliders
+      topProject={topProject}
+      topRecipient={topRecipient}
+      setTopProject={setTopProject}
+      setTopRecipient={setTopRecipient}
+      markReplace={markHistoryReplace}
+      metaFontPx={META_FONT_PX}
+    />
   );
 
   // 基準フォントサイズ調整（デスクトップは左下フローティング、スマホ幅では設定ダイアログ内に表示）
   const fontSizeControlsFragment = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: isCompactWidth ? 4 : 8 }}>
-      {/* スマホ幅では設定ダイアログ内でTopNスライダーと左端・幅を揃えるためのスペーサ */}
-      {isCompactWidth && <span aria-hidden style={{ width: '3.5em', flexShrink: 0 }} />}
-      <input
-        type="range"
-        min={BASE_FONT_PX_MIN}
-        max={BASE_FONT_PX_MAX}
-        step={1}
-        value={baseFontPx}
-        onChange={e => { pendingHistoryAction.current = 'replace'; setBaseFontPx(Number(e.target.value)); }}
-        style={ isCompactWidth ? { flex: 1, minWidth: 0, boxSizing: 'border-box', margin: 0 } : { width: 60, boxSizing: 'border-box', margin: 0 } }
-        data-pan-disabled
-        aria-label="基準フォントサイズ"
-      />
-      {isEditingBaseFont ? (
-        <input
-          type="number"
-          autoFocus
-          min={BASE_FONT_PX_MIN}
-          max={BASE_FONT_PX_MAX}
-          step={1}
-          value={baseFontPxInput}
-          onChange={e => setBaseFontPxInput(e.target.value)}
-          onBlur={() => { commitBaseFontPxInput(); setIsEditingBaseFont(false); }}
-          onKeyDown={e => {
-            if (e.key === 'Enter') { commitBaseFontPxInput(); setIsEditingBaseFont(false); }
-            else if (e.key === 'Escape') { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(false); }
-          }}
-          style={{ width: `${Math.max(40, String(BASE_FONT_PX_MAX).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: CONTROL_SMALL_FONT_PX }}
-          data-pan-disabled
-          aria-label="基準フォントサイズ(数値)"
-        />
-      ) : (
-        <button
-          type="button"
-          onClick={() => { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(true); }}
-          title="クリックしてフォントサイズを入力"
-          style={{ color: '#999', fontSize: META_FONT_PX_DEFAULT, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
-          data-pan-disabled
-          aria-label="基準フォントサイズ編集を開始"
-        >{baseFontPx}</button>
-      )}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-        {([
-          [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '大きく'],
-          [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '小さく'],
-        ] as [number, string, string][]).map(([delta, path, title]) => (
-          <button key={delta} type="button" title={title} aria-label={title}
-            onPointerDown={(e) => {
-              if (e.pointerType === 'mouse' && e.button !== 0) return;
-              e.stopPropagation();
-              e.currentTarget.setPointerCapture(e.pointerId);
-              const step = () => {
-                pendingHistoryAction.current = 'replace';
-                setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
-              };
-              stopFontRepeat();
-              setSelectionSuppressed(true);
-              step();
-              fontRepeatRef.current = setTimeout(() => {
-                fontRepeatRef.current = setInterval(step, 150);
-              }, 400);
-            }}
-            onPointerUp={(e) => { e.stopPropagation(); stopFontRepeat(); }}
-            onPointerLeave={stopFontRepeat}
-            onPointerCancel={stopFontRepeat}
-            onContextMenu={(e) => e.preventDefault()}
-            onClick={(e) => {
-              if (e.detail === 0) {
-                pendingHistoryAction.current = 'replace';
-                setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
-              }
-            }}
-            style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
-            data-pan-disabled
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-          </button>
-        ))}
-      </div>
-      <button
-        type="button"
-        onClick={() => { pendingHistoryAction.current = 'replace'; setBaseFontPx(BASE_FONT_PX_DEFAULT); }}
-        title="既定値に戻す"
-        aria-label="既定値に戻す"
-        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', color: '#555' }}
-        data-pan-disabled
-      >
-        {/* Material Icons: reset_settings */}
-        <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="currentColor">
-          <path d="M520-330v-60h160v60H520Zm60 210v-50h-60v-60h60v-50h60v160h-60Zm100-50v-60h160v60H680Zm40-110v-160h60v50h60v60h-60v50h-60Zm111-280h-83q-26-88-99-144t-169-56q-117 0-198.5 81.5T200-480q0 72 32.5 132t87.5 98v-110h80v240H160v-80h94q-62-50-98-122.5T120-480q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q129 0 226.5 79.5T831-560Z" />
-        </svg>
-      </button>
-    </div>
+    <FontSizeControls
+      baseFontPx={baseFontPx}
+      setBaseFontPx={setBaseFontPx}
+      markReplace={markHistoryReplace}
+      isCompactWidth={isCompactWidth}
+      min={BASE_FONT_PX_MIN}
+      max={BASE_FONT_PX_MAX}
+      defaultValue={BASE_FONT_PX_DEFAULT}
+      controlSmallFontPx={CONTROL_SMALL_FONT_PX}
+      numberFontPx={META_FONT_PX_DEFAULT}
+    />
   );
 
   return (
@@ -4644,27 +4406,12 @@ export default function RealDataSankeyPage() {
                   ] as [number, string, string][]).map(([delta, path, title]) => (
                     <button key={delta} title={title} aria-label={title}
                       data-testid={testId(delta > 0 ? 'recipient-offset-next' : 'recipient-offset-prev')}
-                      onPointerDown={(e) => {
-                        if (e.pointerType === 'mouse' && e.button !== 0) return;
-                        e.stopPropagation();
-                        e.currentTarget.setPointerCapture(e.pointerId);
-                        const step = () => {
-                          pendingHistoryAction.current = 'replace';
-                          pendingFocusId.current = null;
-                          if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
-                          else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
-                        };
-                        stopOffsetRepeat();
-                        setSelectionSuppressed(true);
-                        step();
-                        offsetRepeatRef.current = setTimeout(() => {
-                          offsetRepeatRef.current = setInterval(step, 150);
-                        }, 400);
-                      }}
-                      onPointerUp={(e) => { e.stopPropagation(); stopOffsetRepeat(); }}
-                      onPointerLeave={stopOffsetRepeat}
-                      onPointerCancel={stopOffsetRepeat}
-                      onContextMenu={(e) => e.preventDefault()}
+                      {...offsetRepeat(() => {
+                        pendingHistoryAction.current = 'replace';
+                        pendingFocusId.current = null;
+                        if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
+                        else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
+                      }, { stopPropagation: true })}
                       onClick={(e) => {
                         if (e.detail === 0) {
                           setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -681,10 +681,27 @@ export default function RealDataSankeyPage() {
   const hoveredNode = suppressHoverPopup ? null : hoveredNodeStable;
   const panOrigin = useRef({ x: 0, y: 0 });
   const didPanRef = useRef(false);
+  // リピートボタン長押し中の意図しないテキスト選択/コールアウト（特にモバイル）を抑止する。
+  const setSelectionSuppressed = useCallback((on: boolean) => {
+    if (typeof document === 'undefined') return;
+    const b = document.body;
+    if (on) {
+      b.style.userSelect = 'none';
+      b.style.setProperty('-webkit-user-select', 'none');
+      b.style.setProperty('-webkit-touch-callout', 'none');
+    } else {
+      b.style.userSelect = '';
+      b.style.removeProperty('-webkit-user-select');
+      b.style.removeProperty('-webkit-touch-callout');
+      const sel = typeof window !== 'undefined' ? window.getSelection?.() : null;
+      sel?.removeAllRanges();
+    }
+  }, []);
   const offsetRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stopOffsetRepeat = useCallback(() => {
     if (offsetRepeatRef.current !== null) { clearTimeout(offsetRepeatRef.current); clearInterval(offsetRepeatRef.current); offsetRepeatRef.current = null; }
-  }, []);
+    setSelectionSuppressed(false);
+  }, [setSelectionSuppressed]);
   useEffect(() => {
     const onBlur = () => stopOffsetRepeat();
     window.addEventListener('blur', onBlur);
@@ -694,7 +711,8 @@ export default function RealDataSankeyPage() {
   const topNRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stopTopNRepeat = useCallback(() => {
     if (topNRepeatRef.current !== null) { clearTimeout(topNRepeatRef.current); clearInterval(topNRepeatRef.current); topNRepeatRef.current = null; }
-  }, []);
+    setSelectionSuppressed(false);
+  }, [setSelectionSuppressed]);
   useEffect(() => {
     const onBlur = () => stopTopNRepeat();
     window.addEventListener('blur', onBlur);
@@ -704,7 +722,8 @@ export default function RealDataSankeyPage() {
   const fontRepeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stopFontRepeat = useCallback(() => {
     if (fontRepeatRef.current !== null) { clearTimeout(fontRepeatRef.current); clearInterval(fontRepeatRef.current); fontRepeatRef.current = null; }
-  }, []);
+    setSelectionSuppressed(false);
+  }, [setSelectionSuppressed]);
   useEffect(() => {
     const onBlur = () => stopFontRepeat();
     window.addEventListener('blur', onBlur);
@@ -2602,6 +2621,7 @@ export default function RealDataSankeyPage() {
               onPointerDown={(e) => {
                 if (e.pointerType === 'mouse' && e.button !== 0) return;
                 e.currentTarget.setPointerCapture(e.pointerId);
+                setSelectionSuppressed(true);
                 const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
                 stopTopNRepeat(); step();
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
@@ -2649,6 +2669,7 @@ export default function RealDataSankeyPage() {
               onPointerDown={(e) => {
                 if (e.pointerType === 'mouse' && e.button !== 0) return;
                 e.currentTarget.setPointerCapture(e.pointerId);
+                setSelectionSuppressed(true);
                 const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
                 stopTopNRepeat(); step();
                 topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
@@ -2719,6 +2740,7 @@ export default function RealDataSankeyPage() {
               if (e.pointerType === 'mouse' && e.button !== 0) return;
               e.stopPropagation();
               e.currentTarget.setPointerCapture(e.pointerId);
+              setSelectionSuppressed(true);
               const step = () => {
                 pendingHistoryAction.current = 'replace';
                 setBaseFontPx(prev => Math.max(BASE_FONT_PX_MIN, Math.min(BASE_FONT_PX_MAX, prev + delta)));
@@ -4625,6 +4647,7 @@ export default function RealDataSankeyPage() {
                         if (e.pointerType === 'mouse' && e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        setSelectionSuppressed(true);
                         const step = () => {
                           pendingHistoryAction.current = 'replace';
                           pendingFocusId.current = null;

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4603,10 +4603,10 @@ export default function RealDataSankeyPage() {
                 <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
                 {/* 総件数表示は幅を取るためスマホ幅では非表示 */}
                 {!isCompactWidth && <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+                <div style={{ display: 'flex', flexDirection: 'row', gap: 2, alignItems: 'center' }}>
                   {([
-                    [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '次へ'],
-                    [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '前へ'],
+                    [-1, 'M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6z', '前へ'],
+                    [1,  'M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z', '次へ'],
                   ] as [number, string, string][]).map(([delta, path, title]) => (
                     <button key={delta} title={title} aria-label={title}
                       data-testid={testId(delta > 0 ? 'recipient-offset-next' : 'recipient-offset-prev')}
@@ -4634,9 +4634,9 @@ export default function RealDataSankeyPage() {
                           setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));
                         }
                       }}
-                      style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+                      <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
                     </button>
                   ))}
                 </div>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2553,6 +2553,106 @@ export default function RealDataSankeyPage() {
   const minimapLeft = selectedNodeId !== null ? (isPanelCollapsed ? 26 : sidePanelWidth + 8) : 8;
   const fontControlLeft = minimapLeft + (showMinimap ? MINIMAP_W + 22 : 48);
 
+  // 事業・支出先 TopN スライダー（デスクトップはオフセットパネル内、スマホ幅では設定ダイアログ内に表示）
+  const topNSlidersFragment = (
+    <>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>事業</span>
+        <input
+          type="range" min={1} max={300} step={1}
+          value={localTopProject ?? topProject}
+          onChange={e => { setLocalTopProject(Number(e.target.value)); }}
+          onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
+          onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
+          onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
+          onBlur={e => { if (localTopProject === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
+          style={{ flex: 1, minWidth: 0, width: 0 }}
+        />
+        {isEditingTopProject ? (
+          <input type="number" autoFocus min={1} max={300} step={1}
+            value={topProjectInputValue}
+            onChange={e => setTopProjectInputValue(e.target.value)}
+            onBlur={() => { const v = Number(topProjectInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); } setIsEditingTopProject(false); }}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
+            style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
+          />
+        ) : (
+          <button onClick={() => { setTopProjectInputValue(String(topProject)); setIsEditingTopProject(true); }} title="クリックして直接入力"
+            style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
+          >{localTopProject ?? topProject}</button>
+        )}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+          {([
+            [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
+            [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
+          ] as [number, string, string][]).map(([delta, path, title]) => (
+            <button key={delta} title={title} aria-label={title}
+              onPointerDown={(e) => {
+                if (e.pointerType === 'mouse' && e.button !== 0) return;
+                e.currentTarget.setPointerCapture(e.pointerId);
+                const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
+                stopTopNRepeat(); step();
+                topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
+              }}
+              onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
+              onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); } }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+            </button>
+          ))}
+        </div>
+      </label>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>支出先</span>
+        <input
+          type="range" min={1} max={300} step={1}
+          value={localTopRecipient ?? topRecipient}
+          onChange={e => { setLocalTopRecipient(Number(e.target.value)); }}
+          onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
+          onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
+          onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
+          onBlur={e => { if (localTopRecipient === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
+          style={{ flex: 1, minWidth: 0, width: 0 }}
+        />
+        {isEditingTopRecipient ? (
+          <input type="number" autoFocus min={1} max={300} step={1}
+            value={topRecipientInputValue}
+            onChange={e => setTopRecipientInputValue(e.target.value)}
+            onBlur={() => { const v = Number(topRecipientInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); } setIsEditingTopRecipient(false); }}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
+            style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
+          />
+        ) : (
+          <button onClick={() => { setTopRecipientInputValue(String(topRecipient)); setIsEditingTopRecipient(true); }} title="クリックして直接入力"
+            style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
+          >{localTopRecipient ?? topRecipient}</button>
+        )}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+          {([
+            [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
+            [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
+          ] as [number, string, string][]).map(([delta, path, title]) => (
+            <button key={delta} title={title} aria-label={title}
+              onPointerDown={(e) => {
+                if (e.pointerType === 'mouse' && e.button !== 0) return;
+                e.currentTarget.setPointerCapture(e.pointerId);
+                const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
+                stopTopNRepeat(); step();
+                topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
+              }}
+              onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
+              onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); } }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+            </button>
+          ))}
+        </div>
+      </label>
+    </>
+  );
+
   return (
     <div
       ref={containerRef}
@@ -4451,8 +4551,10 @@ export default function RealDataSankeyPage() {
           if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
         };
         return (
-          <div style={{ position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
+          <div style={ isCompactWidth
+            ? { position: 'absolute', bottom: 12, left: 56, right: 64, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }
+            : { position: 'absolute', top: 12, right: 52, zIndex: 15, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
             {/* Row 1: オフセットスライダー（2列スパン） */}
             <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 8, alignItems: 'center' }}>
               {/* オフセット対象コンボボックス */}
@@ -4533,105 +4635,11 @@ export default function RealDataSankeyPage() {
                 </button>
               </label>
             </div>
-            {/* Row 2: 事業・支出先 TopN スライダー（各グリッドセル） */}
-            {showTopNSliders && <>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-                <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>事業</span>
-                <input
-                  type="range" min={1} max={300} step={1}
-                  value={localTopProject ?? topProject}
-                  onChange={e => { setLocalTopProject(Number(e.target.value)); }}
-                  onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-                  onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-                  onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-                  onBlur={e => { if (localTopProject === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); setLocalTopProject(null); }}
-                  style={{ flex: 1, minWidth: 0, width: 0 }}
-                />
-                {isEditingTopProject ? (
-                  <input type="number" autoFocus min={1} max={300} step={1}
-                    value={topProjectInputValue}
-                    onChange={e => setTopProjectInputValue(e.target.value)}
-                    onBlur={() => { const v = Number(topProjectInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopProject(Math.max(1, Math.min(300, v))); } setIsEditingTopProject(false); }}
-                    onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
-                    style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
-                  />
-                ) : (
-                  <button onClick={() => { setTopProjectInputValue(String(topProject)); setIsEditingTopProject(true); }} title="クリックして直接入力"
-                    style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
-                  >{localTopProject ?? topProject}</button>
-                )}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-                  {([
-                    [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
-                    [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
-                  ] as [number, string, string][]).map(([delta, path, title]) => (
-                    <button key={delta} title={title} aria-label={title}
-                      onPointerDown={(e) => {
-                        if (e.pointerType === 'mouse' && e.button !== 0) return;
-                        e.currentTarget.setPointerCapture(e.pointerId);
-                        const step = () => { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); };
-                        stopTopNRepeat(); step();
-                        topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
-                      }}
-                      onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
-                      onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopProject(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-                      style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-                    </button>
-                  ))}
-                </div>
-              </label>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-                <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>支出先</span>
-                <input
-                  type="range" min={1} max={300} step={1}
-                  value={localTopRecipient ?? topRecipient}
-                  onChange={e => { setLocalTopRecipient(Number(e.target.value)); }}
-                  onPointerUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-                  onTouchEnd={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-                  onKeyUp={e => { const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-                  onBlur={e => { if (localTopRecipient === null) return; const v = Number((e.target as HTMLInputElement).value); pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); setLocalTopRecipient(null); }}
-                  style={{ flex: 1, minWidth: 0, width: 0 }}
-                />
-                {isEditingTopRecipient ? (
-                  <input type="number" autoFocus min={1} max={300} step={1}
-                    value={topRecipientInputValue}
-                    onChange={e => setTopRecipientInputValue(e.target.value)}
-                    onBlur={() => { const v = Number(topRecipientInputValue); if (!isNaN(v) && v >= 1) { pendingHistoryAction.current = 'replace'; setTopRecipient(Math.max(1, Math.min(300, v))); } setIsEditingTopRecipient(false); }}
-                    onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
-                    style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: META_FONT_PX }}
-                  />
-                ) : (
-                  <button onClick={() => { setTopRecipientInputValue(String(topRecipient)); setIsEditingTopRecipient(true); }} title="クリックして直接入力"
-                    style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
-                  >{localTopRecipient ?? topRecipient}</button>
-                )}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
-                  {([
-                    [1,  'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
-                    [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
-                  ] as [number, string, string][]).map(([delta, path, title]) => (
-                    <button key={delta} title={title} aria-label={title}
-                      onPointerDown={(e) => {
-                        if (e.pointerType === 'mouse' && e.button !== 0) return;
-                        e.currentTarget.setPointerCapture(e.pointerId);
-                        const step = () => { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); };
-                        stopTopNRepeat(); step();
-                        topNRepeatRef.current = setTimeout(() => { topNRepeatRef.current = setInterval(step, 150); }, 400);
-                      }}
-                      onPointerUp={stopTopNRepeat} onPointerLeave={stopTopNRepeat} onPointerCancel={stopTopNRepeat}
-                      onClick={(e) => { if (e.detail === 0) { pendingHistoryAction.current = 'replace'; setTopRecipient(prev => Math.max(1, Math.min(300, prev + delta))); } }}
-                      style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-                    </button>
-                  ))}
-                </div>
-              </label>
-            </>}
+            {/* Row 2: 事業・支出先 TopN スライダー（スマホ幅では設定ダイアログへ移動） */}
+            {!isCompactWidth && showTopNSliders && topNSlidersFragment}
           </div>
-          {/* トグルボタン（パネル外・下部） */}
+          {/* トグルボタン（パネル外・下部）— スマホ幅では設定ダイアログにTopNを移すため非表示 */}
+          {!isCompactWidth && (
           <button
             onClick={() => setShowTopNSliders(s => !s)}
             title={showTopNSliders ? 'TopN設定 を隠す' : 'TopN設定 を表示'}
@@ -4641,6 +4649,7 @@ export default function RealDataSankeyPage() {
               <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
             </svg>
           </button>
+          )}
           </div>
         );
       })()}
@@ -4664,6 +4673,13 @@ export default function RealDataSankeyPage() {
           <>
             <div style={{ position: 'fixed', inset: 0, zIndex: 18 }} onMouseDown={() => setShowSettings(false)} />
             <div id="sankey-topn-settings" role="dialog" aria-label="表示設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, minWidth: 240, maxWidth: 'calc(100vw - 24px)', display: 'flex', flexDirection: 'column', gap: 10, colorScheme: 'light', color: '#333' }}>
+              {/* スマホ幅: オフセットパネルから移動したTopNスライダー */}
+              {isCompactWidth && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingBottom: 8, borderBottom: '1px solid #eee' }}>
+                  <span style={{ color: '#555', fontWeight: 600 }}>表示件数（TopN）</span>
+                  {topNSlidersFragment}
+                </div>
+              )}
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                 <input type="checkbox" checked={showLabels} onChange={e => { pendingHistoryAction.current = 'replace'; setShowLabels(e.target.checked); }} style={{ width: 14, height: 14, cursor: 'pointer' }} />
                 <span style={{ color: '#555' }}>すべてのノードラベルを表示</span>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2556,6 +2556,14 @@ export default function RealDataSankeyPage() {
   const searchMaxWidth = `calc(100vw - ${searchLeftOffset}px - 64px)`;
   const minimapLeft = selectedNodeId !== null ? (isPanelCollapsed ? 26 : sidePanelWidth + 8) : 8;
   const fontControlLeft = minimapLeft + (showMinimap ? MINIMAP_W + 22 : 48);
+  // 年度変更（トップ中央セレクトとスマホ幅の設定ダイアログで共用）
+  const handleYearChange = (value: '2024' | '2025') => {
+    pendingHistoryAction.current = 'replace';
+    pendingYearSelectionRef.current = selectedNode
+      ? { type: selectedNode.type, name: selectedNode.name, projectId: selectedNode.projectId }
+      : null;
+    setYear(value);
+  };
 
   // 事業・支出先 TopN スライダー（デスクトップはオフセットパネル内、スマホ幅では設定ダイアログ内に表示）
   const topNSlidersFragment = (
@@ -4151,18 +4159,13 @@ export default function RealDataSankeyPage() {
         </div>
       )}
 
-      {/* Year selector — top center */}
+      {/* Year selector — top center（スマホ幅では検索ボックスに隠れるため設定ダイアログへ移動） */}
+      {!isCompactWidth && (
       <div data-pan-disabled="true" style={{ position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)', zIndex: 15 }}>
         <select
           data-testid={testId('year-select')}
           value={year}
-          onChange={e => {
-            pendingHistoryAction.current = 'replace';
-            pendingYearSelectionRef.current = selectedNode
-              ? { type: selectedNode.type, name: selectedNode.name, projectId: selectedNode.projectId }
-              : null;
-            setYear(e.target.value as '2024' | '2025');
-          }}
+          onChange={e => handleYearChange(e.target.value as '2024' | '2025')}
           style={{ fontSize: CONTROL_FONT_PX, border: '1px solid #e0e0e0', borderRadius: 8, padding: '6px 28px 6px 10px', background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', color: '#333', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none' }}
         >
           <option value="2025">2025年度</option>
@@ -4173,6 +4176,7 @@ export default function RealDataSankeyPage() {
           <path d="M7 10l5 5 5-5z"/>
         </svg>
       </div>
+      )}
 
       {/* Search box — top left */}
       <div
@@ -4690,6 +4694,22 @@ export default function RealDataSankeyPage() {
           <>
             <div style={{ position: 'fixed', inset: 0, zIndex: 18 }} onMouseDown={() => setShowSettings(false)} />
             <div id="sankey-topn-settings" role="dialog" aria-label="表示設定" tabIndex={-1} onKeyDown={(e) => { if (e.key === 'Escape') setShowSettings(false); }} style={{ position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 19, background: '#fff', border: '1px solid #ddd', borderRadius: 6, padding: '12px 16px', boxShadow: '0 4px 12px rgba(0,0,0,0.12)', fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, minWidth: 240, maxWidth: 'calc(100vw - 24px)', display: 'flex', flexDirection: 'column', gap: 10, colorScheme: 'light', color: '#333' }}>
+              {/* スマホ幅: 検索ボックスに隠れるため移動した年度選択 */}
+              {isCompactWidth && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingBottom: 8, borderBottom: '1px solid #eee' }}>
+                  <span style={{ color: '#555', fontWeight: 600 }}>年度</span>
+                  <select
+                    data-testid={testId('year-select-settings')}
+                    value={year}
+                    onChange={e => handleYearChange(e.target.value as '2024' | '2025')}
+                    style={{ fontSize: CONTROL_SMALL_FONT_PX_DEFAULT, padding: '2px 4px', borderRadius: 4, border: '1px solid #ccc', cursor: 'pointer' }}
+                    data-pan-disabled
+                  >
+                    <option value="2025">2025年度</option>
+                    <option value="2024">2024年度</option>
+                  </select>
+                </div>
+              )}
               {/* スマホ幅: オフセットパネルから移動したTopNスライダー */}
               {isCompactWidth && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingBottom: 8, borderBottom: '1px solid #eee' }}>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -2551,7 +2551,9 @@ export default function RealDataSankeyPage() {
   };
 
   const searchLeftOffset = selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth : 0;
-  const searchMaxWidth = `calc(100vw - ${searchLeftOffset}px - 24px)`;
+  // 右上の設定(⋮)ボタン領域(幅32+余白)に重ならないよう右側を確保。
+  // これがないと文字拡大時に検索ボックスが設定ボタンを覆い、タップで開けなくなる。
+  const searchMaxWidth = `calc(100vw - ${searchLeftOffset}px - 64px)`;
   const minimapLeft = selectedNodeId !== null ? (isPanelCollapsed ? 26 : sidePanelWidth + 8) : 8;
   const fontControlLeft = minimapLeft + (showMinimap ? MINIMAP_W + 22 : 48);
 
@@ -2559,7 +2561,7 @@ export default function RealDataSankeyPage() {
   const topNSlidersFragment = (
     <>
       <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>事業</span>
+        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap', width: '3.5em', flexShrink: 0 }}>事業</span>
         <input
           type="range" min={1} max={300} step={1}
           value={localTopProject ?? topProject}
@@ -2606,7 +2608,7 @@ export default function RealDataSankeyPage() {
         </div>
       </label>
       <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>支出先</span>
+        <span style={{ color: '#555', fontSize: META_FONT_PX, whiteSpace: 'nowrap', width: '3.5em', flexShrink: 0 }}>支出先</span>
         <input
           type="range" min={1} max={300} step={1}
           value={localTopRecipient ?? topRecipient}
@@ -2657,7 +2659,9 @@ export default function RealDataSankeyPage() {
 
   // 基準フォントサイズ調整（デスクトップは左下フローティング、スマホ幅では設定ダイアログ内に表示）
   const fontSizeControlsFragment = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: isCompactWidth ? 4 : 8 }}>
+      {/* スマホ幅では設定ダイアログ内でTopNスライダーと左端・幅を揃えるためのスペーサ */}
+      {isCompactWidth && <span aria-hidden style={{ width: '3.5em', flexShrink: 0 }} />}
       <input
         type="range"
         min={BASE_FONT_PX_MIN}
@@ -2665,7 +2669,7 @@ export default function RealDataSankeyPage() {
         step={1}
         value={baseFontPx}
         onChange={e => { pendingHistoryAction.current = 'replace'; setBaseFontPx(Number(e.target.value)); }}
-        style={{ width: 60, boxSizing: 'border-box', margin: 0 }}
+        style={ isCompactWidth ? { flex: 1, minWidth: 0, boxSizing: 'border-box', margin: 0 } : { width: 60, boxSizing: 'border-box', margin: 0 } }
         data-pan-disabled
         aria-label="基準フォントサイズ"
       />
@@ -2692,7 +2696,7 @@ export default function RealDataSankeyPage() {
           type="button"
           onClick={() => { setBaseFontPxInput(String(baseFontPx)); setIsEditingBaseFont(true); }}
           title="クリックしてフォントサイズを入力"
-          style={{ color: '#999', fontSize: META_FONT_PX_DEFAULT, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
+          style={{ color: '#999', fontSize: META_FONT_PX_DEFAULT, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
           data-pan-disabled
           aria-label="基準フォントサイズ編集を開始"
         >{baseFontPx}</button>
@@ -4636,7 +4640,7 @@ export default function RealDataSankeyPage() {
                       }}
                       style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+                      <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
                     </button>
                   ))}
                 </div>
@@ -4644,7 +4648,7 @@ export default function RealDataSankeyPage() {
                 <button onClick={e => { e.preventDefault(); setActiveOffset(0); }} title="先頭へリセット" aria-label="先頭へリセット"
                   style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none' }}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#555" style={{ transform: 'rotate(-90deg)' }}><path d="M8 11h3v10h2V11h3l-4-4-4 4zM4 3v2h16V3H4z"/></svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555" style={{ transform: 'rotate(-90deg)' }}><path d="M8 11h3v10h2V11h3l-4-4-4 4zM4 3v2h16V3H4z"/></svg>
                 </button>
               </label>
             </div>

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -3111,7 +3111,10 @@ export default function RealDataSankeyPage() {
                 const topNodeScreenY = topNode
                   ? pan.y + (MARGIN.top + topNode.y0 + (topNodeShift?.cumShift ?? 0) + (topNodeShift?.topShift ?? 0)) * zoom
                   : pan.y + MARGIN.top * zoom;
-                const top = Math.max(SEARCH_BOX_RESERVE, topNodeScreenY - labelBlockH - 8);
+                // ラベルの上限位置は検索ボックスの実測下端に合わせる。
+                // 静的なSEARCH_BOX_RESERVE(モバイル92/デスクトップ56)だと
+                // モバイルで一律に下げ過ぎるため、実際の検索ボックス高さに追従させる。
+                const top = Math.max(searchBoxBottom + 4, topNodeScreenY - labelBlockH - 8);
                 return (
                   <div
                     key={i}

--- a/client/components/SankeySvg/FontSizeControls.tsx
+++ b/client/components/SankeySvg/FontSizeControls.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useRepeatPress } from './useRepeatPress';
+
+// [delta, SVGパス, ラベル]
+const ARROW_PATHS: [number, string, string][] = [
+  [1, 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '大きく'],
+  [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '小さく'],
+];
+
+interface FontSizeControlsProps {
+  baseFontPx: number;
+  setBaseFontPx: Dispatch<SetStateAction<number>>;
+  markReplace: () => void;
+  isCompactWidth: boolean;
+  min: number;
+  max: number;
+  defaultValue: number;
+  /** 数値入力欄のフォントサイズ（基準フォントに連動した値） */
+  controlSmallFontPx: number;
+  /** 数値表示ボタンのフォントサイズ（基準フォントに連動させない固定値） */
+  numberFontPx: number;
+}
+
+/** 基準フォントサイズ調整（デスクトップは左下フローティング、スマホ幅では設定ダイアログ内に表示） */
+export function FontSizeControls({
+  baseFontPx, setBaseFontPx, markReplace, isCompactWidth, min, max, defaultValue, controlSmallFontPx, numberFontPx,
+}: FontSizeControlsProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(String(baseFontPx));
+  const repeat = useRepeatPress();
+  const clampFont = (v: number) => Math.max(min, Math.min(max, v));
+
+  // 外部から baseFontPx が変わったら入力欄表示を同期（localStorage 復元・履歴操作など）
+  useEffect(() => { setInputValue(String(baseFontPx)); }, [baseFontPx]);
+
+  const commitInput = () => {
+    const v = Number(inputValue);
+    if (!Number.isFinite(v)) { setInputValue(String(baseFontPx)); return; }
+    const next = clampFont(v);
+    setInputValue(String(next));
+    if (next !== baseFontPx) { markReplace(); setBaseFontPx(next); }
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: isCompactWidth ? 4 : 8 }}>
+      {/* スマホ幅では設定ダイアログ内でTopNスライダーと左端・幅を揃えるためのスペーサ */}
+      {isCompactWidth && <span aria-hidden style={{ width: '3.5em', flexShrink: 0 }} />}
+      <input
+        type="range" min={min} max={max} step={1}
+        value={baseFontPx}
+        onChange={e => { markReplace(); setBaseFontPx(Number(e.target.value)); }}
+        style={isCompactWidth ? { flex: 1, minWidth: 0, boxSizing: 'border-box', margin: 0 } : { width: 60, boxSizing: 'border-box', margin: 0 }}
+        data-pan-disabled
+        aria-label="基準フォントサイズ"
+      />
+      {isEditing ? (
+        <input
+          type="number" autoFocus min={min} max={max} step={1}
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
+          onBlur={() => { commitInput(); setIsEditing(false); }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') { commitInput(); setIsEditing(false); }
+            else if (e.key === 'Escape') { setInputValue(String(baseFontPx)); setIsEditing(false); }
+          }}
+          style={{ width: `${Math.max(40, String(max).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: controlSmallFontPx }}
+          data-pan-disabled
+          aria-label="基準フォントサイズ(数値)"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => { setInputValue(String(baseFontPx)); setIsEditing(true); }}
+          title="クリックしてフォントサイズを入力"
+          style={{ color: '#999', fontSize: numberFontPx, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
+          data-pan-disabled
+          aria-label="基準フォントサイズ編集を開始"
+        >{baseFontPx}</button>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+        {ARROW_PATHS.map(([delta, path, title]) => {
+          const step = () => { markReplace(); setBaseFontPx(prev => clampFont(prev + delta)); };
+          return (
+            <button key={delta} type="button" title={title} aria-label={title}
+              {...repeat(step, { stopPropagation: true })}
+              onClick={(e) => { if (e.detail === 0) step(); }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
+              data-pan-disabled
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path} /></svg>
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={() => { markReplace(); setBaseFontPx(defaultValue); }}
+        title="既定値に戻す"
+        aria-label="既定値に戻す"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', color: '#555' }}
+        data-pan-disabled
+      >
+        {/* Material Icons: reset_settings */}
+        <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="currentColor">
+          <path d="M520-330v-60h160v60H520Zm60 210v-50h-60v-60h60v-50h60v160h-60Zm100-50v-60h160v60H680Zm40-110v-160h60v50h60v60h-60v50h-60Zm111-280h-83q-26-88-99-144t-169-56q-117 0-198.5 81.5T200-480q0 72 32.5 132t87.5 98v-110h80v240H160v-80h94q-62-50-98-122.5T120-480q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q129 0 226.5 79.5T831-560Z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/client/components/SankeySvg/FontSizeControls.tsx
+++ b/client/components/SankeySvg/FontSizeControls.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import { useRepeatPress } from './useRepeatPress';
+import { useRepeatPress } from '@/client/components/SankeySvg/useRepeatPress';
 
 // [delta, SVGパス, ラベル]
 const ARROW_PATHS: [number, string, string][] = [

--- a/client/components/SankeySvg/TopNSliders.tsx
+++ b/client/components/SankeySvg/TopNSliders.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import { useRepeatPress } from './useRepeatPress';
+import { useRepeatPress } from '@/client/components/SankeySvg/useRepeatPress';
 
 const TOP_MIN = 1;
 const TOP_MAX = 300;
@@ -36,6 +36,8 @@ function TopNSliderRow({ label, value, setValue, markReplace, metaFontPx }: TopN
         value={local ?? value}
         onChange={e => { setLocal(Number(e.target.value)); }}
         onPointerUp={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
+        onPointerCancel={() => { setLocal(null); }}
+        onLostPointerCapture={() => { setLocal(null); }}
         onTouchEnd={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
         onKeyUp={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
         onBlur={e => { if (local === null) return; commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}

--- a/client/components/SankeySvg/TopNSliders.tsx
+++ b/client/components/SankeySvg/TopNSliders.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useRepeatPress } from './useRepeatPress';
+
+const TOP_MIN = 1;
+const TOP_MAX = 300;
+const clampTop = (v: number) => Math.max(TOP_MIN, Math.min(TOP_MAX, v));
+
+// [delta, SVGパス, ラベル]
+const ARROW_PATHS: [number, string, string][] = [
+  [1, 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z', '増やす'],
+  [-1, 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z', '減らす'],
+];
+
+interface TopNSliderRowProps {
+  label: string;
+  value: number;
+  setValue: Dispatch<SetStateAction<number>>;
+  markReplace: () => void;
+  metaFontPx: number;
+}
+
+function TopNSliderRow({ label, value, setValue, markReplace, metaFontPx }: TopNSliderRowProps) {
+  const [local, setLocal] = useState<number | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const repeat = useRepeatPress();
+  const commit = (v: number) => { markReplace(); setValue(clampTop(v)); };
+  return (
+    <label style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+      <span style={{ color: '#555', fontSize: metaFontPx, whiteSpace: 'nowrap', width: '3.5em', flexShrink: 0 }}>{label}</span>
+      <input
+        type="range" min={TOP_MIN} max={TOP_MAX} step={1}
+        value={local ?? value}
+        onChange={e => { setLocal(Number(e.target.value)); }}
+        onPointerUp={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
+        onTouchEnd={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
+        onKeyUp={e => { commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
+        onBlur={e => { if (local === null) return; commit(Number((e.target as HTMLInputElement).value)); setLocal(null); }}
+        style={{ flex: 1, minWidth: 0, width: 0 }}
+      />
+      {isEditing ? (
+        <input type="number" autoFocus min={TOP_MIN} max={TOP_MAX} step={1}
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
+          onBlur={() => { const v = Number(inputValue); if (!isNaN(v) && v >= 1) commit(v); setIsEditing(false); }}
+          onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') (e.target as HTMLInputElement).blur(); }}
+          style={{ width: 36, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: metaFontPx }}
+        />
+      ) : (
+        <button onClick={() => { setInputValue(String(value)); setIsEditing(true); }} title="クリックして直接入力"
+          style={{ color: '#999', fontSize: metaFontPx, background: 'transparent', border: 'none', cursor: 'text', padding: 0, minWidth: 20, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
+        >{local ?? value}</button>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 0, alignSelf: 'stretch' }}>
+        {ARROW_PATHS.map(([delta, path, title]) => {
+          const step = () => { markReplace(); setValue(prev => clampTop(prev + delta)); };
+          return (
+            <button key={delta} title={title} aria-label={title}
+              {...repeat(step)}
+              onClick={(e) => { if (e.detail === 0) step(); }}
+              style={{ flex: 1, width: 16, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24" fill="#555"><path d={path} /></svg>
+            </button>
+          );
+        })}
+      </div>
+    </label>
+  );
+}
+
+interface TopNSlidersProps {
+  topProject: number;
+  topRecipient: number;
+  setTopProject: Dispatch<SetStateAction<number>>;
+  setTopRecipient: Dispatch<SetStateAction<number>>;
+  markReplace: () => void;
+  metaFontPx: number;
+}
+
+/** 事業・支出先 TopN スライダー（デスクトップはオフセットパネル内、スマホ幅では設定ダイアログ内に表示） */
+export function TopNSliders({ topProject, topRecipient, setTopProject, setTopRecipient, markReplace, metaFontPx }: TopNSlidersProps) {
+  return (
+    <>
+      <TopNSliderRow label="事業" value={topProject} setValue={setTopProject} markReplace={markReplace} metaFontPx={metaFontPx} />
+      <TopNSliderRow label="支出先" value={topRecipient} setValue={setTopRecipient} markReplace={markReplace} metaFontPx={metaFontPx} />
+    </>
+  );
+}

--- a/client/components/SankeySvg/useRepeatPress.ts
+++ b/client/components/SankeySvg/useRepeatPress.ts
@@ -3,18 +3,35 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { PointerEvent as ReactPointerEvent, SyntheticEvent } from 'react';
 
+// 複数の useRepeatPress インスタンスが同時に押下される場合に備え、参照カウントで
+// 管理し、最初の抑止開始時に既存の body インラインスタイルを退避、最後の解除時に復元する。
+const selectionSuppressionState = {
+  depth: 0,
+  userSelect: '',
+  webkitUserSelect: '',
+  webkitTouchCallout: '',
+};
+
 /** 押下中だけ全体のテキスト選択/コールアウト（モバイルの長押し）を抑止する */
 function setSelectionSuppressed(on: boolean) {
   if (typeof document === 'undefined') return;
   const b = document.body;
   if (on) {
+    if (selectionSuppressionState.depth++ === 0) {
+      selectionSuppressionState.userSelect = b.style.userSelect;
+      selectionSuppressionState.webkitUserSelect = b.style.getPropertyValue('-webkit-user-select');
+      selectionSuppressionState.webkitTouchCallout = b.style.getPropertyValue('-webkit-touch-callout');
+    }
     b.style.userSelect = 'none';
     b.style.setProperty('-webkit-user-select', 'none');
     b.style.setProperty('-webkit-touch-callout', 'none');
   } else {
-    b.style.userSelect = '';
-    b.style.removeProperty('-webkit-user-select');
-    b.style.removeProperty('-webkit-touch-callout');
+    if (selectionSuppressionState.depth === 0 || --selectionSuppressionState.depth > 0) return;
+    b.style.userSelect = selectionSuppressionState.userSelect;
+    if (selectionSuppressionState.webkitUserSelect) b.style.setProperty('-webkit-user-select', selectionSuppressionState.webkitUserSelect);
+    else b.style.removeProperty('-webkit-user-select');
+    if (selectionSuppressionState.webkitTouchCallout) b.style.setProperty('-webkit-touch-callout', selectionSuppressionState.webkitTouchCallout);
+    else b.style.removeProperty('-webkit-touch-callout');
     (typeof window !== 'undefined' ? window.getSelection?.() : null)?.removeAllRanges();
   }
 }

--- a/client/components/SankeySvg/useRepeatPress.ts
+++ b/client/components/SankeySvg/useRepeatPress.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { PointerEvent as ReactPointerEvent, SyntheticEvent } from 'react';
+
+/** 押下中だけ全体のテキスト選択/コールアウト（モバイルの長押し）を抑止する */
+function setSelectionSuppressed(on: boolean) {
+  if (typeof document === 'undefined') return;
+  const b = document.body;
+  if (on) {
+    b.style.userSelect = 'none';
+    b.style.setProperty('-webkit-user-select', 'none');
+    b.style.setProperty('-webkit-touch-callout', 'none');
+  } else {
+    b.style.userSelect = '';
+    b.style.removeProperty('-webkit-user-select');
+    b.style.removeProperty('-webkit-touch-callout');
+    (typeof window !== 'undefined' ? window.getSelection?.() : null)?.removeAllRanges();
+  }
+}
+
+export interface RepeatPressHandlers {
+  onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+  onPointerUp: (e: ReactPointerEvent<HTMLElement>) => void;
+  onPointerLeave: () => void;
+  onPointerCancel: () => void;
+  onContextMenu: (e: SyntheticEvent) => void;
+}
+
+/**
+ * 押し続けで step() を繰り返し実行するボタン用のイベントハンドラを生成するフック。
+ * 返り値の関数に step を渡すと、その step を発火する一連のハンドラ（pointer/contextmenu）を返す。
+ * 最初の発火後 400ms で連続実行（150ms 間隔）へ移行し、押下中はネイティブの
+ * テキスト選択・コンテキストメニュー（モバイルの長押し）を抑止する。
+ */
+export function useRepeatPress(): (step: () => void, opts?: { stopPropagation?: boolean }) => RepeatPressHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stop = useCallback(() => {
+    if (timerRef.current !== null) { clearTimeout(timerRef.current); clearInterval(timerRef.current); timerRef.current = null; }
+    setSelectionSuppressed(false);
+  }, []);
+  useEffect(() => {
+    const onBlur = () => stop();
+    window.addEventListener('blur', onBlur);
+    return () => { stop(); window.removeEventListener('blur', onBlur); };
+  }, [stop]);
+  return useCallback((step: () => void, opts?: { stopPropagation?: boolean }): RepeatPressHandlers => ({
+    onPointerDown: (e) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      if (opts?.stopPropagation) e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      stop();
+      setSelectionSuppressed(true);
+      step();
+      timerRef.current = setTimeout(() => { timerRef.current = setInterval(step, 150); }, 400);
+    },
+    onPointerUp: (e) => { if (opts?.stopPropagation) e.stopPropagation(); stop(); },
+    onPointerLeave: () => stop(),
+    onPointerCancel: () => stop(),
+    onContextMenu: (e) => e.preventDefault(),
+  }), [stop]);
+}


### PR DESCRIPTION
## 目的（Why）

スマホでサイトを閲覧するユーザーが、オフセットコントロールが上部の他コントロール（検索ボックス・設定ボタン）に重なって操作できない状態を解消するため。

## 変更内容

スマホ幅（`isCompactWidth` = 幅767px以下）でのコントロール配置を見直し。

- **TopNスライダーを再利用フラグメント化**: `topNSlidersFragment` として抽出し、デスクトップ／スマホ双方で共用。
- **スマホ幅では TopN を設定ダイアログ（⋮メニュー）へ移動**: ダイアログ先頭に「表示件数（TopN）」セクションを追加。オフセットパネル内の TopN 行とトグルボタンはスマホ幅では非表示。
- **オフセットコントロールを画面下部へ移動**: スマホ幅では `bottom:12, left:56, right:64` に配置し、左下ミニマップトグル・右下ズーム系ボタンと干渉しない範囲に収めた。
- デスクトップ表示（768px以上）は従来どおり右上のオフセットパネル＋TopNトグル構成のまま。

## テスト方法

- `npm run dev` で `http://localhost:3000/sankey-svg` を開く
- DevTools のレスポンシブ表示で幅を 767px 以下にする
  - オフセットコントロールが画面下部に移動し、上部の検索・設定ボタンと重ならないこと
  - ⋮（設定）ダイアログを開くと「表示件数（TopN）」の事業／支出先スライダーが表示され、操作できること
- 幅 768px 以上では従来どおり右上にオフセット＋TopN が表示されること
- iOS 実機（Vercel プレビュー）でのタッチ操作確認

`npm run lint` / `npx tsc --noEmit` はエラーなし（既存warningのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added press-and-hold repeat controls for increment/decrement actions
  * Introduced Top N sliders and inline font-size controls (editable + reset)

* **Improvements**
  * Minimap now hides on compact widths and is width-aware
  * Search box, year selector and controls reorganized for compact screens (settings dialog)
  * Column label placement clamped to avoid overlap on small screens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->