### PR TITLE
fix(vercel): AIチャット関数から public/data を除外 — 250MB上限超過でデプロイ失敗の解消

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // AIチャットAPIは全ローダ（graph 96MB級・quality系 数十MB ×2年度等）を import するため、
+  // ファイルトレーシングが public/data を同梱すると Vercel の関数上限 250MB を超える（実測270MB）。
+  // この関数は Vercel 上では isAiChatEnabled ガードで常に 404（データ読込なし）のため同梱不要。
+  // 将来 Vercel で有効化（SANKEY_AI_CHAT_ENABLED=1）する場合はこの除外の見直しが必須（WP5-1）。
+  outputFileTracingExcludes: {
+    '/api/ai/sankey-chat': ['./public/data/**'],
+  },
   transpilePackages: [
     '@nivo/sankey',
     '@nivo/core',


### PR DESCRIPTION
## 目的

main のVercelデプロイが「api/ai/sankey-chat is 270.15mb which exceeds 250mb」で失敗している状態を解消するため。

## 原因

チャットエージェント（app/lib/ai/）が全ローダ（sankey graph 96MB級・quality系 数十MB ×2年度等）を import しており、Next.js のファイルトレーシングが参照先の public/data をこの関数に同梱するため。WP1〜WP3 のツール追加でローダが増え、上限を超えた。

## 修正

`next.config.ts` に `outputFileTracingExcludes: { '/api/ai/sankey-chat': ['./public/data/**'] }` を追加。

**安全性**: この関数は Vercel 上では `isAiChatEnabled` ガードにより常に素の404を返し、データ読込は発生しない（ローカル実験専用機能）。除外による実挙動の変化はない。将来 Vercel でチャットを有効化（`SANKEY_AI_CHAT_ENABLED=1`）する際は本除外の見直しが必須で、コメントと WP5-1 チェック項目に明記した。

## 検証（ローカル production build の .nft.json 実測）

- `/api/ai/sankey-chat`: public/data のトレース **0件**（修正前は同梱）
- `/api/sankey/query`（2件）・`/api/project-details/[projectId]`（4件）等、本番でデータを読む他ルートは従来どおり同梱を維持
- `npm run build` 成功

## 備考

PR #258（使途検索）マージ後も、quality-recipients（30MB×2）は本除外の対象に含まれるため再発しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)