### PR TITLE
fix(sankey-svg): 支出先名フィルタ時の不要な集約ノードを修正 (#229)

### DIFF
--- a/app/lib/sankey-svg-filter.ts
+++ b/app/lib/sankey-svg-filter.ts
@@ -161,9 +161,14 @@ export function filterTopN(
       }
     }
     const sortedWindowProjectRecips = Array.from(windowProjectRecipAmounts.entries()).sort((a, b) => b[1] - a[1]);
-    totalRecipientCount = sortedWindowProjectRecips.length;
-    windowRecipients = sortedWindowProjectRecips.slice(0, topRecipient);
-    tailRecipients = sortedWindowProjectRecips.slice(topRecipient);
+    // When every recipient in scope already fits within topRecipient (e.g. a recipient-name filter
+    // narrowed the set), rank over ALL recipients rather than only window-project recipients. Otherwise
+    // recipients reachable solely via aggregate projects are wrongly collapsed into __agg-recipient even
+    // though there is room to show them individually (issue #229).
+    const sortedRecips = allSortedRecipients.length <= topRecipient ? allSortedRecipients : sortedWindowProjectRecips;
+    totalRecipientCount = sortedRecips.length;
+    windowRecipients = sortedRecips.slice(0, topRecipient);
+    tailRecipients = sortedRecips.slice(topRecipient);
   } else if (ministryFocusMode && pinnedMinistryName) {
     // Recipient window based on ministry-specific flows (supports offset scrolling)
     const ministryRecipientAmounts = new Map<string, number>();


### PR DESCRIPTION
## 概要

`/sankey-svg` で支出先名フィルタを使ったとき、該当する支出先の数が支出先TopN未満なのに余計な集約ノード（「N支出先」）が表示される不具合（#229）を修正。

Closes #229

## 原因

`offsetTarget` のデフォルトは `'project'` で **projectOffsetMode** が有効。このモードでは支出先ウィンドウを「表示中の上位事業からの支出のみ」でランク付けしていたため、**集約事業（TopN圏外）からのみ資金を受け取る支出先**がウィンドウ候補から外れ、TopNに収まる件数でも `__agg-recipient` に巻き込まれていた。

実データで再現:
- `fnr=大阪市` の該当支出先は **6件**
- うち「大阪市教育委員会」(6,300万) と「公立大学法人大阪市立大学」(3,998万) は上位50事業圏外からのみ受注 → 合計 1.03億円 = 観測された「2支出先 (1.03億円)」と一致

## 修正

`app/lib/sankey-svg-filter.ts` の projectOffsetMode で、**スコープ内の全支出先が `topRecipient` 以下に収まる場合は全支出先でランク付けする**よう変更（分岐1行追加）。

## 検証（実データ）

| ケース | 結果 |
|---|---|
| `fnr=大阪市`, TopN=50 | 6件すべて個別表示、集約なし ✅（修正前: 4件+「2支出先」） |
| フィルタなし（全12,521件） | 50件+「12,471支出先」集約 — 従来どおり ✅ |
| `fnr=大阪市`, TopN=3（収まらない） | 正当に「2支出先」集約 — 従来どおり ✅ |

`npx tsc --noEmit` パス、lint は既存warningのみ（新規なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recipient filtering logic to ensure accurate and consistent ranking results in all data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->