### PR TITLE
refactor(ui): サイドパネル chrome 共通化 + 品質ダイアログの再委託導線 (層B-5)

### DIFF
--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -214,6 +214,7 @@ export default function QualityPage() {
           recipients={dialogData.recipients}
           recipientsError={dialogData.recipientsError}
           projectInfo={dialogData.projectInfo}
+          year={year}
         />
       )}
       {/* Header */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -27,6 +27,14 @@ import type { QualityScoreProjection } from '@/app/lib/api/quality-scores-loader
 import type { QualityScoreItem } from '@/app/api/quality-scores/route';
 import { ScoreDetailDialog } from '@/client/components/quality/ScoreDetailDialog';
 import { useScoreDetailData } from '@/client/hooks/useScoreDetailData';
+import { SidePanelChrome } from '@/client/components/SidePanelChrome';
+import {
+  useSidePanel,
+  SIDE_PANEL_WIDTH_DEFAULT,
+  SIDE_PANEL_WIDTH_MIN,
+  SIDE_PANEL_WIDTH_MAX,
+  SIDE_PANEL_VIEWPORT_RESERVE_PX,
+} from '@/client/hooks/useSidePanel';
 
 // ── URL state serialization ──
 
@@ -105,11 +113,7 @@ const FONT_SCALE_REFERENCE_PX = 12;
 const BASE_FONT_PX_DEFAULT = 12;
 const BASE_FONT_PX_MIN = 8;
 const BASE_FONT_PX_MAX = 24;
-const SIDE_PANEL_WIDTH_DEFAULT = 400;
-const SIDE_PANEL_WIDTH_MIN = 200;
-const SIDE_PANEL_WIDTH_MAX = 800;
-// 実効幅クランプ時に地図側へ最低限残す余白(px)。狭いビューポートでパネルが全面を覆うのを防ぐ。
-const SIDE_PANEL_VIEWPORT_RESERVE_PX = 48;
+// サイドパネルの幅定数（既定/最小/最大/ビューポート予約）は client/hooks/useSidePanel.ts に一元化
 const PROJECT_OVERVIEW_PREVIEW_HEIGHT_DEFAULT = 72;
 const PROJECT_OVERVIEW_PREVIEW_HEIGHT_MIN = 24;
 const PROJECT_OVERVIEW_PREVIEW_HEIGHT_MAX = 600;
@@ -307,10 +311,8 @@ export default function RealDataSankeyPage() {
   const [showTopNSliders, setShowTopNSliders] = useState(true);
   const [scrollMode, setScrollMode] = useState<'zoom' | 'pan'>('zoom');
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-  const [isPanelCollapsed, setIsPanelCollapsed] = useState(false);
-  const [sidePanelWidth, setSidePanelWidth] = useState(SIDE_PANEL_WIDTH_DEFAULT);
-  const [isResizingSidePanel, setIsResizingSidePanel] = useState(false);
-  const sidePanelResizeRef = useRef<{ startX: number; startW: number } | null>(null);
+  // 左サイドパネル（ノード詳細）の chrome 状態は useSidePanel に集約。
+  // isPanelCollapsed/effectiveSidePanelWidth/isResizingSidePanel は下記 svgWidth 定義後にエイリアスする
   // AIチャットパネル（右側）。available は /api/ai/sankey-chat の疎通で判定（無効環境では出さない）
   const [aiChatAvailable, setAiChatAvailable] = useState(false);
   const [showAiChat, setShowAiChat] = useState(false);
@@ -383,6 +385,13 @@ export default function RealDataSankeyPage() {
   const isCompactWidth = svgWidth <= COMPACT_CONTROL_MAX_WIDTH;
   // スマホ横（コンパクト幅かつ横長）: オフセットコントロールをサイドパネルでスライドさせる
   const isLandscapeCompact = isCompactWidth && svgWidth > svgHeight;
+
+  // 左サイドパネル（ノード詳細）の chrome 状態。effectiveWidth は svgWidth に対する
+  // ビューポートクランプ込み（旧: minPanelWidthForViewport/maxPanelWidthForViewport 計算と同一式）
+  const leftSidePanel = useSidePanel({ side: 'left', viewportWidth: svgWidth });
+  const isPanelCollapsed = leftSidePanel.collapsed;
+  const isResizingSidePanel = leftSidePanel.isResizing;
+  const effectiveSidePanelWidth = leftSidePanel.effectiveWidth;
 
   useEffect(() => {
     const updateSize = () => {
@@ -676,26 +685,7 @@ export default function RealDataSankeyPage() {
       hoverSuppressTimerRef.current = null;
     }
   }, []);
-  // サイドパネル幅ドラッグリスナ — アンマウントやドラッグ終了時に確実に剥がす
-  useEffect(() => {
-    if (!isResizingSidePanel) return;
-    const onMove = (ev: MouseEvent) => {
-      const s = sidePanelResizeRef.current;
-      if (!s) return;
-      const next = Math.max(SIDE_PANEL_WIDTH_MIN, Math.min(SIDE_PANEL_WIDTH_MAX, s.startW + (ev.clientX - s.startX)));
-      setSidePanelWidth(next);
-    };
-    const onUp = () => {
-      sidePanelResizeRef.current = null;
-      setIsResizingSidePanel(false);
-    };
-    window.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
-    return () => {
-      window.removeEventListener('mousemove', onMove);
-      window.removeEventListener('mouseup', onUp);
-    };
-  }, [isResizingSidePanel]);
+  // サイドパネル幅ドラッグリスナは client/hooks/useSidePanel.ts（leftSidePanel）に集約済み
   // AIチャットパネル幅ドラッグリスナ（右側パネルのため左方向ドラッグで拡大）
   useEffect(() => {
     if (!isResizingAiPanel) return;
@@ -2653,17 +2643,10 @@ export default function RealDataSankeyPage() {
       + `L${tx},${tBot}C${mx},${tBot} ${mx},${sBot} ${sx},${sBot}Z`;
   };
 
-  // サイドパネルの実効幅: ユーザー設定値(sidePanelWidth)を保持しつつ、ビューポート幅に収める。
-  // スマホ縦などビューポートが狭い場合に、設定済みの広い幅がそのまま適用されて画面を
-  // 埋め尽くす（地図が見えなくなる）のを防ぐ。地図を最低 SIDE_PANEL_VIEWPORT_RESERVE_PX 残す。
-  // 極端に狭いビューポート(svgWidth < MIN+RESERVE)では MIN より reserve を優先し、
-  // 実効幅が svgWidth - RESERVE を超えない（地図が完全に消えない）ことを保証する。
+  // 左サイドパネルの実効幅（ビューポートクランプ込み）は leftSidePanel（useSidePanel）が算出済み。
+  // AIチャットパネル（右）も同じクランプ規則を使うため、境界値だけここでも算出する。
   const maxPanelWidthForViewport = Math.max(0, svgWidth - SIDE_PANEL_VIEWPORT_RESERVE_PX);
   const minPanelWidthForViewport = Math.min(SIDE_PANEL_WIDTH_MIN, maxPanelWidthForViewport);
-  const effectiveSidePanelWidth = Math.min(
-    maxPanelWidthForViewport,
-    Math.max(minPanelWidthForViewport, sidePanelWidth),
-  );
   const searchLeftOffset = selectedNodeId !== null && !isPanelCollapsed ? effectiveSidePanelWidth : 0;
   // AIチャットパネル（右側）の実効幅: 左パネルと同じ規則でビューポート幅に収める。
   // コンパクト幅では全幅オーバーレイになるため右端コントロールの退避は行わない。
@@ -3377,78 +3360,19 @@ export default function RealDataSankeyPage() {
 
       {/* Left side panel — node detail */}
       {selectedNodeId !== null && (
-        <div
-          data-pan-disabled="true"
-          style={{
-            position: 'fixed', left: 0, top: 0, height: '100%',
-            width: isPanelCollapsed ? 0 : effectiveSidePanelWidth,
-            background: '#fff',
-            borderRight: isPanelCollapsed ? 'none' : '1px solid #e0e0e0',
-            boxShadow: isPanelCollapsed ? 'none' : '2px 0 8px rgba(0,0,0,0.1)',
-            zIndex: 25,
-            transition: isResizingSidePanel ? 'none' : 'width 0.2s ease',
-            overflow: 'visible',
-            cursor: 'default',
-          }}
+        <SidePanelChrome
+          side="left"
+          open={!isPanelCollapsed}
+          onToggle={leftSidePanel.toggleCollapsed}
+          width={effectiveSidePanelWidth}
+          minWidth={SIDE_PANEL_WIDTH_MIN}
+          maxWidth={SIDE_PANEL_WIDTH_MAX}
+          onResizeStart={leftSidePanel.onResizeStart}
+          isResizing={isResizingSidePanel}
+          onResetWidth={leftSidePanel.resetWidth}
         >
-          {/* Width resize handle — right edge */}
-          {!isPanelCollapsed && (
-            <div
-              data-pan-disabled="true"
-              role="separator"
-              aria-orientation="vertical"
-              aria-label="サイドパネルの幅を変更"
-              title="ドラッグで幅を変更（ダブルクリックで既定値）"
-              onMouseDown={e => {
-                e.preventDefault();
-                sidePanelResizeRef.current = { startX: e.clientX, startW: sidePanelWidth };
-                setIsResizingSidePanel(true);
-              }}
-              onDoubleClick={() => setSidePanelWidth(SIDE_PANEL_WIDTH_DEFAULT)}
-              style={{
-                position: 'absolute', right: -3, top: 0, width: 6, height: '100%',
-                cursor: 'ew-resize', zIndex: 26,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                userSelect: 'none',
-              }}
-            >
-              <div style={{ width: 3, height: 32, borderRadius: 2, background: isResizingSidePanel ? '#a0a0a0' : 'transparent' }} />
-            </div>
-          )}
-          {/* Collapse/expand toggle + close buttons on right edge */}
-          <div
-            data-pan-disabled="true"
-            style={{
-              position: 'absolute', right: -25, top: '50%', transform: 'translateY(-50%)',
-              width: 25,
-              background: '#fff', border: '1px solid #e0e0e0', borderLeft: 'none',
-              borderRadius: '0 6px 6px 0',
-              boxShadow: '2px 0 4px rgba(0,0,0,0.08)',
-              display: 'flex', flexDirection: 'column', alignItems: 'center',
-            }}
-          >
-            {/* Collapse/expand button: panel folds, node stays selected */}
-            <button
-              data-pan-disabled="true"
-              onClick={() => setIsPanelCollapsed(c => !c)}
-              title={isPanelCollapsed ? 'パネルを展開' : 'パネルを折りたたむ'}
-              style={{
-                width: 25, height: 56,
-                background: 'transparent', border: 'none',
-                cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                padding: 0, borderRadius: '0 6px 6px 0',
-              }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 24 24" fill="none" stroke="#888" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                {isPanelCollapsed
-                  ? <polyline points="9 6 15 12 9 18"/>
-                  : <polyline points="15 6 9 12 15 18"/>}
-              </svg>
-            </button>
-          </div>
-
           {/* Panel content */}
-          {!isPanelCollapsed && selectedNode && (
+          {selectedNode && (
             <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
               {/* Header — fixed, never scrolls */}
               <div style={{ padding: '12px 14px 10px', borderBottom: '1px solid #f0f0f0', flexShrink: 0, background: '#fff' }}>
@@ -4222,7 +4146,7 @@ export default function RealDataSankeyPage() {
               })()}
             </div>
           )}
-        </div>
+        </SidePanelChrome>
       )}
 
       {/* Year selector — top center（スマホ幅では検索ボックスに隠れるため設定ダイアログへ移動） */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4882,6 +4882,7 @@ export default function RealDataSankeyPage() {
           recipients={scoreDialogData.recipients}
           recipientsError={scoreDialogData.recipientsError}
           projectInfo={scoreDialogData.projectInfo}
+          year={year}
         />,
         document.body,
       )}

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -24,6 +24,11 @@ import {
   NODE_PAD,
   type LayoutBlock,
 } from '@/app/lib/subcontract-layout';
+import { SidePanelChrome } from '@/client/components/SidePanelChrome';
+import { useSidePanel, SIDE_PANEL_WIDTH_MIN, SIDE_PANEL_WIDTH_MAX } from '@/client/hooks/useSidePanel';
+
+// サイドパネルの既定幅は現状の SidePane 固定幅(390)を維持。最小/最大はサンキーと共通の値を使う
+const SUBCONTRACT_PANEL_WIDTH_DEFAULT = 390;
 
 const COLOR_BACK_EDGE = 'rgba(217,69,69,0.65)';
 const COLOR_CANVAS = '#fff';
@@ -333,11 +338,9 @@ function SidePane({
 
   return (
     <aside style={{
-      width: 390,
-      minWidth: 390,
-      maxWidth: 460,
+      width: '100%',
+      height: '100%',
       background: '#fff',
-      borderLeft: `1px solid ${COLOR_PANEL_BORDER}`,
       overflowY: 'auto',
       display: 'flex',
       flexDirection: 'column',
@@ -905,6 +908,8 @@ function SubcontractDetailPageInner() {
   const hoverSuppressTimerRef = useRef<number | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
   const [activeTab, setActiveTab] = useState<PaneTab>('flow');
+  // サイドパネル（右）の chrome 状態。既定幅は現状の SidePane 固定幅(390)を維持
+  const rightSidePanel = useSidePanel({ side: 'right', defaultWidth: SUBCONTRACT_PANEL_WIDTH_DEFAULT });
 
   const beginHoverSuppressCooldown = useCallback(() => {
     setIsHoverSuppressed(true);
@@ -1567,8 +1572,14 @@ function SubcontractDetailPageInner() {
           );
         })()}
 
-        {/* ズームコントロール — 右下（BlockPanel 表示時は左にシフト） */}
-        <div style={{ position: 'absolute', bottom: 12, right: 12, zIndex: 15, display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {/* ズームコントロール — 右下（サイドパネル表示時は左にシフト。パネルは position:fixed のオーバーレイのため、
+            キャンバスは全幅を使う＝このコントロールの座標系はビューポート全体に一致する） */}
+        <div style={{
+          position: 'absolute', bottom: 12,
+          right: !rightSidePanel.collapsed ? rightSidePanel.effectiveWidth + 12 : 12,
+          zIndex: 15, display: 'flex', flexDirection: 'column', gap: 4,
+          transition: rightSidePanel.isResizing ? 'none' : 'right 0.2s ease',
+        }}>
           {/* + / スライダー / - */}
           <div style={{ background: 'rgba(255,255,255,0.9)', borderRadius: 8, boxShadow: '0 1px 4px rgba(0,0,0,0.12)', overflow: 'hidden', width: 44, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <button aria-label="ズームイン" onClick={() => applyZoom(1.5)} title="ズームイン" style={{ width: '100%', padding: '5px 0', display: 'flex', justifyContent: 'center', background: 'transparent', border: 'none', borderBottom: '1px solid #e5e7eb', cursor: 'pointer' }}>
@@ -1623,17 +1634,29 @@ function SubcontractDetailPageInner() {
       </div>
 
         {/* サイドパネル */}
-        <SidePane
-          block={selectedBlock}
-          graph={graph}
-          projectDetail={projectDetail}
-          orgChain={visibleOrgChain}
-          year={year}
-          activeTab={activeTab}
-          onChangeTab={setActiveTab}
-          onSelectBlock={handleSelectFromList}
-          onDeselectBlock={() => setSelectedBlock(null)}
-        />
+        <SidePanelChrome
+          side="right"
+          open={!rightSidePanel.collapsed}
+          onToggle={rightSidePanel.toggleCollapsed}
+          width={rightSidePanel.effectiveWidth}
+          minWidth={SIDE_PANEL_WIDTH_MIN}
+          maxWidth={SIDE_PANEL_WIDTH_MAX}
+          onResizeStart={rightSidePanel.onResizeStart}
+          isResizing={rightSidePanel.isResizing}
+          onResetWidth={rightSidePanel.resetWidth}
+        >
+          <SidePane
+            block={selectedBlock}
+            graph={graph}
+            projectDetail={projectDetail}
+            orgChain={visibleOrgChain}
+            year={year}
+            activeTab={activeTab}
+            onChangeTab={setActiveTab}
+            onSelectBlock={handleSelectFromList}
+            onDeselectBlock={() => setSelectedBlock(null)}
+          />
+        </SidePanelChrome>
     </div>
   );
 }

--- a/client/components/SidePanelChrome.tsx
+++ b/client/components/SidePanelChrome.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+/**
+ * サイドパネルの chrome（枠・開閉タブ・リサイズハンドル）の共通表示コンポーネント。
+ *
+ * 表示専用: fetch・状態保持は一切行わない。状態は client/hooks/useSidePanel.ts が持ち、
+ * 呼び出し側の page.tsx がそれを繋ぐ（app/lib 同様、UI と状態管理は分離する）。
+ *
+ * 見た目・操作感は app/sankey-svg/page.tsx の左ノード詳細パネル（実装の正）に合わせている:
+ * 折りたたみ時は幅0＋画面端の開閉タブのみ、展開時はリサイズハンドル＋children。
+ *
+ * 対象外: AiChatPanel（右・既に同等機能を自前実装済み。閉状態の見た目が異なるため統合しない）。
+ */
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface SidePanelChromeProps {
+  /** パネルの画面上の位置。境界線・リサイズハンドル・開閉タブの向きが side に応じて鏡映する */
+  side: 'left' | 'right';
+  /** true = 展開（children を表示）。false = 折りたたみ（幅0、開閉タブのみ表示） */
+  open: boolean;
+  onToggle: () => void;
+  /** 展開時の実効幅(px)（ビューポートクランプ済みの値を渡す） */
+  width: number;
+  minWidth: number;
+  maxWidth: number;
+  onResizeStart: (e: React.MouseEvent) => void;
+  isResizing: boolean;
+  onResetWidth: () => void;
+  /** 開閉タブの title/aria-label（既定はサンキーと同じ文言） */
+  expandLabel?: string;
+  collapseLabel?: string;
+  zIndex?: number;
+  /** ルート要素に付与する data-testid 等の識別用途 */
+  testId?: string;
+  children: ReactNode;
+}
+
+const LEFT_ARROW = '15 6 9 12 15 18'; // "<"
+const RIGHT_ARROW = '9 6 15 12 9 18'; // ">"
+
+export function SidePanelChrome({
+  side,
+  open,
+  onToggle,
+  width,
+  minWidth,
+  maxWidth,
+  onResizeStart,
+  isResizing,
+  onResetWidth,
+  expandLabel = 'パネルを展開',
+  collapseLabel = 'パネルを折りたたむ',
+  zIndex = 25,
+  testId,
+  children,
+}: SidePanelChromeProps) {
+  const isLeft = side === 'left';
+  // 折りたたみ時: 画面端へ向く矢印（クリックで展開）。展開時: 画面端側へ戻る矢印（クリックで折りたたみ）
+  const toggleIcon = open
+    ? (isLeft ? LEFT_ARROW : RIGHT_ARROW)
+    : (isLeft ? RIGHT_ARROW : LEFT_ARROW);
+
+  const rootStyle: CSSProperties = {
+    position: 'fixed',
+    [isLeft ? 'left' : 'right']: 0,
+    top: 0,
+    height: '100%',
+    width: open ? width : 0,
+    background: '#fff',
+    [isLeft ? 'borderRight' : 'borderLeft']: open ? '1px solid #e0e0e0' : 'none',
+    boxShadow: open ? (isLeft ? '2px 0 8px rgba(0,0,0,0.1)' : '-2px 0 8px rgba(0,0,0,0.1)') : 'none',
+    zIndex,
+    transition: isResizing ? 'none' : 'width 0.2s ease',
+    overflow: 'visible',
+    cursor: 'default',
+  };
+
+  return (
+    <div data-pan-disabled="true" data-testid={testId} style={rootStyle}>
+      {/* 幅リサイズハンドル — 内側の境界線側の端 */}
+      {open && (
+        <div
+          data-pan-disabled="true"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={`${isLeft ? '左側' : '右側'}パネルの幅を変更`}
+          aria-valuemin={minWidth}
+          aria-valuemax={maxWidth}
+          aria-valuenow={Math.round(width)}
+          title="ドラッグで幅を変更（ダブルクリックで既定値）"
+          onMouseDown={onResizeStart}
+          onDoubleClick={onResetWidth}
+          style={{
+            position: 'absolute',
+            [isLeft ? 'right' : 'left']: -3,
+            top: 0, width: 6, height: '100%',
+            cursor: 'ew-resize', zIndex: 2,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            userSelect: 'none',
+          }}
+        >
+          <div style={{ width: 3, height: 32, borderRadius: 2, background: isResizing ? '#a0a0a0' : 'transparent' }} />
+        </div>
+      )}
+
+      {/* 開閉タブ（折りたたみ/展開の両方でこのボタンのみ画面端に常時表示） */}
+      <div
+        data-pan-disabled="true"
+        style={{
+          position: 'absolute',
+          [isLeft ? 'right' : 'left']: -25,
+          top: '50%', transform: 'translateY(-50%)',
+          width: 25, zIndex: 1,
+          background: '#fff',
+          border: '1px solid #e0e0e0',
+          [isLeft ? 'borderLeft' : 'borderRight']: 'none',
+          borderRadius: isLeft ? '0 6px 6px 0' : '6px 0 0 6px',
+          boxShadow: isLeft ? '2px 0 4px rgba(0,0,0,0.08)' : '-2px 0 4px rgba(0,0,0,0.08)',
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+        }}
+      >
+        <button
+          data-pan-disabled="true"
+          onClick={onToggle}
+          title={open ? collapseLabel : expandLabel}
+          aria-label={open ? collapseLabel : expandLabel}
+          style={{
+            width: 25, height: 56,
+            background: 'transparent', border: 'none',
+            cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 0, borderRadius: isLeft ? '0 6px 6px 0' : '6px 0 0 6px',
+          }}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 24 24" fill="none" stroke="#888" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points={toggleIcon} />
+          </svg>
+        </button>
+      </div>
+
+      {/* パネル本体（展開時のみ） */}
+      {open && (
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/quality/ScoreDetailDialog.tsx
+++ b/client/components/quality/ScoreDetailDialog.tsx
@@ -25,20 +25,23 @@ export function ScoreDetailDialog({
   recipients,
   recipientsError,
   projectInfo,
+  year,
 }: {
   item: QualityScoreItem;
   onClose: () => void;
   recipients: RecipientRow[] | null;
   recipientsError: boolean;
   projectInfo: ProjectDetail | null | undefined;
+  /** 再委託構造ページ（/subcontracts/[pid]）へのリンク用年度 */
+  year: string;
 }) {
   const [recipientSearch, setRecipientSearch] = useState('');
   const [recipientSortField, setRecipientSortField] = useState<'chain' | 'b' | 's' | 'c' | 'o' | 'a2' | 'pct'>('chain');
   const [recipientSortDir, setRecipientSortDir] = useState<'asc' | 'desc'>('asc');
   const [showAxisDetail, setShowAxisDetail] = useState(false);
   const [showProjectInfo, setShowProjectInfo] = useState(true);
-  const COL_MAX_WIDTHS = [undefined, 70, 130, 60, 50, undefined, undefined];
-  const [colWidths, setColWidths] = useState<number[]>([200, 70, 120, 60, 50, 200, 200]);
+  const COL_MAX_WIDTHS = [undefined, 60, 70, 130, 60, 50, undefined, undefined];
+  const [colWidths, setColWidths] = useState<number[]>([200, 48, 70, 120, 60, 50, 200, 200]);
   const resizingCol = useRef<{ index: number; startX: number; startW: number } | null>(null);
 
   useEffect(() => {
@@ -146,6 +149,14 @@ export function ScoreDetailDialog({
             <div className="text-sm font-bold text-gray-900 dark:text-white leading-snug">{item.name}</div>
             <div className="flex items-center gap-1.5 flex-wrap mt-1 text-[10px] text-gray-500 dark:text-gray-400">
               <span className="font-mono bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded">PID {item.pid}</span>
+              <a
+                href={`/subcontracts/${item.pid}?year=${year}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                title="この事業の再委託構造（ブロック図）を新しいタブで開く"
+                onClick={e => e.stopPropagation()}
+              >再委託構造 ↗</a>
               {[item.ministry, item.bureau, item.division, item.section, item.office, item.team, item.unit].filter(Boolean).map((org, i) => (
                 <span key={i}>{i > 0 ? '' : ''}<span className={i === 0 ? 'font-medium' : ''}>{org}</span>{i < [item.ministry, item.bureau, item.division, item.section, item.office, item.team, item.unit].filter(Boolean).length - 1 ? <span className="text-gray-300 dark:text-gray-600 mx-0.5">›</span> : null}</span>
               ))}
@@ -392,7 +403,7 @@ export function ScoreDetailDialog({
           )}
           {recipients && recipients.length > 0 && (
             <div className="overflow-auto flex-1">
-              <table className="w-full min-w-[720px] text-xs table-fixed">
+              <table className="w-full min-w-[770px] text-xs table-fixed">
                 <colgroup>
                   {colWidths.map((w, i) => <col key={i} style={{ width: w, maxWidth: COL_MAX_WIDTHS[i] }} />)}
                 </colgroup>
@@ -400,6 +411,7 @@ export function ScoreDetailDialog({
                   <tr className="text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
                     {([
                       { label: '支出先名', align: 'left', sort: null, title: undefined },
+                      { label: 'ブロック', align: 'center', sort: 'b' as const, title: 'ブロック記号（A/B/C…）でソート' },
                       { label: '委託チェーン', align: 'left', sort: 'chain' as const, title: '委託チェーン（A→B→C）でソート' },
                       { label: '法人番号', align: 'center', sort: 'c' as const, title: '法人番号(Corporate Number)。記入有無でソート。⚠は形式不正（誤記載の疑い）' },
                       { label: '金額', align: 'right', sort: 'a2' as const, title: '個別支出額（CSVの「金額」列）' },
@@ -434,6 +446,7 @@ export function ScoreDetailDialog({
                             {row.o && <span className="shrink-0 inline-block px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200" title="不透明キーワードにマッチ">不透明</span>}
                           </div>
                         </td>
+                        <td className="px-2 py-1.5 text-center font-mono text-gray-600 dark:text-gray-300">{row.b || '-'}</td>
                         <td className="px-3 py-1.5 font-mono text-gray-500 dark:text-gray-400 truncate" title={row.chain}>
                           {row.chain
                             ? (row.chain.startsWith('組織→') ? row.chain.slice('組織→'.length) : row.chain)

--- a/client/hooks/useSidePanel.ts
+++ b/client/hooks/useSidePanel.ts
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * サイドパネル（サンキー左ノード詳細・/subcontracts 右詳細）の chrome 状態管理フック。
+ *
+ * 幅・折りたたみ・リサイズドラッグ・ダブルクリック既定復帰・ビューポートクランプをまとめる。
+ * 表示（JSX・スタイル）は client/components/SidePanelChrome.tsx に委譲する（本フックは状態のみ）。
+ *
+ * 幅系の既定値（400/200/800）と、実効幅クランプ時の反対側への最低余白(48px)は、
+ * 元々 app/sankey-svg/page.tsx にローカル定義されていたものをここへ一元化した。
+ */
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+export const SIDE_PANEL_WIDTH_DEFAULT = 400;
+export const SIDE_PANEL_WIDTH_MIN = 200;
+export const SIDE_PANEL_WIDTH_MAX = 800;
+// 実効幅クランプ時に反対側（サンキーなら地図、subcontractsなら図キャンバス）へ最低限残す
+// 余白(px)。狭いビューポートでパネルが画面を埋め尽くすのを防ぐ。
+export const SIDE_PANEL_VIEWPORT_RESERVE_PX = 48;
+
+export interface UseSidePanelOptions {
+  /** パネルの画面上の位置。リサイズドラッグの符号（幅が増減する方向）に影響する */
+  side: 'left' | 'right';
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  /**
+   * 実効幅クランプに使うビューポート幅(px)。呼び出し側が既に幅を state で持っている場合
+   * （サンキーの svgWidth 等）はそれを渡すと二重計測を避けられる。
+   * 省略時は window.innerWidth を自前で追跡する（resize リスナ）。
+   */
+  viewportWidth?: number;
+  initialCollapsed?: boolean;
+}
+
+export interface UseSidePanelResult {
+  /** ユーザーがドラッグで設定した生の幅（クランプ前） */
+  width: number;
+  setWidth: Dispatch<SetStateAction<number>>;
+  /** ビューポート幅でクランプ済みの実効幅。描画にはこちらを使う */
+  effectiveWidth: number;
+  collapsed: boolean;
+  setCollapsed: Dispatch<SetStateAction<boolean>>;
+  toggleCollapsed: () => void;
+  isResizing: boolean;
+  /** リサイズハンドルの onMouseDown にそのまま渡す */
+  onResizeStart: (e: React.MouseEvent) => void;
+  /** 幅を既定値へ戻す（ダブルクリックハンドラにそのまま渡す） */
+  resetWidth: () => void;
+}
+
+export function useSidePanel(options: UseSidePanelOptions): UseSidePanelResult {
+  const {
+    side,
+    defaultWidth = SIDE_PANEL_WIDTH_DEFAULT,
+    minWidth = SIDE_PANEL_WIDTH_MIN,
+    maxWidth = SIDE_PANEL_WIDTH_MAX,
+    viewportWidth,
+    initialCollapsed = false,
+  } = options;
+
+  const [width, setWidth] = useState(defaultWidth);
+  const [collapsed, setCollapsed] = useState(initialCollapsed);
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeRef = useRef<{ startX: number; startW: number } | null>(null);
+
+  // viewportWidth が渡されない呼び出し側向けに window.innerWidth を自前追跡
+  const [trackedViewportWidth, setTrackedViewportWidth] = useState<number>(1200);
+  useEffect(() => {
+    if (viewportWidth !== undefined) return;
+    const onResize = () => setTrackedViewportWidth(window.innerWidth);
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [viewportWidth]);
+
+  const onResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeRef.current = { startX: e.clientX, startW: width };
+    setIsResizing(true);
+  }, [width]);
+
+  // ドラッグ中のみ window にリスナを張る。アンマウントやドラッグ終了時に確実に剥がす
+  useEffect(() => {
+    if (!isResizing) return;
+    const onMove = (ev: MouseEvent) => {
+      const s = resizeRef.current;
+      if (!s) return;
+      const delta = ev.clientX - s.startX;
+      const raw = side === 'left' ? s.startW + delta : s.startW - delta;
+      setWidth(Math.max(minWidth, Math.min(maxWidth, raw)));
+    };
+    const onUp = () => {
+      resizeRef.current = null;
+      setIsResizing(false);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [isResizing, side, minWidth, maxWidth]);
+
+  const resetWidth = useCallback(() => setWidth(defaultWidth), [defaultWidth]);
+  const toggleCollapsed = useCallback(() => setCollapsed(c => !c), []);
+
+  const effectiveViewportWidth = viewportWidth ?? trackedViewportWidth;
+  const effectiveWidth = useMemo(() => {
+    const maxForViewport = Math.max(0, effectiveViewportWidth - SIDE_PANEL_VIEWPORT_RESERVE_PX);
+    const minForViewport = Math.min(minWidth, maxForViewport);
+    return Math.min(maxForViewport, Math.max(minForViewport, width));
+  }, [width, effectiveViewportWidth, minWidth]);
+
+  return {
+    width, setWidth, effectiveWidth,
+    collapsed, setCollapsed, toggleCollapsed,
+    isResizing, onResizeStart, resetWidth,
+  };
+}

--- a/client/hooks/useSidePanel.ts
+++ b/client/hooks/useSidePanel.ts
@@ -74,11 +74,20 @@ export function useSidePanel(options: UseSidePanelOptions): UseSidePanelResult {
     return () => window.removeEventListener('resize', onResize);
   }, [viewportWidth]);
 
+  const effectiveViewportWidth = viewportWidth ?? trackedViewportWidth;
+  const effectiveWidth = useMemo(() => {
+    const maxForViewport = Math.max(0, effectiveViewportWidth - SIDE_PANEL_VIEWPORT_RESERVE_PX);
+    const minForViewport = Math.min(minWidth, maxForViewport);
+    return Math.min(maxForViewport, Math.max(minForViewport, width));
+  }, [width, effectiveViewportWidth, minWidth]);
+
   const onResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
-    resizeRef.current = { startX: e.clientX, startW: width };
+    // アンカーは描画されている実効幅（クランプ後）。生の width を使うと、ビューポートで
+    // クランプされている間は「見えない差分」を跨ぐまでドラッグが効かないデッドゾーンになる
+    resizeRef.current = { startX: e.clientX, startW: effectiveWidth };
     setIsResizing(true);
-  }, [width]);
+  }, [effectiveWidth]);
 
   // ドラッグ中のみ window にリスナを張る。アンマウントやドラッグ終了時に確実に剥がす
   useEffect(() => {
@@ -104,13 +113,6 @@ export function useSidePanel(options: UseSidePanelOptions): UseSidePanelResult {
 
   const resetWidth = useCallback(() => setWidth(defaultWidth), [defaultWidth]);
   const toggleCollapsed = useCallback(() => setCollapsed(c => !c), []);
-
-  const effectiveViewportWidth = viewportWidth ?? trackedViewportWidth;
-  const effectiveWidth = useMemo(() => {
-    const maxForViewport = Math.max(0, effectiveViewportWidth - SIDE_PANEL_VIEWPORT_RESERVE_PX);
-    const minForViewport = Math.min(minWidth, maxForViewport);
-    return Math.min(maxForViewport, Math.max(minForViewport, width));
-  }, [width, effectiveViewportWidth, minWidth]);
 
   return {
     width, setWidth, effectiveWidth,


### PR DESCRIPTION
## 目的

/subcontracts のサイドパネルがサンキー図と操作感が異なる（固定幅・開閉/リサイズ不可）状態を解消し、以後のパネル実装の共通土台を作るため。あわせて品質スコアダイアログから再委託構造への導線を追加する。

## 変更内容

### サイドパネル chrome 共通化（層B-5）

- 新規 `client/components/SidePanelChrome.tsx`（表示専用・left/right 対応）+ `client/hooks/useSidePanel.ts`（幅・折りたたみ・ドラッグ・ダブルクリック復帰・ビューポートクランプ。`SIDE_PANEL_*` 定数を一元化）
- **サンキー左パネル: 純置換**（既存識別子をエイリアス維持し他消費箇所ゼロ変更、chrome JSX 約90行を1:1移設。挙動不変が受け入れ条件）
- **subcontracts 詳細の右パネル**: 固定390px → 開閉・リサイズ（200-800px）・ダブルクリック復帰・狭幅クランプを新規獲得。fixed 化に伴い右下ズームコントロールをパネル幅分退避
- AiChatPanel は対象外（自前実装を維持・移行は別途）

### 品質スコアダイアログ（ついで2件）

- ヘッダPID横に「再委託構造 ↗」リンク（/subcontracts/[pid]?year= 新規タブ）
- 支出先一覧に「ブロック」列（A/B/C…・ソート可）

## テスト方法

```bash
npm run dev
# /sankey-svg — ノード選択→左パネル: ドラッグ幅変更/ダブルクリック400px復帰/折りたたみ/狭幅クランプが従来どおり
# /subcontracts/7259?year=2024 — 右パネルで同4操作が新たに効く・展開時に右下ズームUIが左へ退避
# /quality — 事業を開く→「再委託構造 ↗」でブロック図・支出先一覧にブロック列
```

- `npx tsc --noEmit` エラー0 / `npm run lint` 新規警告なし / 3ページ200確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent collapsible, resizable side panels with drag controls, width limits, and reset behavior.
  - Improved side-panel layout across Sankey and subcontract views, including responsive positioning of zoom controls.
  - Added a “Block” column to quality score details.
  - Added links from score details to the relevant subcontract structure for the selected year.
- **Bug Fixes**
  - Ensured quality detail dialogs display data for the currently selected year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->