### PR TITLE
fix(sankey-svg): フィルタ展開時のレイアウト改善と各種z-index調整

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1325,7 +1325,9 @@ export default function RealDataSankeyPage() {
     return filterTopN(nodes, edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, true, showAggRecipient, showAggProject, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, projectSortBy);
   }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, filterExcludedIds]);
 
-  // オフセットコントロールの実高を計測（スマホ縦のリスト下パディング用）
+  // オフセットコントロールの実高を計測（スマホ縦のリスト下パディング用）。
+  // 再購読はコントロールのマウント/アンマウント時のみで十分。サイズ変化は ResizeObserver が拾う。
+  const offsetControlMounted = filtered != null;
   useLayoutEffect(() => {
     const el = offsetControlRef.current;
     if (!el) { setOffsetControlHeight(0); return; }
@@ -1334,7 +1336,7 @@ export default function RealDataSankeyPage() {
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [filtered, isCompactWidth, selectedNodeId, offsetTarget, topRecipient, topProject]);
+  }, [offsetControlMounted]);
 
   const layout = useMemo(() => {
     if (!filtered) return null;
@@ -4136,7 +4138,8 @@ export default function RealDataSankeyPage() {
                               </label>
                             ))}
                           </div>,
-                          document.body
+                          // body直下ではなく検索ボックス(zIndex:20)内へportalし、サイドパネル(zIndex:25)の背面に収める
+                          searchBoxRef.current ?? document.body
                         )}
                       </div>
                       {!acAllSelected && (
@@ -4189,7 +4192,8 @@ export default function RealDataSankeyPage() {
                               </label>
                             ))}
                           </div>,
-                          document.body
+                          // body直下ではなく検索ボックス(zIndex:20)内へportalし、サイドパネル(zIndex:25)の背面に収める
+                          searchBoxRef.current ?? document.body
                         )}
                       </div>
                       {!allSelected && (

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -109,7 +109,7 @@ const HOVER_SUPPRESS_AFTER_INTERACTION_MS = 500;
 const HOVER_ENTER_DELAY_MS = 220;
 const TOUCH_PAN_SLOP_PX = 10;
 const FIT_TOP_PAD_PX = 32;
-const ZOOM_FONT_MAX_RATIO = 1.8;   // zoom-in でフォントを最大で元の何倍まで拡大するか
+const ZOOM_FONT_MAX_RATIO = 2.0;   // zoom-in でフォントを最大で元の何倍まで拡大するか
 const AGGREGATE_BOUNDARY_GAP_PX = 6;
 
 type ShiftLayoutNode = {
@@ -1125,6 +1125,11 @@ export default function RealDataSankeyPage() {
   // スマホ幅ではミニマップを表示しない（実機の縦横ともに画面が狭く有用性が低いため）
   const minimapVisible = showMinimap && !isCompactWidth;
   const searchBoxRef = useRef<HTMLDivElement>(null);
+  const filterPanelRef = useRef<HTMLDivElement>(null);
+  // スマホ縦のとき、サイドパネルのリスト下端がオフセットコントロールに隠れないよう
+  // コントロールの実高を計測してリストの下パディングを確保する。
+  const offsetControlRef = useRef<HTMLDivElement>(null);
+  const [offsetControlHeight, setOffsetControlHeight] = useState(0);
 
   // Layout constants for bottom-right widgets the dropdown must clear
   const MINIMAP_BOTTOM = 8;       // minimap wrapper bottom offset
@@ -1135,14 +1140,19 @@ export default function RealDataSankeyPage() {
   const DROPDOWN_GAP = 12;        // gap between search box bottom and dropdown top
 
   const [searchBoxBottom, setSearchBoxBottom] = useState(52); // 12 (top) + ~40 (approx height)
+  // 展開中のフィルタパネルの実高。列ヘッダーの基準位置を「フィルタ非展開時」に固定するため使う。
+  const [filterPanelHeight, setFilterPanelHeight] = useState(0);
   useLayoutEffect(() => {
     const measure = () => {
       const r = searchBoxRef.current?.getBoundingClientRect();
       if (r) setSearchBoxBottom(r.bottom);
+      const fr = filterPanelRef.current?.getBoundingClientRect();
+      setFilterPanelHeight(fr ? fr.height : 0);
     };
     measure();
     const ro = new ResizeObserver(measure);
     if (searchBoxRef.current) ro.observe(searchBoxRef.current);
+    if (filterPanelRef.current) ro.observe(filterPanelRef.current);
     return () => ro.disconnect();
   }, [showFilterPanel]);
 
@@ -1314,6 +1324,17 @@ export default function RealDataSankeyPage() {
     const clampedOffset = Math.min(recipientOffset, maxOffset);
     return filterTopN(nodes, edges, topMinistry, topProject, topRecipient, clampedOffset, pinnedProjectId, true, showAggRecipient, showAggProject, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, projectSortBy);
   }, [graphData, topMinistry, topProject, topRecipient, recipientOffset, pinnedProjectId, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, pinnedRecipientId, pinnedMinistryName, offsetTarget, projectOffset, filterExcludedIds]);
+
+  // オフセットコントロールの実高を計測（スマホ縦のリスト下パディング用）
+  useLayoutEffect(() => {
+    const el = offsetControlRef.current;
+    if (!el) { setOffsetControlHeight(0); return; }
+    const measure = () => setOffsetControlHeight(el.getBoundingClientRect().height);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [filtered, isCompactWidth, selectedNodeId, offsetTarget, topRecipient, topProject]);
 
   const layout = useMemo(() => {
     if (!filtered) return null;
@@ -2901,7 +2922,10 @@ export default function RealDataSankeyPage() {
                 // ラベルの上限位置は検索ボックスの実測下端に合わせる。
                 // 静的なSEARCH_BOX_RESERVE(モバイル92/デスクトップ56)だと
                 // モバイルで一律に下げ過ぎるため、実際の検索ボックス高さに追従させる。
-                const top = Math.max(searchBoxBottom + 4, topNodeScreenY - labelBlockH - 8);
+                // フィルタ展開時も列ヘッダーの位置を固定する。
+                // searchBoxBottom はフィルタパネル込みの実測値なので、その実高を差し引いて
+                // 「フィルタ非展開時の下端」を基準にする（フィルタパネルは zIndex で前面に重なる）。
+                const top = Math.max(searchBoxBottom - filterPanelHeight + 4, topNodeScreenY - labelBlockH - 8);
                 return (
                   <div
                     key={i}
@@ -3902,7 +3926,8 @@ export default function RealDataSankeyPage() {
                       </button>
                     </div>
                     {/* Tab content */}
-                    <div style={{ padding: '10px 14px', flex: 1, overflowY: 'auto' }}>
+                    {/* スマホ縦では下端のオフセットコントロールに最終行が隠れるため、その実高ぶん下に余白を確保 */}
+                    <div style={{ padding: '10px 14px', flex: 1, overflowY: 'auto', paddingBottom: isCompactWidth && !isLandscapeCompact ? offsetControlHeight + 24 : 10 }}>
                       {/* 省庁タブ */}
                       {panelTab === 'ministry' && (() => {
                         const items = panelSections.ministries;
@@ -3969,10 +3994,12 @@ export default function RealDataSankeyPage() {
       )}
 
       {/* Search box — top left */}
+      {/* zIndex は サイドパネル(25) より下。列ヘッダー(8)/年度(15)/設定ダイアログ(19) より上、
+          かつ展開したフィルタを含めてサイドパネルの背面に回す（パネル展開時は横へ退避するため実害は少ない）。 */}
       <div
         ref={searchBoxRef}
         data-pan-disabled="true"
-        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12, zIndex: 100, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
+        style={{ position: 'absolute', top: 12, left: selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 12 : 12, zIndex: 20, width: SEARCH_BOX_WIDTH_PX, maxWidth: searchMaxWidth, transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }}
       >
         {/* Row 1: 検索セクション（input+sliders+toggle）とフィルタボタン */}
         <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
@@ -4058,7 +4085,7 @@ export default function RealDataSankeyPage() {
 
             {/* フィルタ（card内部 — TopNのshowTopNSliders && <> に相当） */}
             {showFilterPanel && (
-              <div style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <div ref={filterPanelRef} style={{ padding: '4px 10px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
                 {/* 会計区分フィルタ（コンボボックス） */}
                 {(() => {
                   const acOptions = [
@@ -4360,7 +4387,7 @@ export default function RealDataSankeyPage() {
           if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
         };
         return (
-          <div style={ isCompactWidth
+          <div ref={offsetControlRef} style={ isCompactWidth
             ? { position: 'absolute', bottom: 12, left: isLandscapeCompact && selectedNodeId !== null && !isPanelCollapsed ? sidePanelWidth + 8 : 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)', transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }
             : { position: 'absolute', top: 12, right: 52, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>


### PR DESCRIPTION
## 目的（Why）

スマホ・PC利用者が `/sankey-svg` のフィルタやサイドパネルを操作した際に、要素の重なりで見づらくなる状態を解消するため。

## 変更内容

`/sankey-svg`（[app/sankey-svg/page.tsx](app/sankey-svg/page.tsx)）に対する4点のUI調整：

1. **ズームイン時フォント最大拡大率を 1.8 → 2.0 に引き上げ**（`ZOOM_FONT_MAX_RATIO`）

2. **フィルタ展開時も列ヘッダー位置を固定**
   - 従来は列ヘッダーが検索ボックスの実測下端を基準にしていたため、フィルタを開くとヘッダーが下に連動して動いていた
   - フィルタパネルの実高を計測し、`searchBoxBottom - filterPanelHeight` で「フィルタ非展開時の下端」を基準にすることで位置を固定（フィルタは前面に重なる）

3. **スマホ縦でリスト最終行がオフセットコントロールに隠れる問題を修正**
   - サイドパネルのリスト（省庁/事業/支出先）の最下行が画面下のオフセットコントロールに重なって見えなくなっていた
   - コントロールの実高を計測し、スマホ縦のときだけリストに `paddingBottom` を確保

4. **検索ボックス（フィルタ含む）の z-index をサイドパネル背面に変更（100 → 20）**
   - 列ヘッダー(8)/年度(15)/設定ダイアログ(19) より上、サイドパネル(25) より下に配置
   - 展開したフィルタやフィルタ内コンボボックスもサイドパネルの背面に回る

## テスト方法

```bash
npm run dev   # localhost:3000/sankey-svg
```

- フィルタを開閉して列ヘッダー（総額/府省庁/事業/支出先）が動かないこと
- スマホ幅・縦表示でノードを選択 → サイドパネルのリストを最下までスクロールし、最終行がオフセットコントロールに隠れず見えること
- サイドパネルを開いた状態で検索ボックス/フィルタがパネルの背面に回ること
- ズームインでラベルフォントが最大2.0倍まで拡大すること

## 確認済み

- `npx tsc --noEmit` パス（エラーなし）
- `npm run lint` 既存warningのみ（本変更由来のエラー・warningなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved column header positioning when filter panels expand or collapse
  * Fixed content being hidden behind controls on mobile devices
  * Enhanced label scaling to improve readability of displayed information
  * Improved overlay positioning accuracy for responsive layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->