### PR TITLE
feat(subcontracts): URL=状態化とフォントスケール — サンキーとの一貫性土台の完成 (層B-6/B-7)

### DIFF
--- a/app/lib/font-scale.ts
+++ b/app/lib/font-scale.ts
@@ -1,0 +1,24 @@
+/**
+ * フォントスケール機構（Pure）。
+ *
+ * baseFontPx（ユーザーが調整する基準フォントサイズ）と FONT_SCALE_REFERENCE_PX（既定値）の比率で
+ * 各 UI 要素の px 指定フォントサイズを比例拡縮する。サンキー（app/sankey-svg/page.tsx）発の仕組みを
+ * 他ページ（例: /subcontracts/[projectId]）でも再利用できるよう切り出したもの。
+ *
+ * HTTP・React に依存しない Pure ヘルパーのため app/lib/ に置く（CLAUDE.md のレイヤー規約）。
+ */
+
+/** scaleFont の基準となる px 値（この値のとき等倍＝拡縮なし） */
+export const FONT_SCALE_REFERENCE_PX = 12;
+
+/**
+ * 指定した baseFontPx に基づく scaleFont 関数を生成する。
+ * 各ページの既定値定数（FONT_PX_DEFAULT）に適用して実際の描画フォントサイズを得る。
+ */
+export function createScaleFont(
+  baseFontPx: number,
+  referencePx: number = FONT_SCALE_REFERENCE_PX,
+): (px: number) => number {
+  const fontScale = baseFontPx / referencePx;
+  return (px: number) => Math.max(1, Math.round(px * fontScale));
+}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -14,6 +14,8 @@ import { MinimapOverlay } from '@/client/components/SankeySvg/MinimapOverlay';
 import { TopNSliders } from '@/client/components/SankeySvg/TopNSliders';
 import { FontSizeControls } from '@/client/components/SankeySvg/FontSizeControls';
 import { useRepeatPress } from '@/client/components/SankeySvg/useRepeatPress';
+import { useBaseFontPx } from '@/client/hooks/useBaseFontPx';
+import { createScaleFont, FONT_SCALE_REFERENCE_PX } from '@/app/lib/font-scale';
 import { filterTopN, computeLayout, getTopMinistriesInScope } from '@/app/lib/sankey-svg-filter';
 import { canonicalSelectableNodeId } from '@/app/lib/sankey-svg-ids';
 import { resolveYearSelectionSnapshot, type YearSelectionSnapshot } from '@/app/lib/sankey-svg-year-selection';
@@ -108,8 +110,8 @@ const PANEL_META_FONT_PX_DEFAULT = 13;
 const TOOLTIP_TITLE_FONT_PX_DEFAULT = 12;
 const TOOLTIP_VALUE_FONT_PX_DEFAULT = 11;
 const TOOLTIP_META_FONT_PX_DEFAULT = 10;
-// フォントスケールの基準値（baseFontPx ÷ FONT_SCALE_REFERENCE_PX で全フォントを比例拡縮）
-const FONT_SCALE_REFERENCE_PX = 12;
+// フォントスケールの基準値（baseFontPx ÷ FONT_SCALE_REFERENCE_PX で全フォントを比例拡縮）。
+// 実際の scaleFont 生成は app/lib/font-scale.ts（Pure ヘルパー、他ページと共有）に委譲。
 const BASE_FONT_PX_DEFAULT = 12;
 const BASE_FONT_PX_MIN = 8;
 const BASE_FONT_PX_MAX = 24;
@@ -288,7 +290,9 @@ export default function RealDataSankeyPage() {
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
   const [showSettings, setShowSettings] = useState(false);
   const [showFontControls, setShowFontControls] = useState(false);
-  const [baseFontPx, setBaseFontPx] = useState(BASE_FONT_PX_DEFAULT);
+  const [baseFontPx, setBaseFontPx] = useBaseFontPx(
+    'sankey-base-font-px', BASE_FONT_PX_DEFAULT, BASE_FONT_PX_MIN, BASE_FONT_PX_MAX,
+  );
   const [showLabels, setShowLabels] = useState(true);
   const [showAggRecipient, setShowAggRecipient] = useState(true);
   const [showAggProject, setShowAggProject] = useState(true);
@@ -406,31 +410,6 @@ export default function RealDataSankeyPage() {
     window.addEventListener('resize', updateSize);
     return () => { ro.disconnect(); window.removeEventListener('resize', updateSize); };
   }, []);
-
-  // Restore font size from localStorage on mount
-  useEffect(() => {
-    try {
-      const saved = window.localStorage.getItem('sankey-base-font-px');
-      if (saved !== null) {
-        const parsed = parseInt(saved, 10);
-        if (!isNaN(parsed)) {
-          const clamped = Math.min(BASE_FONT_PX_MAX, Math.max(BASE_FONT_PX_MIN, parsed));
-          setBaseFontPx(clamped);
-        }
-      }
-    } catch {
-      // localStorage unavailable (private browsing etc.) — ignore
-    }
-  }, []);
-
-  // Persist font size to localStorage on change
-  useEffect(() => {
-    try {
-      window.localStorage.setItem('sankey-base-font-px', String(baseFontPx));
-    } catch {
-      // ignore
-    }
-  }, [baseFontPx]);
 
   // Initialize state from URL on mount
   useEffect(() => {
@@ -926,8 +905,8 @@ export default function RealDataSankeyPage() {
   showLabelsRef.current = showLabels;
 
   const fontScale = baseFontPx / FONT_SCALE_REFERENCE_PX;
-  const scaleFont = (px: number) => Math.max(1, Math.round(px * fontScale));
-  const scaleSize = (px: number) => Math.max(1, Math.round(px * fontScale));
+  const scaleFont = useMemo(() => createScaleFont(baseFontPx), [baseFontPx]);
+  const scaleSize = scaleFont;
   // Top offset reserved for search/year/TopN controls. Narrow screens need another row's worth of breathing room.
   const SEARCH_BOX_RESERVE = Math.round((svgWidth < 1100 ? 92 : 56) * Math.max(1, fontScale));
   const searchBoxReserveRef = useRef(SEARCH_BOX_RESERVE);

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -1,5 +1,15 @@
 'use client';
 
+/**
+ * /subcontracts/[projectId]（詳細） URL=状態パラメータ一覧。
+ * 既定値のときは省略する（クリーンなURL維持）。
+ *
+ *   year : 年度（既存、2024|2025。既定2025）
+ *   sel  : 選択中ブロックID（未選択時は省略）。選択・タブ変更は history.pushState（ブラウザバックで戻れる）
+ *   tab  : アクティブタブの短縮コード（fl=流れ/bl=ブロック/rc=支出先/ic=間接経費。既定'fl'は省略）
+ *   z    : ズーム倍率（絶対スケール値、小数第2位）。history.replaceState（debounce後、履歴を汚さない）
+ *   tx/ty: パン位置（transform.x / transform.y、整数px）。z と同じ replaceState 経路で同期
+ */
 import { useState, useEffect, useRef, useCallback, useMemo, Suspense, type CSSProperties } from 'react';
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -238,6 +248,37 @@ type HoveredNode =
 // ─── サイドパネル（タブ式） ──────────────────────────────────────────────
 
 type PaneTab = 'flow' | 'blocks' | 'recipients' | 'indirect-cost';
+
+const TAB_TO_CODE: Record<PaneTab, string> = { flow: 'fl', blocks: 'bl', recipients: 'rc', 'indirect-cost': 'ic' };
+const CODE_TO_TAB: Record<string, PaneTab> = { fl: 'flow', bl: 'blocks', rc: 'recipients', ic: 'indirect-cost' };
+
+interface DetailUrlState {
+  sel: string;
+  tab: PaneTab;
+  zoom: number;
+  tx: number;
+  ty: number;
+}
+
+/** URL(検索パラメータ文字列)から sel/tab/z/tx/ty を復元する。存在しない・不正な値は省略する */
+function parseDetailUrlState(sp: { get(key: string): string | null }): Partial<DetailUrlState> {
+  const result: Partial<DetailUrlState> = {};
+  const sel = sp.get('sel'); if (sel) result.sel = sel;
+  const tab = sp.get('tab'); if (tab && CODE_TO_TAB[tab]) result.tab = CODE_TO_TAB[tab];
+  const z = sp.get('z'); if (z !== null) { const n = parseFloat(z); if (!isNaN(n) && n > 0) result.zoom = n; }
+  const tx = sp.get('tx'); if (tx !== null) { const n = parseFloat(tx); if (!isNaN(n)) result.tx = n; }
+  const ty = sp.get('ty'); if (ty !== null) { const n = parseFloat(ty); if (!isNaN(n)) result.ty = n; }
+  return result;
+}
+
+/** 選択・タブ変更を pushState で反映する（ブラウザバックで選択を戻れる）。sel=null は選択解除 */
+function pushSelTabUrl(sel: string | null, tab: PaneTab) {
+  const p = new URLSearchParams(window.location.search);
+  if (sel !== null) p.set('sel', sel); else p.delete('sel');
+  if (tab !== 'flow') p.set('tab', TAB_TO_CODE[tab]); else p.delete('tab');
+  const qs = p.toString();
+  window.history.pushState(null, '', qs ? `?${qs}` : window.location.pathname);
+}
 
 function SidePane({
   block,
@@ -893,6 +934,15 @@ function SubcontractDetailPageInner() {
   const projectId = params.projectId;
   const parsedYear = Number.parseInt(searchParams.get('year') ?? '2025', 10);
   const year = parsedYear === 2024 || parsedYear === 2025 ? parsedYear : 2025;
+  // マウント時のURL(sel/tab/z/tx/ty)を一度だけ捕捉。データ読み込み後の初回復元にのみ使う
+  // （sel/tab の復元先はグラフ読み込み完了時、z/tx/ty の復元先は初回フィット時と別タイミングのため、
+  //   オブジェクト自体は読み取り専用で保持し、消費側は各々の「適用済み」refで一度きりに制御する）
+  const initialUrlStateRef = useRef<Partial<DetailUrlState> | null>(null);
+  if (initialUrlStateRef.current === null) initialUrlStateRef.current = parseDetailUrlState(searchParams);
+  const selRestoredRef = useRef(false);
+  const viewportRestoredRef = useRef(false);
+  // resetViewport() 呼び出しがURL復元由来か（=書き込み抑制すべきか）を伝えるフラグ
+  const suppressViewportWriteRef = useRef(false);
 
   const [graph, setGraph] = useState<SubcontractGraph | null>(null);
   const [projectDetail, setProjectDetail] = useState<ProjectDetail | null>(null);
@@ -944,17 +994,18 @@ function SubcontractDetailPageInner() {
 
   // ノードクリック: 同じブロックなら解除、別ブロックなら選択 + 支出先タブへ
   const handleNodeClick = useCallback((node: BlockNode) => {
-    setSelectedBlock((prev) => {
-      if (prev?.blockId === node.blockId) return null;
-      return node;
-    });
-    setActiveTab((prev) => (selectedBlock?.blockId === node.blockId ? prev : 'recipients'));
-  }, [selectedBlock]);
+    const isDeselect = selectedBlock?.blockId === node.blockId;
+    setSelectedBlock(isDeselect ? null : node);
+    const nextTab = isDeselect ? activeTab : 'recipients';
+    setActiveTab(nextTab);
+    pushSelTabUrl(isDeselect ? null : node.blockId, nextTab);
+  }, [selectedBlock, activeTab]);
 
   // フロー一覧/ブロック一覧の行から選択した場合: 選択 + 支出先タブへ
   const handleSelectFromList = useCallback((node: BlockNode) => {
     setSelectedBlock(node);
     setActiveTab('recipients');
+    pushSelTabUrl(node.blockId, 'recipients');
   }, []);
 
   // ズーム/パン
@@ -984,8 +1035,19 @@ function SubcontractDetailPageInner() {
       .then((data: SubcontractGraph) => {
         if (controller.signal.aborted) return;
         setGraph(data);
-        // 主語は「事業」。ブロック選択はユーザーの明示クリックを起点とする
-        setSelectedBlock(null);
+        // 主語は「事業」。ブロック選択はユーザーの明示クリックを起点とする。
+        // ただしマウント時にURLへ sel/tab があれば復元する（存在しないblockIdは無視）。
+        // この復元は最初の読み込みでのみ行い、以降の年度/事業切替では適用しない
+        if (!selRestoredRef.current) {
+          selRestoredRef.current = true;
+          const restore = initialUrlStateRef.current;
+          const restoredBlock = restore?.sel ? data.blocks.find((b) => b.blockId === restore.sel) ?? null : null;
+          setSelectedBlock(restoredBlock);
+          if (restore?.tab) setActiveTab(restore.tab);
+          else if (restoredBlock) setActiveTab('recipients');
+        } else {
+          setSelectedBlock(null);
+        }
         setLoading(false);
       })
       .catch((e: Error) => {
@@ -1104,10 +1166,63 @@ function SubcontractDetailPageInner() {
     });
   }, [layout]);
 
-  // グラフ読み込み後に全体表示
+  // グラフ読み込み後に全体表示。ただし最初の1回はURLにz/tx/tyがあればそれを優先復元する
   useEffect(() => {
-    if (layout) resetViewport();
+    if (!layout) return;
+    const container = containerRef.current;
+    if (!viewportRestoredRef.current) {
+      viewportRestoredRef.current = true;
+      const restore = initialUrlStateRef.current;
+      if (container && restore?.zoom !== undefined && restore.tx !== undefined && restore.ty !== undefined) {
+        const cW = container.clientWidth;
+        const cH = container.clientHeight;
+        const fitZoom = Math.max(0.05, Math.min(10, Math.min(cW / layout.svgWidth, cH / layout.svgHeight) * 0.9));
+        suppressViewportWriteRef.current = true;
+        setBaseZoom(fitZoom);
+        setTransform({ x: restore.tx, y: restore.ty, scale: restore.zoom });
+        return;
+      }
+    }
+    suppressViewportWriteRef.current = true;
+    resetViewport();
   }, [layout]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ズーム/パンのURL同期。手動操作（ホイール/ボタン/ドラッグ）による変化のみ書き込む
+  // （resetViewport起因の自動フィットは suppressViewportWriteRef で抑制）。history.replaceState、debounce後に反映
+  useEffect(() => {
+    if (!layout) return;
+    if (suppressViewportWriteRef.current) { suppressViewportWriteRef.current = false; return; }
+    const timer = window.setTimeout(() => {
+      const p = new URLSearchParams(window.location.search);
+      p.set('z', transform.scale.toFixed(2));
+      p.set('tx', String(Math.round(transform.x)));
+      p.set('ty', String(Math.round(transform.y)));
+      const qs = p.toString();
+      window.history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
+    }, 500);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- layout intentionally excluded; only transform changes should retrigger this write
+  }, [transform.scale, transform.x, transform.y]);
+
+  // ブラウザバック/フォワードで sel/tab を復元する（同一ページ内の履歴移動。z/tx/tyも併せて反映）
+  useEffect(() => {
+    function onPopState() {
+      const s = parseDetailUrlState(new URLSearchParams(window.location.search));
+      if (s.sel) {
+        const found = graph?.blocks.find((b) => b.blockId === s.sel) ?? null;
+        setSelectedBlock(found);
+      } else {
+        setSelectedBlock(null);
+      }
+      setActiveTab(s.tab ?? 'flow');
+      if (s.zoom !== undefined && s.tx !== undefined && s.ty !== undefined) {
+        suppressViewportWriteRef.current = true;
+        setTransform({ x: s.tx, y: s.ty, scale: s.zoom });
+      }
+    }
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [graph]);
 
   function onMouseDown(e: React.MouseEvent) {
     if (e.button !== 0) return;
@@ -1283,7 +1398,7 @@ function SubcontractDetailPageInner() {
 
             {/* 事業コンテキストノード */}
             <g
-              onClick={() => { setSelectedBlock(null); setActiveTab('flow'); }}
+              onClick={() => { setSelectedBlock(null); setActiveTab('flow'); pushSelTabUrl(null, 'flow'); }}
               onMouseEnter={() => setHoveredNodeRaw({ kind: 'root' })}
               onMouseLeave={() => setHoveredNodeRaw(null)}
               style={{ cursor: 'pointer' }}
@@ -1652,9 +1767,9 @@ function SubcontractDetailPageInner() {
             orgChain={visibleOrgChain}
             year={year}
             activeTab={activeTab}
-            onChangeTab={setActiveTab}
+            onChangeTab={(tab) => { setActiveTab(tab); pushSelTabUrl(selectedBlock?.blockId ?? null, tab); }}
             onSelectBlock={handleSelectFromList}
-            onDeselectBlock={() => setSelectedBlock(null)}
+            onDeselectBlock={() => { setSelectedBlock(null); pushSelTabUrl(null, activeTab); }}
           />
         </SidePanelChrome>
     </div>

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -1484,7 +1484,7 @@ function SubcontractDetailPageInner() {
                   <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: 'rgba(255,255,255,0.78)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     事業 / PID {graph.projectId}
                   </div>
-                  <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: '#fff', lineHeight: '13px', marginTop: 3, ...CLAMP_2_LINES }}>
+                  <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: '#fff', lineHeight: `${scaleFont(13)}px`, marginTop: 3, ...CLAMP_2_LINES }}>
                     {graph.projectName}
                   </div>
                 </div>
@@ -1506,7 +1506,7 @@ function SubcontractDetailPageInner() {
                   {visibleOrgChain.length > 0 && (
                     <div style={{ display: 'flex', gap: 4, alignItems: 'baseline', marginTop: 4 }}>
                       <span style={{ fontWeight: 700, color: COLOR_CONTEXT_BODY_SUBTLE, flexShrink: 0, width: 48 }}>担当組織</span>
-                      <span style={{ fontWeight: 600, color: COLOR_CONTEXT_BODY_TEXT, minWidth: 0, flex: 1, lineHeight: '11px', ...CLAMP_2_LINES }}>
+                      <span style={{ fontWeight: 600, color: COLOR_CONTEXT_BODY_TEXT, minWidth: 0, flex: 1, lineHeight: `${scaleFont(11)}px`, ...CLAMP_2_LINES }}>
                         {visibleOrgChain.map((v, i) => `${ORG_LEVEL_LABELS[i] ?? '組織'}:${v}`).join(' / ')}
                       </span>
                     </div>
@@ -1523,7 +1523,7 @@ function SubcontractDetailPageInner() {
                 style={{ userSelect: 'none' }}
               >
                 <tspan x={safeLayout.root.x + safeLayout.root.w - 14}>予算 {graph.budget > 0 ? formatYen(graph.budget) : '—'}</tspan>
-                <tspan x={safeLayout.root.x + safeLayout.root.w - 14} dy={12}>支出 {graph.execution > 0 ? formatYen(graph.execution) : '—'}</tspan>
+                <tspan x={safeLayout.root.x + safeLayout.root.w - 14} dy={scaleFont(12)}>支出 {graph.execution > 0 ? formatYen(graph.execution) : '—'}</tspan>
               </text>
             </g>
 

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -36,6 +36,9 @@ import {
 } from '@/app/lib/subcontract-layout';
 import { SidePanelChrome } from '@/client/components/SidePanelChrome';
 import { useSidePanel, SIDE_PANEL_WIDTH_MIN, SIDE_PANEL_WIDTH_MAX } from '@/client/hooks/useSidePanel';
+import { useBaseFontPx } from '@/client/hooks/useBaseFontPx';
+import { createScaleFont } from '@/app/lib/font-scale';
+import { FontSizeControls } from '@/client/components/SankeySvg/FontSizeControls';
 
 // サイドパネルの既定幅は現状の SidePane 固定幅(390)を維持。最小/最大はサンキーと共通の値を使う
 const SUBCONTRACT_PANEL_WIDTH_DEFAULT = 390;
@@ -168,9 +171,16 @@ const COLOR_CONTEXT_BODY = '#d8f1df';
 const COLOR_CONTEXT_BODY_TEXT = '#1f6b3a';
 const COLOR_CONTEXT_BODY_SUBTLE = '#2d7d46';
 const COLOR_PANEL_BORDER = '#e5e7eb';
-const PANEL_LIST_NAME_FONT_PX = 12;
-const PANEL_LIST_VALUE_FONT_PX = 12;
-const PANEL_META_FONT_PX = 11;
+// フォントスケール機構（サンキー = app/sankey-svg/page.tsx と共通の app/lib/font-scale.ts + client/hooks/useBaseFontPx.ts を使用）。
+// 以下の "_DEFAULT" 定数は等倍（baseFontPx = BASE_FONT_PX_DEFAULT）時の値。実描画では scaleFont(...) を通す。
+const BASE_FONT_PX_DEFAULT = 12;
+const BASE_FONT_PX_MIN = 8;
+const BASE_FONT_PX_MAX = 24;
+const PANEL_TITLE_FONT_PX_DEFAULT = 14;
+const PANEL_PRIMARY_VALUE_FONT_PX_DEFAULT = 15;
+const PANEL_LIST_NAME_FONT_PX_DEFAULT = 12;
+const PANEL_LIST_VALUE_FONT_PX_DEFAULT = 12;
+const PANEL_META_FONT_PX_DEFAULT = 11;
 const CARD_HEADER_H = 46;
 const CARD_RADIUS = 6;
 const CARD_BORDER_W = 1;
@@ -290,6 +300,7 @@ function SidePane({
   onChangeTab,
   onSelectBlock,
   onDeselectBlock,
+  scaleFont,
 }: {
   block: BlockNode | null;
   graph: SubcontractGraph;
@@ -300,7 +311,11 @@ function SidePane({
   onChangeTab: (tab: PaneTab) => void;
   onSelectBlock: (block: BlockNode) => void;
   onDeselectBlock: () => void;
+  scaleFont: (px: number) => number;
 }) {
+  const PANEL_TITLE_FONT_PX = scaleFont(PANEL_TITLE_FONT_PX_DEFAULT);
+  const PANEL_PRIMARY_VALUE_FONT_PX = scaleFont(PANEL_PRIMARY_VALUE_FONT_PX_DEFAULT);
+  const PANEL_META_FONT_PX = scaleFont(PANEL_META_FONT_PX_DEFAULT);
   const [expandedRecipients, setExpandedRecipients] = useState<Set<number>>(new Set());
   const [recipientQuery, setRecipientQuery] = useState('');
   const [recipientSort, setRecipientSort] = useState<'amount-desc' | 'amount-asc' | 'name-asc'>('amount-desc');
@@ -391,10 +406,10 @@ function SidePane({
       <div style={{ padding: '14px 16px 12px', borderBottom: `1px solid ${COLOR_PANEL_BORDER}` }}>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontWeight: 700, fontSize: 14, color: '#111', wordBreak: 'break-all', lineHeight: 1.4 }}>
+            <div style={{ fontWeight: 700, fontSize: PANEL_TITLE_FONT_PX, color: '#111', wordBreak: 'break-all', lineHeight: 1.4 }}>
               {graph.projectName}
             </div>
-            <div style={{ fontSize: 15, fontWeight: 600, color: '#222', marginTop: 3 }}>
+            <div style={{ fontSize: PANEL_PRIMARY_VALUE_FONT_PX, fontWeight: 600, color: '#222', marginTop: 3 }}>
               <span style={{ fontSize: PANEL_META_FONT_PX, color: '#aaa', fontWeight: 400, marginRight: 4 }}>予算</span>
               {graph.budget > 0 ? formatYen(graph.budget) : '—'}
             </div>
@@ -526,6 +541,7 @@ function SidePane({
                 flow={flow}
                 graph={graph}
                 onSelectBlock={onSelectBlock}
+                scaleFont={scaleFont}
               />
             ))}
           </>
@@ -583,6 +599,7 @@ function SidePane({
                 block={b}
                 onClick={() => onSelectBlock(b)}
                 selected={block?.blockId === b.blockId}
+                scaleFont={scaleFont}
               />
             ))}
           </>
@@ -671,6 +688,7 @@ function SidePane({
                     onToggle={() => toggleRecipient(i)}
                     totalAmount={block.totalAmount}
                     barColor={originPalette(block.originKind).header}
+                    scaleFont={scaleFont}
                   />
                 ))}
                 {sortedRecipients.length === 0 && (
@@ -715,9 +733,12 @@ function SidePane({
   );
 }
 
-function BlockListRow({ block, selected, onClick }: { block: BlockNode; selected: boolean; onClick: () => void }) {
+function BlockListRow({ block, selected, onClick, scaleFont }: { block: BlockNode; selected: boolean; onClick: () => void; scaleFont: (px: number) => number }) {
   const badge = originKindBadgeColor(block.originKind);
   const badgeText = originKindLabel(block.originKind);
+  const PANEL_LIST_NAME_FONT_PX = scaleFont(PANEL_LIST_NAME_FONT_PX_DEFAULT);
+  const PANEL_LIST_VALUE_FONT_PX = scaleFont(PANEL_LIST_VALUE_FONT_PX_DEFAULT);
+  const PANEL_META_FONT_PX = scaleFont(PANEL_META_FONT_PX_DEFAULT);
 
   return (
     <button
@@ -769,12 +790,15 @@ function BlockListRow({ block, selected, onClick }: { block: BlockNode; selected
 }
 
 function FlowListRow({
-  flow, graph, onSelectBlock,
+  flow, graph, onSelectBlock, scaleFont,
 }: {
   flow: BlockEdge;
   graph: SubcontractGraph;
   onSelectBlock: (block: BlockNode) => void;
+  scaleFont: (px: number) => number;
 }) {
+  const PANEL_LIST_NAME_FONT_PX = scaleFont(PANEL_LIST_NAME_FONT_PX_DEFAULT);
+  const PANEL_META_FONT_PX = scaleFont(PANEL_META_FONT_PX_DEFAULT);
   const blockById = new Map(graph.blocks.map(b => [b.blockId, b]));
   const sourceBlock = flow.sourceBlock ? blockById.get(flow.sourceBlock) ?? null : null;
   const targetBlock = blockById.get(flow.targetBlock) ?? null;
@@ -855,16 +879,20 @@ function FlowListRow({
 }
 
 function RecipientCard({
-  recipient, expanded, onToggle, totalAmount, barColor,
+  recipient, expanded, onToggle, totalAmount, barColor, scaleFont,
 }: {
   recipient: BlockRecipient;
   expanded: boolean;
   onToggle: () => void;
   totalAmount: number;
   barColor: string;
+  scaleFont: (px: number) => number;
 }) {
   const hasDetails = recipient.contractSummaries.length > 0 || recipient.expenses.length > 0;
   const share = totalAmount > 0 ? Math.max(2, Math.min(100, (recipient.amount / totalAmount) * 100)) : 0;
+  const PANEL_LIST_NAME_FONT_PX = scaleFont(PANEL_LIST_NAME_FONT_PX_DEFAULT);
+  const PANEL_LIST_VALUE_FONT_PX = scaleFont(PANEL_LIST_VALUE_FONT_PX_DEFAULT);
+  const PANEL_META_FONT_PX = scaleFont(PANEL_META_FONT_PX_DEFAULT);
 
   return (
     <div style={{
@@ -960,6 +988,11 @@ function SubcontractDetailPageInner() {
   const [activeTab, setActiveTab] = useState<PaneTab>('flow');
   // サイドパネル（右）の chrome 状態。既定幅は現状の SidePane 固定幅(390)を維持
   const rightSidePanel = useSidePanel({ side: 'right', defaultWidth: SUBCONTRACT_PANEL_WIDTH_DEFAULT });
+  // 基準フォントサイズ（サンキーと同じ localStorage 永続化方式。キーはページごとに分離）
+  const [baseFontPx, setBaseFontPx] = useBaseFontPx(
+    'subcontracts-detail-base-font-px', BASE_FONT_PX_DEFAULT, BASE_FONT_PX_MIN, BASE_FONT_PX_MAX,
+  );
+  const scaleFont = useMemo(() => createScaleFont(baseFontPx), [baseFontPx]);
 
   const beginHoverSuppressCooldown = useCallback(() => {
     setIsHoverSuppressed(true);
@@ -1365,12 +1398,12 @@ function SubcontractDetailPageInner() {
                         fontFamily: 'inherit',
                       }}>
                         {amountLabel && (
-                          <div style={{ fontSize: 9, fontWeight: 700, color: '#475569', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: '#475569', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                             {amountLabel}
                           </div>
                         )}
                         {edge.note && (
-                          <div style={{ fontSize: 8, fontWeight: 600, color: '#64748b', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <div style={{ fontSize: scaleFont(8), fontWeight: 600, color: '#64748b', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                             {edge.note}
                           </div>
                         )}
@@ -1448,10 +1481,10 @@ function SubcontractDetailPageInner() {
                 style={{ pointerEvents: 'none' }}
               >
                 <div style={{ fontFamily: 'inherit', userSelect: 'none' }}>
-                  <div style={{ fontSize: 9, fontWeight: 700, color: 'rgba(255,255,255,0.78)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: 'rgba(255,255,255,0.78)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     事業 / PID {graph.projectId}
                   </div>
-                  <div style={{ fontSize: 11, fontWeight: 700, color: '#fff', lineHeight: '13px', marginTop: 3, ...CLAMP_2_LINES }}>
+                  <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: '#fff', lineHeight: '13px', marginTop: 3, ...CLAMP_2_LINES }}>
                     {graph.projectName}
                   </div>
                 </div>
@@ -1463,10 +1496,10 @@ function SubcontractDetailPageInner() {
                 height={44}
                 style={{ pointerEvents: 'none' }}
               >
-                <div style={{ fontFamily: 'inherit', fontSize: 9, userSelect: 'none' }}>
+                <div style={{ fontFamily: 'inherit', fontSize: scaleFont(9), userSelect: 'none' }}>
                   <div style={{ display: 'flex', gap: 4, alignItems: 'baseline' }}>
                     <span style={{ fontWeight: 700, color: COLOR_CONTEXT_BODY_SUBTLE, flexShrink: 0, width: 48 }}>府省庁</span>
-                    <span style={{ fontWeight: 700, fontSize: 10, color: COLOR_CONTEXT_BODY_TEXT, minWidth: 0, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <span style={{ fontWeight: 700, fontSize: scaleFont(10), color: COLOR_CONTEXT_BODY_TEXT, minWidth: 0, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {graph.ministry}
                     </span>
                   </div>
@@ -1484,7 +1517,7 @@ function SubcontractDetailPageInner() {
                 x={safeLayout.root.x + safeLayout.root.w - 14}
                 y={safeLayout.root.y + safeLayout.root.h - 24}
                 textAnchor="end"
-                fontSize={9}
+                fontSize={scaleFont(9)}
                 fontWeight={700}
                 fill={COLOR_CONTEXT_BODY_SUBTLE}
                 style={{ userSelect: 'none' }}
@@ -1562,10 +1595,10 @@ function SubcontractDetailPageInner() {
                     style={{ pointerEvents: 'none' }}
                   >
                     <div style={{ fontFamily: 'inherit', userSelect: 'none' }}>
-                      <div style={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.86)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div style={{ fontSize: scaleFont(10), fontWeight: 700, color: 'rgba(255,255,255,0.86)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {headerKindLabel} / ブロック {lb.blockId}
                       </div>
-                      <div style={{ fontSize: 12, fontWeight: 700, color: '#fff', marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div style={{ fontSize: scaleFont(12), fontWeight: 700, color: '#fff', marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {lb.blockName}
                       </div>
                     </div>
@@ -1579,18 +1612,18 @@ function SubcontractDetailPageInner() {
                     style={{ pointerEvents: 'none' }}
                   >
                     <div style={{ fontFamily: 'inherit', userSelect: 'none' }}>
-                      <div style={{ fontSize: 11, fontWeight: 700, color: bodyTextColor, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: bodyTextColor, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {lb.isZeroAmount ? '金額内訳なし' : `${formatYen(lb.totalAmount)} / 支出先 ${recipients.length.toLocaleString()}件`}
                       </div>
                       {lb.node.role && (
-                        <div style={{ fontSize: 9, fontWeight: 600, color: bodySubtleTextColor, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <div style={{ fontSize: scaleFont(9), fontWeight: 600, color: bodySubtleTextColor, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           {lb.node.role}
                         </div>
                       )}
                       {!lb.isZeroAmount && topRecipients.map((r, i) => (
                         <div
                           key={`${r.name}-${r.corporateNumber}-${i}`}
-                          style={{ display: 'flex', gap: 4, alignItems: 'baseline', fontSize: 9, color: bodyTextColor, marginTop: i === 0 ? 6 : 3 }}
+                          style={{ display: 'flex', gap: 4, alignItems: 'baseline', fontSize: scaleFont(9), color: bodyTextColor, marginTop: i === 0 ? 6 : 3 }}
                         >
                           <span style={{ fontWeight: 700, flexShrink: 0 }}>{i + 1}.</span>
                           <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -1653,7 +1686,7 @@ function SubcontractDetailPageInner() {
                 background: headerColor,
                 color: '#fff',
                 padding: '7px 10px',
-                fontSize: 11,
+                fontSize: scaleFont(11),
                 fontWeight: 700,
                 lineHeight: 1.35,
               }}>
@@ -1661,7 +1694,7 @@ function SubcontractDetailPageInner() {
                   ? `事業 / PID ${graph.projectId}`
                   : `${palette!.badgeText} / ブロック ${lb!.blockId}`}
               </div>
-              <div style={{ padding: '8px 10px', fontSize: 11, lineHeight: 1.45, color: textColor }}>
+              <div style={{ padding: '8px 10px', fontSize: scaleFont(11), lineHeight: 1.45, color: textColor }}>
                 {isRoot ? (
                   <>
                     <div style={{ fontWeight: 700, color: '#111827', marginBottom: 4 }}>{graph.projectName}</div>
@@ -1746,6 +1779,36 @@ function SubcontractDetailPageInner() {
           </div>
         </div>
 
+        {/* フォントサイズコントロール — 左下フローティング（サンキー流儀と同じ配置・操作感） */}
+        <div
+          data-pan-disabled="true"
+          style={{
+            position: 'absolute',
+            left: 12,
+            bottom: 12,
+            zIndex: 15,
+            display: 'flex',
+            alignItems: 'center',
+            background: 'rgba(255,255,255,0.95)',
+            border: '1px solid #e0e0e0',
+            borderRadius: 8,
+            boxShadow: '0 1px 4px rgba(0,0,0,0.12)',
+            padding: '6px 10px',
+          }}
+        >
+          <FontSizeControls
+            baseFontPx={baseFontPx}
+            setBaseFontPx={setBaseFontPx}
+            markReplace={() => {}}
+            isCompactWidth={false}
+            min={BASE_FONT_PX_MIN}
+            max={BASE_FONT_PX_MAX}
+            defaultValue={BASE_FONT_PX_DEFAULT}
+            controlSmallFontPx={scaleFont(12)}
+            numberFontPx={11}
+          />
+        </div>
+
       </div>
 
         {/* サイドパネル */}
@@ -1770,6 +1833,7 @@ function SubcontractDetailPageInner() {
             onChangeTab={(tab) => { setActiveTab(tab); pushSelTabUrl(selectedBlock?.blockId ?? null, tab); }}
             onSelectBlock={handleSelectFromList}
             onDeselectBlock={() => { setSelectedBlock(null); pushSelTabUrl(null, activeTab); }}
+            scaleFont={scaleFont}
           />
         </SidePanelChrome>
     </div>

--- a/app/subcontracts/page.tsx
+++ b/app/subcontracts/page.tsx
@@ -1,8 +1,28 @@
 'use client';
 
+/**
+ * /subcontracts（一覧） URL=状態パラメータ一覧。
+ * 既定値のときは省略する（クリーンなURL維持）。すべて history.replaceState で同期（debounce後）。
+ *
+ *   year : 年度（既存、2024|2025。既定2025）
+ *   q    : フリーテキスト検索語
+ *   sort : ソートキー（SortKey のいずれか。既定 'projectId' は省略）
+ *   dir  : ソート方向（'asc'|'desc'。sortKey既定時の既定dirは'asc'、それ以外は'desc'。一致時は省略）
+ *   page : ページ番号（1始まり。既定1は省略）
+ *   fp   : フィルタパネル開閉（'1'で開）
+ *   fm   : 省庁フィルタ（複数選択、複数指定可）
+ *   fac  : 会計区分フィルタ（複数選択、複数指定可）
+ *   fst  : 構造フィルタ（複数選択、複数指定可）
+ *   fnp  : 事業名テキストフィルタ
+ *   fbu  : 担当組織テキストフィルタ
+ *   bmin/bmax : 予算額 Min/Max
+ *   emin/emax : 執行額 Min/Max
+ *   dmin/dmax : 直接支出合計 Min/Max
+ *   tmin/tmax : 支出額合計 Min/Max
+ */
 import { useState, useEffect, useMemo, useRef, Suspense, type CSSProperties, type ReactNode } from 'react';
 import Link from 'next/link';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { FilterRow } from '@/components/filters/FilterRow';
 import { FilterTextInput } from '@/components/filters/FilterTextInput';
 import { MinMaxInput } from '@/components/filters/MinMaxInput';
@@ -44,6 +64,23 @@ const STRING_SORT_KEYS: ReadonlySet<SortKey> = new Set<SortKey>([
   'accountCategory',
 ]);
 type SortDir = 'asc' | 'desc';
+
+const SORT_KEY_SET: ReadonlySet<string> = new Set<SortKey>([
+  'projectId', 'projectName', 'ministry', 'bureau', 'accountCategory',
+  'budget', 'execution', 'directExpenseTotal', 'totalExpense',
+  'totalMinusDirect', 'executionMinusDirect', 'maxDepth',
+  'totalBlockCount', 'directBlockCount', 'subcontractBlockCount',
+  'indirectCostCount', 'separateOriginCount', 'totalRecipientCount',
+  'branchingBlockCount', 'maxBranchWidth', 'mergeTargetCount', 'maxMergeWidth',
+  'institutional',
+]);
+function isSortKey(v: string): v is SortKey {
+  return SORT_KEY_SET.has(v);
+}
+// sortKey切替時の既定方向（toggleSortの既定と一致させ、URL省略時の復元を揃える）
+function defaultSortDir(key: SortKey): SortDir {
+  return key === 'projectId' ? 'asc' : 'desc';
+}
 
 const PAGE_SIZE = 50;
 const COLUMN_WIDTH_STORAGE_KEY = 'subcontracts-column-widths';
@@ -116,7 +153,6 @@ function loadColumnWidths(): number[] {
 
 function SubcontractsPageInner() {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const [year, setYear] = useState(() => {
     const y = parseInt(searchParams.get('year') ?? '2025', 10);
     return [2024, 2025].includes(y) ? y : 2025;
@@ -124,30 +160,41 @@ function SubcontractsPageInner() {
   const [graphs, setGraphs] = useState<SubcontractGraph[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
-  const [sortKey, setSortKey] = useState<SortKey>('projectId');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '');
+  const [sortKey, setSortKey] = useState<SortKey>(() => {
+    const s = searchParams.get('sort');
+    return s && isSortKey(s) ? s : 'projectId';
+  });
+  const [sortDir, setSortDir] = useState<SortDir>(() => {
+    const s = searchParams.get('sort');
+    const key: SortKey = s && isSortKey(s) ? s : 'projectId';
+    const d = searchParams.get('dir');
+    return d === 'asc' || d === 'desc' ? d : defaultSortDir(key);
+  });
   // 複数選択フィルタ
-  const [selectedMinistries, setSelectedMinistries] = useState<string[]>([]);
+  const [selectedMinistries, setSelectedMinistries] = useState<string[]>(() => searchParams.getAll('fm'));
   // 会計区分（'一般会計' | '特別会計' | '一般・特別' | '区分なし'）の複数選択
-  const [selectedAccountCategories, setSelectedAccountCategories] = useState<string[]>([]);
+  const [selectedAccountCategories, setSelectedAccountCategories] = useState<string[]>(() => searchParams.getAll('fac'));
   // 構造（'別財源あり' | '合流あり' | '制度フローのみ'）の複数選択（OR）
-  const [selectedStructures, setSelectedStructures] = useState<string[]>([]);
+  const [selectedStructures, setSelectedStructures] = useState<string[]>(() => searchParams.getAll('fst'));
   // 名称・組織テキストフィルタ
-  const [filterProjectName, setFilterProjectName] = useState('');
-  const [filterBureau, setFilterBureau] = useState('');
+  const [filterProjectName, setFilterProjectName] = useState(() => searchParams.get('fnp') ?? '');
+  const [filterBureau, setFilterBureau] = useState(() => searchParams.get('fbu') ?? '');
   // 金額 Min/Max
-  const [filterBudgetMin, setFilterBudgetMin] = useState('');
-  const [filterBudgetMax, setFilterBudgetMax] = useState('');
-  const [filterExecutionMin, setFilterExecutionMin] = useState('');
-  const [filterExecutionMax, setFilterExecutionMax] = useState('');
-  const [filterDirectMin, setFilterDirectMin] = useState('');
-  const [filterDirectMax, setFilterDirectMax] = useState('');
-  const [filterTotalExpenseMin, setFilterTotalExpenseMin] = useState('');
-  const [filterTotalExpenseMax, setFilterTotalExpenseMax] = useState('');
+  const [filterBudgetMin, setFilterBudgetMin] = useState(() => searchParams.get('bmin') ?? '');
+  const [filterBudgetMax, setFilterBudgetMax] = useState(() => searchParams.get('bmax') ?? '');
+  const [filterExecutionMin, setFilterExecutionMin] = useState(() => searchParams.get('emin') ?? '');
+  const [filterExecutionMax, setFilterExecutionMax] = useState(() => searchParams.get('emax') ?? '');
+  const [filterDirectMin, setFilterDirectMin] = useState(() => searchParams.get('dmin') ?? '');
+  const [filterDirectMax, setFilterDirectMax] = useState(() => searchParams.get('dmax') ?? '');
+  const [filterTotalExpenseMin, setFilterTotalExpenseMin] = useState(() => searchParams.get('tmin') ?? '');
+  const [filterTotalExpenseMax, setFilterTotalExpenseMax] = useState(() => searchParams.get('tmax') ?? '');
   // 折りたたみパネル
-  const [showFilterPanel, setShowFilterPanel] = useState(false);
-  const [page, setPage] = useState(1);
+  const [showFilterPanel, setShowFilterPanel] = useState(() => searchParams.get('fp') === '1');
+  const [page, setPage] = useState(() => {
+    const p = Number(searchParams.get('page'));
+    return Number.isInteger(p) && p >= 1 ? p : 1;
+  });
   const [columnWidths, setColumnWidths] = useState(loadColumnWidths);
   const resizingColumnRef = useRef<{ index: number; startX: number; startWidth: number } | null>(null);
   const savedColumnWidthsRef = useRef<string | null>(null);
@@ -232,6 +279,43 @@ function SubcontractsPageInner() {
       document.body.style.userSelect = '';
     };
   }, []);
+
+  // URL=状態同期（検索・ソート・フィルタ・ページ・年度）。history.replaceState、打鍵はdebounce後に反映
+  const listUrlMountedRef = useRef(false);
+  useEffect(() => {
+    if (!listUrlMountedRef.current) { listUrlMountedRef.current = true; return; }
+    const timer = window.setTimeout(() => {
+      const p = new URLSearchParams();
+      if (year !== 2025) p.set('year', String(year));
+      if (query) p.set('q', query);
+      if (sortKey !== 'projectId') p.set('sort', sortKey);
+      if (sortDir !== defaultSortDir(sortKey)) p.set('dir', sortDir);
+      if (page !== 1) p.set('page', String(page));
+      if (showFilterPanel) p.set('fp', '1');
+      for (const m of selectedMinistries) p.append('fm', m);
+      for (const a of selectedAccountCategories) p.append('fac', a);
+      for (const s of selectedStructures) p.append('fst', s);
+      if (filterProjectName) p.set('fnp', filterProjectName);
+      if (filterBureau) p.set('fbu', filterBureau);
+      if (filterBudgetMin) p.set('bmin', filterBudgetMin);
+      if (filterBudgetMax) p.set('bmax', filterBudgetMax);
+      if (filterExecutionMin) p.set('emin', filterExecutionMin);
+      if (filterExecutionMax) p.set('emax', filterExecutionMax);
+      if (filterDirectMin) p.set('dmin', filterDirectMin);
+      if (filterDirectMax) p.set('dmax', filterDirectMax);
+      if (filterTotalExpenseMin) p.set('tmin', filterTotalExpenseMin);
+      if (filterTotalExpenseMax) p.set('tmax', filterTotalExpenseMax);
+      const qs = p.toString();
+      window.history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
+    }, 200);
+    return () => window.clearTimeout(timer);
+  }, [
+    year, query, sortKey, sortDir, page, showFilterPanel,
+    selectedMinistries, selectedAccountCategories, selectedStructures,
+    filterProjectName, filterBureau,
+    filterBudgetMin, filterBudgetMax, filterExecutionMin, filterExecutionMax,
+    filterDirectMin, filterDirectMax, filterTotalExpenseMin, filterTotalExpenseMax,
+  ]);
 
   // 金額フィルタの解析
   const budgetMinYen = parseAmountToYen(filterBudgetMin);
@@ -525,7 +609,7 @@ function SubcontractsPageInner() {
           <div style={{ position: 'relative', flexShrink: 0 }}>
             <select
               value={year}
-              onChange={(e) => { const y = Number(e.target.value); setYear(y); router.replace(`/subcontracts?year=${y}`); }}
+              onChange={(e) => setYear(Number(e.target.value))}
               style={{
                 fontSize: 13,
                 border: '1px solid #e0e0e0',

--- a/app/subcontracts/page.tsx
+++ b/app/subcontracts/page.tsx
@@ -441,6 +441,11 @@ function SubcontractsPageInner() {
   }
 
   const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  // URL復元由来の page が実ページ数を超えている場合はクランプ（空テーブル+「次へ」有効の防止）。
+  // loading 中はデータ未着で totalPages=1 になるため、確定後にのみ判定する
+  if (!loading && page > totalPages) {
+    setPage(totalPages);
+  }
   const pageItems = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   function toggleSort(key: SortKey) {

--- a/client/hooks/useBaseFontPx.ts
+++ b/client/hooks/useBaseFontPx.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+/**
+ * 基準フォントサイズ（baseFontPx）を localStorage に永続化する状態フック。
+ *
+ * サンキー（app/sankey-svg/page.tsx）の現行方式（URLパラメータには含めず localStorage のみで保持）を
+ * そのまま踏襲する。ページごとに storageKey を分けて使うこと。
+ */
+export function useBaseFontPx(
+  storageKey: string,
+  defaultValue: number,
+  min: number,
+  max: number,
+): [number, Dispatch<SetStateAction<number>>] {
+  const [baseFontPx, setBaseFontPx] = useState(defaultValue);
+
+  // Restore font size from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(storageKey);
+      if (saved !== null) {
+        const parsed = parseInt(saved, 10);
+        if (!isNaN(parsed)) {
+          setBaseFontPx(Math.min(max, Math.max(min, parsed)));
+        }
+      }
+    } catch {
+      // localStorage unavailable (private browsing etc.) — ignore
+    }
+    // 初回マウント時のみ復元する（min/max/storageKey の変化では再実行しない）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist font size to localStorage on change
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, String(baseFontPx));
+    } catch {
+      // ignore
+    }
+  }, [storageKey, baseFontPx]);
+
+  return [baseFontPx, setBaseFontPx];
+}


### PR DESCRIPTION
## 目的

/subcontracts の状態（検索・フィルタ・選択・ズーム）が共有・リロードで失われる問題と、文字サイズ調整に非対応な問題を解消し、サンキー図の設計原則（URL=状態・scaleFont）との一貫性土台を完成させるため。

設計: `docs/tasks/20260711_0616_subcontracts_UI改善アイデア.md` 層B-6/B-7（PR3）。これで層Bが完了し、以後は方向性判断（現UI磨き込み or サンキー統一モデルチェンジ）に応じて層Cへ。

## 変更内容

### URL=状態化（層B-7）

- **一覧**: `q/sort/dir/page/フィルタ群` を replaceState（200ms debounce・既定値は省略）。既存の year 個別同期は統合
- **詳細**: `sel`（選択ブロック）/`tab` は **pushState**（ブラウザバックで選択が戻る・サンキーの sel と同セマンティクス）、`z/tx/ty`（ズーム/パン）は replaceState（500ms debounce）。自動フィット由来の書き込みは抑制し手動操作のみ記録
- popstate 復元・初回マウント復元（不明な blockId は無視）。パラメータ一覧は各ファイル冒頭コメント

### フォントスケール（層B-6）

- サンキーの機構を `app/lib/font-scale.ts` + `client/hooks/useBaseFontPx.ts` に抽出して共有（サンキー側は同ロジック・同キーで挙動不変）
- 詳細ページの px 直書き（SVG/foreignObject ラベル・エッジラベル・ツールチップ・パネル定数）を scaleFont 経由に置換。**既定値 12px では scale=1 のためレンダリング不変**
- FontSizeControls をキャンバス左下に露出。localStorage キーは subcontracts 専用で独立永続化

## テスト方法

```bash
npm run dev
# 詳細: ブロック選択+タブ+ズーム → リロード再現・ブラウザバックで選択が戻る・URL共有で同じ状態
# 一覧: 検索+ソート+2ページ目 → URL共有で再現
# フォント: 左下コントロールでラベル・ツールチップ・パネルが連動拡縮・リロード維持
# 回帰: /sankey-svg のフォントコントロール・URL同期が従来どおり
```

- `npx tsc --noEmit` エラー0 / `npm run lint` 新規警告なし / 状態付きURLの直叩き200確認・ユーザー目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added font-size controls to subcontract detail views, with preferences saved between visits.
  - Applied consistent adjustable text sizing across panels, labels, tooltips, and charts.
  - Added URL-synchronized state for subcontract filters, sorting, pagination, selections, tabs, and chart view position.
  - Browser back and forward navigation now restores subcontract list and detail-view state.
  - Improved font scaling consistency in Sankey visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->