### PR TITLE
fix(site-url): 公開URLのドメイン直書きを解消しデプロイ先に追随

### DIFF
--- a/app/lib/site-url.ts
+++ b/app/lib/site-url.ts
@@ -1,6 +1,17 @@
 /**
- * サイトの公開URL。
- * Vercel 環境では NEXT_PUBLIC_SITE_URL を設定して上書きする。
+ * サイトの公開URL（OGP/canonical・sitemap・robots の絶対URL基準）。
+ *
+ * 特定ドメインをソースに直書きしない。デプロイ先に追随させる:
+ *   1. NEXT_PUBLIC_SITE_URL          … 明示指定があれば最優先
+ *   2. VERCEL_PROJECT_PRODUCTION_URL … Vercel本番の安定ドメイン（推奨）
+ *   3. VERCEL_URL                    … その他のVercelデプロイURL（preview等）
+ *   4. http://localhost:3000         … ローカル開発フォールバック
+ *
+ * いずれも server 専用箇所（layout metadata / robots / sitemap）からのみ参照される。
  */
+const vercelHost =
+  process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
+
 export const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://marumie-rssystem.vercel.app';
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (vercelHost ? `https://${vercelHost}` : 'http://localhost:3000');

--- a/docs/tasks/20260623_0633_rs-visへの反映対応案_A+B.md
+++ b/docs/tasks/20260623_0633_rs-visへの反映対応案_A+B.md
@@ -1,0 +1,173 @@
+# rs-vis への反映 対応案（スコープ A+B・コミット順維持）
+
+**日時**: 2026-06-23 06:33 (JST)
+**対象**: marumie-rssystem main の最新状態を rs-vis へ反映（公開ミラー同期）
+**スコープ**: ユーザー決定 **A（公開ページの修正）＋ B（AIフレンドリー化＋SEO/ハードニングのAPI層）**。docs/設定（C）は除外。
+**特記**: **marumie の PR コミット順を維持**して反映する（1個の squash 同期ではなく、PR 単位の順序付きコミットにする）。
+
+---
+
+## 0. 改訂メモ（2026-06-23 更新）
+
+検討の結果、初版から次の前提が変わった。本文（§5/§8/§10 等）はこのメモを優先して読むこと。
+
+1. **`SITE_URL` のドメイン直書きを marumie 側で解消済み**。`app/lib/site-url.ts` から `https://marumie-rssystem.vercel.app` を削除し、`NEXT_PUBLIC_SITE_URL → VERCEL_PROJECT_PRODUCTION_URL → VERCEL_URL → http://localhost:3000` の順で**デプロイ先に追随**する形にした。
+   - → **rs-vis にそのまま反映してもコード変更なしで rs-vis 自身のドメインになる**。初版 §8/§10 で挙げた「ドメイン値を marumie のまま入れるか置換するか」という懸念は**解消**（env 設定すら不要。明示したい場合のみ rs-vis で `NEXT_PUBLIC_SITE_URL` を設定）。
+2. **「フィルタ時の集約ノードのバグ修正」は A**（`app/lib/sankey-svg-filter.ts`、marumie #229/#230）であり、**B には含まれない**。B を入れなくてもこの修正は A だけで反映できる。
+3. **B のスコープは要再確認**。当初 A+B だが、「B 全体をやめる」案も俎上にある。最小なら **A のみ（sankey 2ファイル、フィルタ修正込み）** で完結し、ドメイン問題も B 依存も発生しない。B を入れるかは別途決定（SITE_URL の障害は除去済みなので、判断材料は「rs-vis が API ハードニング/SEO/検索・支出先エンドポイントを欲しいか」に絞られた）。
+
+> 当面の最小反映（A のみ）で進める場合のコミットは「§5 コミット3（sankey 2ファイル）」のみ。B を入れる場合は §5 全体（コミット1→2→3）。
+
+---
+
+## 1. 目的（Why）
+
+rs-vis（公開ミラー）の保守者・閲覧者が、marumie 側で進んだ「サイドパネルの不具合修正（A）」と「API のAIフレンドリー化＋セキュリティハードニング（B）」を、**marumie の変更履歴の順序を保ったまま**追える形で受け取れるようにするため。
+
+---
+
+## 2. rs-vis の現状と分岐（ここが「込み入っている」理由）
+
+rs-vis 最新は `b3facbc`（rs-vis 独自の品質スコア再設計 `40ccdb7` ＋ 2024再生成）。marumie とは次の点で分岐している。
+
+| 観点 | rs-vis 現状 | marumie main |
+|------|------------|--------------|
+| /quality 再設計 | **独自に先行導入済**（`40ccdb7`）。`app/quality/page.tsx` は**両者一致** | #234 で取り込み（rs-vis版を #231 のハードニング済ルート上にマージ） |
+| quality scores データ | **raw `.json`** をGit管理 | **`.gz` のみ**管理（#234でビルド時展開へ移行） |
+| API層（B: #231） | **未反映**（`app/lib/api/*`・`app/lib/search/*`・`robots.ts`・`sitemap.ts`・新エンドポイント等が無い） | あり |
+| sankey-svg/page.tsx | #237 直前相当（marumie と **差分33行**＝#237＋幅/フォント） | #237 反映済 |
+| /sankey-svg-next | 無し | 削除済（#225）→ **rs-vis では対応不要** |
+| llms.txt | 無し | 削除済（#232）→ **rs-vis では実質 No-op** |
+
+**核心の難所**: #231（API改善）は **再設計前の** quality ルートを改変し、その後 #234 がルートを再設計した。rs-vis は #234 相当のルート（再設計版）を**独自履歴で先に**持っている。よって #231 のパッチを素直に当てると quality ルートで競合する。→ **quality/project-details ルートは #231 単独で当てず、最終形を #234 コミットでまとめて反映**する（中間退行を避ける）。
+
+---
+
+## 3. 対象 marumie PR（コミット順）
+
+| 順 | PR | 日付 | 種別 | rs-vis への反映 |
+|----|----|------|------|----------------|
+| 1 | **#231** feat(api): AIフレンドリー化＋ハードニング | 2026-06-12 | B | API infra 一式（quality/project-details ルートは除き #234 へ後回し） |
+| 2 | #232 chore: llms.txt 削除 | 2026-06-12 | B付随 | **No-op**（rs-vis に llms.txt 無し。robots.ts は #231 で最終形） |
+| 3 | **#234** feat(quality): 再設計（マージ版） | 2026-06-19 | B結合 | quality/project-details ルート**最終形** ＋ データを `.gz` 管理へ移行 |
+| 4 | **#237** fix(sankey-svg): パネル幅＋金額重なり | 2026-06-23 | A | `app/sankey-svg/page.tsx`（＋未反映の `sankey-svg-filter.ts` 差分） |
+
+> #233・#235・#236（docsのみ）と #231内のdocs・`.claude/CLAUDE.md`・`.coderabbit.yaml` は **C/設定として除外**。
+
+---
+
+## 4. コミット順を維持する方式
+
+リポジトリ間で履歴を共有しないため `git cherry-pick` は使えない。**各 marumie PR を 1 rs-vis コミットとして再現**する（PR が触れたファイルの**最終 marumie 状態**を rs-vis にコピーし、PR 相当のメッセージでコミット）。順序は §3 のとおり。quality ルートは #231/#234 の二重改変のため、退行回避として **#234 コミットに集約**する。
+
+結果、rs-vis には **3 コミット**（#232 は No-op のため省略）が PR 順で積まれる。
+
+---
+
+## 5. コミット計画（ファイル単位）
+
+### コミット1 — `feat(api): AIフレンドリー化 + セキュリティ初期ハードニングを反映 (marumie #231)`
+
+**新規追加（marumie からコピー）**
+- `app/lib/api/api-notes.ts` / `links.ts` / `quality-scores-loader.ts` / `recipient-index-loader.ts`
+- `app/lib/recipient-key.ts`
+- `app/lib/search/project-search.ts` / `recipient-search.ts`
+- `app/lib/site-url.ts`
+- `app/robots.ts` / `app/sitemap.ts`
+- `app/api/recipients/[key]/route.ts`
+- `app/api/search/projects/route.ts` / `app/api/search/recipients/route.ts`
+
+**変更（#231のみが触れた公開系ルート/layout）**
+- `app/layout.tsx`（`SITE_URL`/metadataBase 追加）
+- `app/api/sankey/mof-overview/route.ts`（api-notes 利用）
+- `app/api/subcontracts/[projectId]/route.ts`（buildMetadata/links 利用）
+
+**この時点で除外**: `app/api/quality-scores/*`・`app/api/project-details/route.ts`（#234 コミットで最終形を反映）。docs・`.claude`・`.coderabbit` は除外。
+
+### コミット2 — `feat(quality): 再設計ルートのマージ反映とスコアデータの.gz管理化 (marumie #234)`
+
+- **ルート最終形**（marumie main からコピー）: `app/api/quality-scores/route.ts`・`app/api/quality-scores/recipients/route.ts`・`app/api/project-details/[projectId]/route.ts`
+  - これらは #231 由来の `parseYear`/`serverErrorResponse`/`projectLinks`/`API_CACHE_CONTROL`（コミット1で導入済）に依存。
+- **データ管理を `.gz` へ移行**:
+  - `git rm --cached public/data/project-quality-scores-2024.json 2025.json`（raw を追跡解除）
+  - `.gz` を追加（`project-quality-scores-2024.json.gz` / `2025.json.gz`）
+  - `.gitignore`（raw を ignore・`.gz` 許可）/ `scripts/decompress-data.sh`（展開対象に追加）/ `package.json`（compress-data に追加）を marumie に合わせる
+- `scripts/score-project-quality.py` の差分（あれば）。`score-project-quality-ai.py` は rs-vis に既存（`40ccdb7`）のため差分のみ確認。
+- `app/quality/page.tsx` は**両者一致のため変更なし**。
+
+### コミット3 — `fix(sankey-svg): サイドパネル幅クランプと金額重なり等の修正を反映 (marumie #237 ほか)`
+
+- `app/sankey-svg/page.tsx`（marumie 最終形＝幅クランプ・`scaleSize(112)` 金額折返し・幅既定400・PANEL_META 13）
+- `app/lib/sankey-svg-filter.ts`（rs-vis と差分あり。未反映の sankey ロジックを最終形で反映）
+
+---
+
+## 6. 反映しないもの（C/D）
+
+- **C（docs/ツール）**: `docs/tasks/*`、`docs/*-guide.md` の新規/差分、`scripts/score-project-quality-ai-google.py`、`scripts/generate-recipient-index.ts`、`.claude/CLAUDE.md`、`.coderabbit.yaml`。ミラーは task docs を持ち込まない方針。
+- **D（秘密・ノイズ）**: `.env.local`（**APIキー** — 絶対に反映しない）、`.DS_Store`、`__pycache__`。
+
+---
+
+## 7. ビルド・動作確認
+
+各コミット後ではなく、**全コミット後に一括検証**（中間状態は sync ブランチ内のため可）。
+
+```bash
+cd /Users/igomuni/MyGitHub/rs-vis
+npm run lint
+npx tsc --noEmit          # B の新規lib/エンドポイントの型解決を確認
+npm run build             # prebuild の decompress で .gz→.json 展開が通るか
+```
+
+確認ポイント:
+- `app/lib/api/*` を import する全ルートが解決する（コミット1の取りこぼしがないか）。
+- `/quality`・`/subcontracts`・`/mof-budget-overview`・`/sankey-svg` の4公開ページがビルド成功。
+- `.gz` 管理移行後、prebuild でスコアJSONが展開される。
+
+---
+
+## 8. リスク・注意
+
+- **最大リスク**: B の infra ファイル（`app/lib/api/*` 等）の**取りこぼし**による型/ビルド破綻。コミット1で #231 の新規ファイルを漏れなくコピーすること（§5 のリストで照合）。
+- **quality ルートの二重改変**: 必ず #234 の最終形をコミット2で反映（コミット1では触らない）。
+- **データ二重管理**: rs-vis の raw `.json` を `git rm --cached` し忘れると raw と `.gz` が併存する。コミット2で必ず追跡解除。
+- **新エンドポイントの依存**: `app/api/recipients/[key]` `app/api/search/*` は loader/search/recipient-key に依存。セットで反映。
+- ~~rs-vis 固有のドメイン値調整が必要~~ → **解消済み（§0-1）**。`site-url.ts` はデプロイ先追随になったため、marumie の値が混入することはない。`robots.ts` の `disallow: ['/data/*.json','/api/']`（帯域/DoS保護）は維持されることを確認する。
+
+---
+
+## 9. 実行手順（概要）
+
+1. `cd rs-vis && git checkout main && git pull && git checkout -b sync/marumie-231-237`
+2. コミット1（#231 infra）→ コミット2（#234 quality最終形＋.gz）→ コミット3（#237 sankey）を §5 の順で作成。
+3. `site-url.ts`/OGP 等を rs-vis ドメインに合わせて調整（必要時、コミット1内で）。
+4. `npm run lint` / `npx tsc --noEmit` / `npm run build` で一括検証。
+5. draft PR を作成（base: rs-vis の main）。**実行は本対応案の承認後**。
+
+---
+
+## 10. 次アクション
+
+`SITE_URL` のドメイン依存（初版の最大の確認事項）は §0-1 で**解消済み**。残る判断は **B を入れるか／A のみにするか**のスコープ決定のみ。
+
+- **A のみで進める場合**: §5 コミット3（`sankey-svg/page.tsx` ＋ `sankey-svg-filter.ts`）だけを rs-vis に反映。フィルタ集約ノード修正も含まれ、最小・低リスク。
+- **A+B で進める場合**: §5 全体（コミット1→2→3）。SITE_URL 障害が無くなったため、コード変更なしで反映可能。判断材料は「rs-vis が B の機能（API ハードニング/SEO/検索・支出先エンドポイント）を採用するか」のみ。
+
+スコープ確定後、§9 の手順で実施する。なお `app/lib/site-url.ts` のドメイン直書き解消は marumie 単独の改善としても有効で、別途コミット/PR 可能。
+
+---
+
+## 11. 実施記録（2026-06-23）
+
+ユーザー決定により **A+B を実施**。rs-vis に `sync/marumie-a-plus-b` ブランチを作成し、marumie PR 順を維持した **3段階コミット**で反映済み（ローカル動作確認 OK・PR は保留中）。
+
+| コミット | 内容 |
+|---------|------|
+| `feat(api): … (marumie #231)` | B本体＋tail（lib/api・search・recipient-key・site-url・robots/sitemap・新エンドポイント3・layout/mof/subcontracts 改変 ＋ `types/recipient-index.ts`・`recipient-index-*.json.gz`） |
+| `feat(quality): … (marumie #234)` | quality/project-details ルート最終形 ＋ スコアデータ `.gz` 管理化（raw を `git rm --cached`） |
+| `fix(sankey-svg): … (marumie #237 ほか)` | サイドパネル幅クランプ・金額重なり・フィルタ集約ノード修正（A） |
+
+検証: **`app/` が marumie と完全一致**、`npx tsc --noEmit` 通過、`npm run lint` エラーなし、秘密/ノイズ（`.env`/cache 等）混入なし。
+
+`app/lib/site-url.ts` のドメイン直書き解消は **marumie 側でも別 PR 化**し、デプロイで Vercel 自動ドメイン追随（`VERCEL_PROJECT_PRODUCTION_URL`）を検証してから rs-vis の PR を ready にする方針。


### PR DESCRIPTION
## 目的（Why）

`app/lib/site-url.ts` にハードコードされた本番ドメイン `https://marumie-rssystem.vercel.app` をソースから無くし、**デプロイ先に自動追随**させるため。あわせて公開ミラー(rs-vis)へ反映してもコード変更なしで各デプロイの正しいドメインになるようにする。

**本PRは、デプロイで Vercel 自動ドメイン追随が問題なく効くことを確認するためのもの。**

## 変更内容

`app/lib/site-url.ts` の解決順を変更（ドメイン直書きを削除）:

```text
1. NEXT_PUBLIC_SITE_URL          … 明示指定があれば最優先
2. VERCEL_PROJECT_PRODUCTION_URL … Vercel本番の安定ドメイン（推奨・自動付与）
3. VERCEL_URL                    … その他Vercelデプロイ（preview等）
4. http://localhost:3000         … ローカル開発
```

- `SITE_URL` は server 専用箇所（`layout` の `metadataBase` / `robots.ts` / `sitemap.ts`）からのみ参照。
- marumie の Vercel 本番では `VERCEL_PROJECT_PRODUCTION_URL` が自動で marumie ドメインを供給 → **従来どおりの挙動**（OGP/canonical/sitemap/robots）。
- 併せて rs-vis への A+B 反映 対応案＋実施記録を `docs/tasks/20260623_0633_*` に追加。

## テスト / 確認

- `npx tsc --noEmit` 通過。`new URL(SITE_URL)` が全env想定（未設定=localhost / VERCEL_* / 明示）で有効URLになることを確認。
- **デプロイ後に確認したいこと**: 本番URLで `https://<本番ドメイン>/sitemap.xml`・`/robots.txt`、各ページの OGP/canonical が**正しいドメイン**を指すこと。

## 補足

- rs-vis 側はこの site-url.ts（ドメイン非依存版）を含む A+B を別途反映済み（`sync/marumie-a-plus-b`・PR保留中）。本PRのデプロイ検証OK後に rs-vis PR を ready 化する流れ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site URL configuration to dynamically adapt across different deployment environments, including production, preview deployments, and local development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->