### PR TITLE
refactor(quality): ScoreDetailDialog のデータ取得をページ側へ分離 (#246)

### DIFF
--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import type { QualityScoreItem, QualityScoresResponse } from '@/app/api/quality-scores/route';
 import { ScoreDetailDialog } from '@/client/components/quality/ScoreDetailDialog';
+import { useScoreDetailData } from '@/client/hooks/useScoreDetailData';
 import { scoreColor, formatAmount, pct } from '@/client/components/quality/score-format';
 
 const PAGE_SIZE = 50;
@@ -77,6 +78,8 @@ export default function QualityPage() {
   const [page, setPage] = useState(1);
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [dialogItem, setDialogItem] = useState<QualityScoreItem | null>(null);
+  // ダイアログ用データはページ側で取得し ScoreDetailDialog へ props で渡す（Issue #246）
+  const dialogData = useScoreDetailData(dialogItem?.pid ?? null, year);
 
   // 初回のみ URL の ?year= を年度に反映（/sankey-svg サイドパネル等からの年度付きリンク対応）。
   // フェッチ効果の先頭で判定することで、パラメータ指定時にデフォルト年度の無駄な全件取得を避ける。
@@ -204,7 +207,15 @@ export default function QualityPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      {dialogItem && <ScoreDetailDialog item={dialogItem} onClose={() => setDialogItem(null)} year={year} />}
+      {dialogItem && (
+        <ScoreDetailDialog
+          item={dialogItem}
+          onClose={() => setDialogItem(null)}
+          recipients={dialogData.recipients}
+          recipientsError={dialogData.recipientsError}
+          projectInfo={dialogData.projectInfo}
+        />
+      )}
       {/* Header */}
       <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-4">
         <div className="max-w-[1600px] mx-auto">

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -24,6 +24,7 @@ import type { AccountCategoryKey } from '@/types/sankey-query';
 import type { QualityScoreProjection } from '@/app/lib/api/quality-scores-loader';
 import type { QualityScoreItem } from '@/app/api/quality-scores/route';
 import { ScoreDetailDialog } from '@/client/components/quality/ScoreDetailDialog';
+import { useScoreDetailData } from '@/client/hooks/useScoreDetailData';
 
 // ── URL state serialization ──
 
@@ -294,6 +295,8 @@ export default function RealDataSankeyPage() {
   // 品質スコア詳細ダイアログ（/quality と共通の ScoreDetailDialog を全項目取得して表示）
   const [scoreDialogItem, setScoreDialogItem] = useState<QualityScoreItem | null>(null);
   const [scoreDialogLoading, setScoreDialogLoading] = useState(false);
+  // ダイアログ用データはページ側で取得し ScoreDetailDialog へ props で渡す（Issue #246）
+  const scoreDialogData = useScoreDetailData(scoreDialogItem?.pid ?? null, year);
   const [baseZoom, setBaseZoom] = useState(1);
   const [isEditingZoom, setIsEditingZoom] = useState(false);
   const [zoomInputValue, setZoomInputValue] = useState('');
@@ -3302,8 +3305,8 @@ export default function RealDataSankeyPage() {
                     </div>
                     {selectedNode.type === 'recipient' && selectedNode.representativeCorporateNumber && (
                       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3, fontSize: META_FONT_PX, color: '#666' }}>
-                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'monospace' }} title="法人番号（代表：内包する有効法人番号のうち最大金額のもの）">
-                          <span>法人番号 {selectedNode.representativeCorporateNumber}</span>
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'monospace', lineHeight: 1 }} title="法人番号（代表：内包する有効法人番号のうち最大金額のもの）">
+                          <span style={{ lineHeight: 1 }}>法人番号 {selectedNode.representativeCorporateNumber}</span>
                           {(() => {
                             // 有効な法人番号のみ gBizINFO へリンク（検証・URL構築は共有ヘルパーに集約）
                             const links = externalCorporateLinks(selectedNode.representativeCorporateNumber);
@@ -4775,8 +4778,10 @@ export default function RealDataSankeyPage() {
       {scoreDialogItem && createPortal(
         <ScoreDetailDialog
           item={scoreDialogItem}
-          year={year}
           onClose={() => setScoreDialogItem(null)}
+          recipients={scoreDialogData.recipients}
+          recipientsError={scoreDialogData.recipientsError}
+          projectInfo={scoreDialogData.projectInfo}
         />,
         document.body,
       )}

--- a/client/components/quality/ScoreDetailDialog.tsx
+++ b/client/components/quality/ScoreDetailDialog.tsx
@@ -17,14 +17,25 @@ const STATUS_META: Record<RecipientRow['s'], { label: string; cls: string }> = {
   unknown: { label: '未登録',  cls: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' },
 };
 
-export function ScoreDetailDialog({ item, onClose, year }: { item: QualityScoreItem; onClose: () => void; year: string }) {
-  const [recipients, setRecipients] = useState<RecipientRow[] | null>(null);
-  const [recipientsError, setRecipientsError] = useState(false);
+// データ（recipients / projectInfo）はページ側が useScoreDetailData で取得して渡す。
+// このコンポーネントは client/components 配下の再利用UIのため直接 API を叩かない（Issue #246）。
+export function ScoreDetailDialog({
+  item,
+  onClose,
+  recipients,
+  recipientsError,
+  projectInfo,
+}: {
+  item: QualityScoreItem;
+  onClose: () => void;
+  recipients: RecipientRow[] | null;
+  recipientsError: boolean;
+  projectInfo: ProjectDetail | null | undefined;
+}) {
   const [recipientSearch, setRecipientSearch] = useState('');
   const [recipientSortField, setRecipientSortField] = useState<'chain' | 'b' | 's' | 'c' | 'o' | 'a2' | 'pct'>('chain');
   const [recipientSortDir, setRecipientSortDir] = useState<'asc' | 'desc'>('asc');
   const [showAxisDetail, setShowAxisDetail] = useState(false);
-  const [projectInfo, setProjectInfo] = useState<ProjectDetail | null | undefined>(undefined);
   const [showProjectInfo, setShowProjectInfo] = useState(true);
   const COL_MAX_WIDTHS = [undefined, 70, 130, 60, 50, undefined, undefined];
   const [colWidths, setColWidths] = useState<number[]>([200, 70, 120, 60, 50, 200, 200]);
@@ -51,27 +62,15 @@ export function ScoreDetailDialog({ item, onClose, year }: { item: QualityScoreI
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [onClose]);
 
+  // 事業（pid）が切り替わったら表示状態（検索・ソート・折りたたみ）を初期化する。
+  // データ取得はページ側の useScoreDetailData が担う。
   useEffect(() => {
-    setRecipients(null);
-    setRecipientsError(false);
     setRecipientSearch('');
     setRecipientSortField('chain');
     setRecipientSortDir('asc');
     setShowAxisDetail(false);
-    setProjectInfo(undefined);
     setShowProjectInfo(true);
-    // 古い pid/year の fetch が後着で新しい表示を上書きしないようガードする
-    let cancelled = false;
-    fetch(`/api/quality-scores/recipients?pid=${item.pid}&year=${year}`)
-      .then(res => res.ok ? res.json() : Promise.reject())
-      .then((rows: RecipientRow[]) => { if (!cancelled) setRecipients(rows); })
-      .catch(() => { if (!cancelled) setRecipientsError(true); });
-    fetch(`/api/project-details/${item.pid}?year=${year}`)
-      .then(res => res.ok ? res.json() : Promise.reject())
-      .then((d: ProjectDetail) => { if (!cancelled) setProjectInfo(d); })
-      .catch(() => { if (!cancelled) setProjectInfo(null); });
-    return () => { cancelled = true; };
-  }, [item.pid, year]);
+  }, [item.pid]);
 
   const displayedRecipients = useMemo(() => {
     if (!recipients) return [];
@@ -447,13 +446,13 @@ export function ScoreDetailDialog({ item, onClose, year }: { item: QualityScoreI
                             const links = externalCorporateLinks(cn);
                             if (links) {
                               return (
-                                <span className="inline-flex items-center gap-1 font-mono text-[10px] text-gray-600 dark:text-gray-300" title={cn}>
-                                  <span className="select-text">{cn}</span>
+                                <span className="inline-flex items-center gap-1 font-mono text-[10px] leading-none text-gray-600 dark:text-gray-300" title={cn}>
+                                  <span className="select-text leading-none">{cn}</span>
                                   <a
                                     href={links.gbizinfo}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="shrink-0 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+                                    className="shrink-0 inline-flex items-center -mt-0.5 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
                                     title={`gBizINFO で法人番号を確認: ${cn}`}
                                     onClick={e => e.stopPropagation()}
                                   >

--- a/client/hooks/useScoreDetailData.ts
+++ b/client/hooks/useScoreDetailData.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { RecipientRow } from '@/app/api/quality-scores/recipients/route';
+import type { ProjectDetail } from '@/types/project-details';
+
+/**
+ * 品質スコア詳細ダイアログ（ScoreDetailDialog）が必要とするデータの取得フック。
+ *
+ * ScoreDetailDialog は client/components 配下の再利用UIであり、直接 API を叩かない方針
+ * （Issue #246）。フェッチはページ側がこのフック経由で所有し、結果を props で渡す。
+ *
+ * 状態の意味:
+ *   - recipients:     null=読み込み中 / 配列=取得済み（recipientsError=true 時は取得失敗）
+ *   - projectInfo:    undefined=読み込み中 / null=データなし・取得失敗 / オブジェクト=取得済み
+ */
+export interface ScoreDetailData {
+  recipients: RecipientRow[] | null;
+  recipientsError: boolean;
+  projectInfo: ProjectDetail | null | undefined;
+}
+
+export function useScoreDetailData(
+  pid: string | null | undefined,
+  year: string,
+): ScoreDetailData {
+  const [recipients, setRecipients] = useState<RecipientRow[] | null>(null);
+  const [recipientsError, setRecipientsError] = useState(false);
+  const [projectInfo, setProjectInfo] = useState<ProjectDetail | null | undefined>(undefined);
+
+  useEffect(() => {
+    // pid 未指定（ダイアログ非表示）は待機状態にリセットして何もフェッチしない。
+    setRecipients(null);
+    setRecipientsError(false);
+    setProjectInfo(undefined);
+    if (!pid) return;
+
+    // 古い pid/year の fetch が後着で新しい表示を上書きしないようガードする
+    let cancelled = false;
+    fetch(`/api/quality-scores/recipients?pid=${pid}&year=${year}`)
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then((rows: RecipientRow[]) => { if (!cancelled) setRecipients(rows); })
+      .catch(() => { if (!cancelled) setRecipientsError(true); });
+    fetch(`/api/project-details/${pid}?year=${year}`)
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then((d: ProjectDetail) => { if (!cancelled) setProjectInfo(d); })
+      .catch(() => { if (!cancelled) setProjectInfo(null); });
+    return () => { cancelled = true; };
+  }, [pid, year]);
+
+  return { recipients, recipientsError, projectInfo };
+}


### PR DESCRIPTION
Closes #246

## 目的（Why）

`ScoreDetailDialog`（`/quality` と `/sankey-svg` で共有）がコンポーネント内で直接 `fetch` しており、「`client/components/**` の再利用UIは API を直接叩かない」ガイドラインに違反していた（PR #245 で意図的に先送りした宿題）。これを解消し、コンポーネントを純粋なプレゼンテーショナルにするため。

## 変更内容

### Issue #246 本体
- **新設 `client/hooks/useScoreDetailData.ts`**: `recipients`（`/api/quality-scores/recipients`）と `projectInfo`（`/api/project-details/:pid`）の取得・loading/error ステートを担う共有フック。既存 `client/hooks/`（`useTopNSettings.ts`）と同列で `client/components/**` の対象外。Issue が許容する「フックの注入」方式で両ページの重複を回避。
- **`ScoreDetailDialog`**: 内部の `fetch` と `recipients`/`projectInfo` ステート・`year` props を撤去し、`recipients` / `recipientsError` / `projectInfo` を **props で受け取る**形に変更。検索・ソート・折りたたみ・列リサイズ等のUI状態はコンポーネントに保持し、`pid` 変更時に初期化（挙動不変）。
- **`/quality`・`/sankey-svg` 両ページ**: `useScoreDetailData(item?.pid ?? null, year)` を呼び、結果を props で渡す。

### 軽微修正（同梱）
- 法人番号の隣の gBizINFO リンクアイコンの縦中心を番号テキストに揃える（詳細ダイアログ・サイドパネルとも line-height 調整、ダイアログはアイコンを微上げ）。

## 受け入れ基準

- [x] `ScoreDetailDialog` は `fetch` を直接呼ばない（props でデータ・loading/error を受領）
- [x] `/quality`・`/sankey-svg` 両ページがデータを取得して渡す
- [x] 挙動の回帰なし（検索・ソート・折りたたみ・列リサイズ）
- [x] TypeScript / lint パス

## テスト方法

```bash
npm run dev
```

- **/quality**: 事業行の詳細ボタンからダイアログを開き、支出先一覧・検索・ソート・事業内容の折りたたみ・列リサイズが従来どおり動くこと。法人番号の gBizINFO リンクアイコンが番号と縦中心で揃うこと。
- **/sankey-svg**: 支出先ノード選択 → サイドパネルの品質スコア詳細から同ダイアログを開き、同様に動作すること。
- `npx tsc --noEmit` / `npm run lint` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the quality score detail dialog to load and display recipient and project information more reliably.
  * Added clearer handling for missing or failed detail data, so the dialog updates more consistently when selections change.

* **Bug Fixes**
  * Prevented outdated dialog data from appearing after switching projects or years.
  * Refined the corporate number link and related layout styling for better presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->