### PR TITLE
chore(test): vitest 導入と app/lib Pure関数の最小ユニットテスト71件

### DIFF
--- a/.claude/commands/quality-check.md
+++ b/.claude/commands/quality-check.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(npm run lint:*), Bash(npx tsc:*)
-description: lint と TypeScript 型チェックを実行する
+allowed-tools: Bash(npm run lint:*), Bash(npx tsc:*), Bash(npm test:*)
+description: lint と TypeScript 型チェックとユニットテストを実行する
 ---
 
 ## タスク
@@ -21,7 +21,14 @@ description: lint と TypeScript 型チェックを実行する
    - エラーがある場合はユーザーに報告して修正を提案する
    - エラーがない場合は「型チェック OK」と報告する
 
+3. **ユニットテスト**（vitest・app/lib/ の Pure 関数対象・実データ非依存）
+   ```bash
+   npm test
+   ```
+   - 失敗がある場合はユーザーに報告して修正を提案する
+
 ## 完了条件
 
 - lint エラー 0件
 - tsc エラー 0件
+- テスト全件パス

--- a/app/lib/ai/sankey-chat-agent.test.ts
+++ b/app/lib/ai/sankey-chat-agent.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// runSankeyChatAgent calls loadSankeyGraph(year) directly (module-level import, not injected),
+// so we mock the loader module to avoid touching public/data/*.json fixtures. All three scenarios
+// below only ever reach loadSankeyGraph (via the initial ministryNames lookup and/or
+// executeQuery/run_sankey_query/submit_result), so this single mock is sufficient — the other
+// loaders (quality-scores, recipient-index, project-details, subcontracts, highlights) are never
+// invoked because the mocked LLM never calls search_projects/get_project_detail/etc.
+// vi.mock factories are hoisted above imports, so the fixture must be built with vi.hoisted().
+const fixtureGraph = vi.hoisted(() => ({
+  metadata: {
+    totalBudget: 0,
+    totalSpending: 0,
+    directSpending: 0,
+    indirectSpending: 0,
+    ministryCount: 1,
+    projectCount: 0,
+    recipientCount: 0,
+  },
+  nodes: [
+    { id: 'ministry-A省', name: 'A省', type: 'ministry', value: 0 },
+  ],
+  edges: [],
+}));
+
+vi.mock('@/app/lib/api/sankey-graph-loader', () => ({
+  loadSankeyGraph: vi.fn(() => fixtureGraph),
+}));
+
+const { runSankeyChatAgent } = await import('@/app/lib/ai/sankey-chat-agent');
+// Mirrors the unexported MAX_TOOL_CALLS constant in sankey-chat-agent.ts. Per the task spec we
+// must not export internal helpers just to test them, so this is duplicated here deliberately.
+const MAX_TOOL_CALLS_FOR_TEST = 10;
+
+import type { LlmCaller, LlmMessage } from '@/app/lib/ai/sankey-chat-agent';
+
+describe('runSankeyChatAgent', () => {
+  it('(a) a plain-text response with no tool_calls ends the run immediately', async () => {
+    const callLlm: LlmCaller = vi.fn(async (): Promise<LlmMessage> => ({
+      role: 'assistant',
+      content: 'これはフィルタ条件ではなく雑談的な質問ですね。',
+    }));
+
+    const result = await runSankeyChatAgent([{ role: 'user', content: 'こんにちは' }], { year: '2024' }, callLlm);
+
+    expect(result.message).toBe('これはフィルタ条件ではなく雑談的な質問ですね。');
+    expect(result.result).toBeUndefined();
+    expect(result.toolCalls).toBe(0);
+    expect(callLlm).toHaveBeenCalledTimes(1);
+  });
+
+  it('(b) a submit_result tool call finalizes the run with a query + summary', async () => {
+    const callLlm: LlmCaller = vi.fn(async (): Promise<LlmMessage> => ({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'submit_result',
+            arguments: JSON.stringify({ query: { year: '2024' }, message: 'デジタル庁の事業に絞り込みました。' }),
+          },
+        },
+      ],
+    }));
+
+    const result = await runSankeyChatAgent([{ role: 'user', content: 'デジタル庁だけ見せて' }], { year: '2024' }, callLlm);
+
+    expect(result.message).toBe('デジタル庁の事業に絞り込みました。');
+    expect(result.result).toBeDefined();
+    expect(result.result?.query.year).toBe('2024');
+    expect(result.result?.summary).toBeDefined();
+    expect(result.toolCalls).toBe(1);
+    expect(callLlm).toHaveBeenCalledTimes(1);
+  });
+
+  it('(c) exceeding the tool-call budget yields an error payload for the overflow calls and the run eventually gives up', async () => {
+    let round = 0;
+    const callLlm: LlmCaller = vi.fn(async (): Promise<LlmMessage> => {
+      round++;
+      if (round === 1) {
+        // Emit more tool calls in a single round than MAX_TOOL_CALLS (10) allows.
+        return {
+          role: 'assistant',
+          content: null,
+          tool_calls: Array.from({ length: MAX_TOOL_CALLS_FOR_TEST + 2 }, (_, i) => ({
+            id: `call-${i}`,
+            type: 'function' as const,
+            function: { name: 'run_sankey_query', arguments: JSON.stringify({ query: {} }) },
+          })),
+        };
+      }
+      // Subsequent round: end with plain text so the loop terminates deterministically.
+      return { role: 'assistant', content: '今回はここまでにします。' };
+    });
+
+    const result = await runSankeyChatAgent([{ role: 'user', content: '絞り込んで' }], { year: '2024' }, callLlm);
+
+    expect(result.toolCalls).toBe(MAX_TOOL_CALLS_FOR_TEST + 2);
+    expect(result.message).toBe('今回はここまでにします。');
+    // Verify at least one overflow call actually received the budget-exceeded error payload
+    // by inspecting the tool messages fed back to the LLM on the second round.
+    const secondRoundCallArgs = (callLlm as ReturnType<typeof vi.fn>).mock.calls[1][0] as LlmMessage[];
+    const toolMessages = secondRoundCallArgs.filter(m => m.role === 'tool');
+    expect(toolMessages).toHaveLength(MAX_TOOL_CALLS_FOR_TEST + 2);
+    const overflowPayloads = toolMessages.slice(MAX_TOOL_CALLS_FOR_TEST).map(m => JSON.parse(m.content ?? '{}'));
+    for (const payload of overflowPayloads) {
+      expect(payload.error).toMatch(/上限/);
+    }
+  });
+});

--- a/app/lib/api/quality-scores-loader.ts
+++ b/app/lib/api/quality-scores-loader.ts
@@ -29,7 +29,8 @@ export interface QualityScoreItem {
   cnEmpty: number;
   cnFillRatio: number | null;
   budgetAmount: number;
-  execAmount: number;
+  // 生JSONで null になりうる（gapRatio が number|null なのと同源。highlights.ts も null ガード済み）
+  execAmount: number | null;
   spendTotal: number;
   spendNetTotal: number;
   gapRatio: number | null;

--- a/app/lib/font-scale.test.ts
+++ b/app/lib/font-scale.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { createScaleFont, FONT_SCALE_REFERENCE_PX } from '@/app/lib/font-scale';
+
+describe('createScaleFont', () => {
+  it('is the identity function (rounded) at the reference baseline', () => {
+    const scaleFont = createScaleFont(FONT_SCALE_REFERENCE_PX);
+    expect(scaleFont(12)).toBe(12);
+    expect(scaleFont(20)).toBe(20);
+    expect(scaleFont(1)).toBe(1);
+  });
+
+  it('scales proportionally when baseFontPx differs from the reference', () => {
+    const scaleFont = createScaleFont(24, FONT_SCALE_REFERENCE_PX); // 2x scale
+    expect(scaleFont(12)).toBe(24);
+    expect(scaleFont(10)).toBe(20);
+  });
+
+  it('rounds to the nearest integer', () => {
+    const scaleFont = createScaleFont(13, FONT_SCALE_REFERENCE_PX); // scale factor 13/12
+    // 10 * 13/12 = 10.833... -> rounds to 11
+    expect(scaleFont(10)).toBe(11);
+  });
+
+  it('never returns less than 1 even for very small px or scale', () => {
+    const scaleFont = createScaleFont(1, FONT_SCALE_REFERENCE_PX); // scale factor 1/12
+    expect(scaleFont(1)).toBe(1);
+    expect(scaleFont(0)).toBe(1);
+  });
+
+  it('supports a custom referencePx', () => {
+    const scaleFont = createScaleFont(10, 10);
+    expect(scaleFont(16)).toBe(16);
+  });
+});

--- a/app/lib/highlights.test.ts
+++ b/app/lib/highlights.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import type { RawNode, RawEdge } from '@/types/sankey-svg';
+import type { QualityScoreItem } from '@/app/lib/api/quality-scores-loader';
+import {
+  computeHighlights,
+  HIGHLIGHTS_MIN_SPEND_YEN,
+  HIGHLIGHTS_MULTI_SIGNAL_MIN_METRICS,
+} from '@/app/lib/highlights';
+
+function makeQualityItem(overrides: Partial<QualityScoreItem> & Pick<QualityScoreItem, 'pid' | 'name'>): QualityScoreItem {
+  return {
+    ministry: 'A省',
+    bureau: '',
+    division: '',
+    section: '',
+    office: '',
+    team: '',
+    unit: '',
+    rowCount: 1,
+    validCount: 1,
+    govAgencyCount: 0,
+    suppValidCount: 0,
+    invalidCount: 0,
+    validRatio: 1,
+    cnFilled: 1,
+    cnEmpty: 0,
+    cnFillRatio: 1,
+    budgetAmount: 0,
+    execAmount: 0,
+    spendTotal: 0,
+    spendNetTotal: 0,
+    gapRatio: null,
+    blockCount: 1,
+    orphanBlockCount: 0,
+    hasRedelegation: false,
+    redelegationDepth: 0,
+    opaqueRatio: null,
+    axis1: null,
+    axis2: null,
+    axis3: null,
+    axis4: null,
+    axis5: null,
+    totalScore: null,
+    ...overrides,
+  };
+}
+
+function makeNode(overrides: Partial<RawNode> & Pick<RawNode, 'id' | 'name' | 'type' | 'value'>): RawNode {
+  return { ...overrides };
+}
+
+describe('computeHighlights', () => {
+  it('excludes projects below HIGHLIGHTS_MIN_SPEND_YEN from otherRatio/concentration population', () => {
+    const nodes: RawNode[] = [
+      makeNode({ id: 'project-spending-1', name: '小規模事業', type: 'project-spending', value: 0, projectId: 1 }),
+      makeNode({ id: 'r-2', name: 'その他', type: 'recipient', value: 0 }),
+    ];
+    const edges: RawEdge[] = [
+      { source: 'project-spending-1', target: 'r-2', value: HIGHLIGHTS_MIN_SPEND_YEN - 1 },
+    ];
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: '小規模事業', spendTotal: HIGHLIGHTS_MIN_SPEND_YEN - 1 }),
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes, edges },
+      qualityItems,
+    });
+    expect(result.meta.otherRatioPopulation).toBe(0);
+    expect(result.meta.concentrationPopulation).toBe(0);
+    expect(result.metrics.otherRatio).toEqual([]);
+  });
+
+  it('includes projects at or above HIGHLIGHTS_MIN_SPEND_YEN in the otherRatio population', () => {
+    const nodes: RawNode[] = [
+      makeNode({ id: 'project-spending-1', name: '大規模事業', type: 'project-spending', value: 0, projectId: 1 }),
+      makeNode({ id: 'r-2', name: 'その他', type: 'recipient', value: 0 }),
+    ];
+    const edges: RawEdge[] = [
+      { source: 'project-spending-1', target: 'r-2', value: HIGHLIGHTS_MIN_SPEND_YEN },
+    ];
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: '大規模事業', spendTotal: HIGHLIGHTS_MIN_SPEND_YEN }),
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes, edges },
+      qualityItems,
+    });
+    expect(result.meta.otherRatioPopulation).toBe(1);
+    expect(result.metrics.otherRatio).toHaveLength(1);
+    expect(result.metrics.otherRatio[0].otherRatio).toBe(1);
+  });
+
+  it('multiSignal requires HIGHLIGHTS_MULTI_SIGNAL_MIN_METRICS (2+) co-occurring metrics', () => {
+    expect(HIGHLIGHTS_MULTI_SIGNAL_MIN_METRICS).toBe(2);
+    // Empty graph -> otherRatio/concentration never fire; only lowScoreHighBudget and
+    // execBudgetGap are in play here.
+    // pid1: very low totalScore (lowScore signal) but gapRatio=0, ranked out of execBudgetGap's
+    //   top10 by 11 other higher-gap items -> single signal only, excluded from multiSignal.
+    // pid2: very low totalScore AND a large gapRatio that ranks #1 in execBudgetGap -> 2 signals.
+    const fillers: QualityScoreItem[] = Array.from({ length: 11 }, (_, i) =>
+      makeQualityItem({
+        pid: `p${i + 3}`,
+        name: `事業${i + 3}`,
+        totalScore: (i + 1) * 10 + 20, // 30..140, well above the low-score threshold
+        budgetAmount: 100,
+        execAmount: 100 + (i + 1) * 50, // gapRatio 0.5..5.5, all > pid1's gapRatio of 0
+      }),
+    );
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: '事業1', totalScore: 1, budgetAmount: 100, execAmount: 100 }),
+      makeQualityItem({ pid: '2', name: '事業2', totalScore: 2, budgetAmount: 100, execAmount: 1200 }),
+      ...fillers,
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems,
+    });
+    // Sanity: pid1 has a lowScore signal but is pushed out of execBudgetGap's top 10
+    expect(result.metrics.lowScoreHighBudget.map(e => e.pid)).toContain('1');
+    expect(result.metrics.execBudgetGap.map(e => e.pid)).not.toContain('1');
+
+    const pids = result.multiSignal.map(m => m.pid);
+    expect(pids).toContain('2');
+    expect(pids).not.toContain('1');
+    const entry2 = result.multiSignal.find(m => m.pid === '2')!;
+    expect(entry2.signals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('execBudgetGap excludes items with budgetAmount <= 0', () => {
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: 'ゼロ予算事業', budgetAmount: 0, execAmount: 1000 }),
+      makeQualityItem({ pid: '2', name: '負予算事業', budgetAmount: -100, execAmount: 1000 }),
+      makeQualityItem({ pid: '3', name: '正常事業', budgetAmount: 100, execAmount: 200 }),
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems,
+    });
+    const pids = result.metrics.execBudgetGap.map(e => e.pid);
+    expect(pids).toEqual(['3']);
+  });
+
+  it('execBudgetGap excludes items with null execAmount', () => {
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: '執行額未定', budgetAmount: 100, execAmount: null as unknown as number }),
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems,
+    });
+    expect(result.metrics.execBudgetGap).toEqual([]);
+  });
+
+  it('computes lowScoreHighBudget threshold via nearest-rank method (ceil(n*0.25)-1) on a small sample', () => {
+    // 8 items with totalScore 10,20,...,80 and budgetAmount>0.
+    // sorted ascending: [10,20,30,40,50,60,70,80]; idx = ceil(8*0.25)-1 = 2-1 = 1 -> threshold = 20
+    const qualityItems: QualityScoreItem[] = Array.from({ length: 8 }, (_, i) =>
+      makeQualityItem({
+        pid: String(i + 1),
+        name: `事業${i + 1}`,
+        totalScore: (i + 1) * 10,
+        budgetAmount: 1000,
+      }),
+    );
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems,
+    });
+    expect(result.meta.lowScoreThreshold).toBe(20);
+    // entries: totalScore <= 20 -> pid 1 (score10), pid 2 (score20)
+    const pids = result.metrics.lowScoreHighBudget.map(e => e.pid).sort();
+    expect(pids).toEqual(['1', '2']);
+  });
+
+  it('returns null lowScoreThreshold when no items have both totalScore and budgetAmount > 0', () => {
+    const qualityItems: QualityScoreItem[] = [
+      makeQualityItem({ pid: '1', name: 'スコアなし', totalScore: null, budgetAmount: 1000 }),
+      makeQualityItem({ pid: '2', name: '予算ゼロ', totalScore: 50, budgetAmount: 0 }),
+    ];
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems,
+    });
+    expect(result.meta.lowScoreThreshold).toBeNull();
+    expect(result.metrics.lowScoreHighBudget).toEqual([]);
+  });
+
+  it('spendingChange is empty with priorYear null when no priorGraph is given', () => {
+    const result = computeHighlights({
+      year: '2024',
+      currentGraph: { nodes: [], edges: [] },
+      qualityItems: [],
+    });
+    expect(result.metrics.spendingChange.priorYear).toBeNull();
+    expect(result.metrics.spendingChange.increased).toEqual([]);
+  });
+
+  it('populates spendingChange.priorYear when priorGraph is supplied', () => {
+    const result = computeHighlights({
+      year: '2025',
+      currentGraph: { nodes: [], edges: [] },
+      priorGraph: { year: '2024', nodes: [], edges: [] },
+      qualityItems: [],
+    });
+    expect(result.metrics.spendingChange.priorYear).toBe('2024');
+  });
+});

--- a/app/lib/sankey-query.test.ts
+++ b/app/lib/sankey-query.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import type { RawNode, RawEdge } from '@/types/sankey-svg';
+import type { SankeyQuery } from '@/types/sankey-query';
+import {
+  resolveSankeyQuery,
+  sankeyQueryToUrlParams,
+  sankeyQueryFromUrlParams,
+  summarizeFilteredGraph,
+  compareYearsSummary,
+  TOP_PROJECT_MAX,
+  SANKEY_QUERY_DEFAULTS,
+} from '@/app/lib/sankey-query';
+
+describe('resolveSankeyQuery', () => {
+  it('reports an error for an invalid regex pattern', () => {
+    const { errors } = resolveSankeyQuery({
+      filter: { projectName: { query: '(unterminated', regex: true } },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(/正規表現として不正/);
+  });
+
+  it('reports an error when budget min > max', () => {
+    const { errors } = resolveSankeyQuery({
+      filter: { budget: { min: 100, max: 10 } },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(/min.*max/);
+  });
+
+  it('falls back to the default year when omitted', () => {
+    const { query, errors } = resolveSankeyQuery({});
+    expect(errors).toEqual([]);
+    expect(query.year).toBe(SANKEY_QUERY_DEFAULTS.year);
+  });
+
+  it('clamps topProject above TOP_PROJECT_MAX down to the max', () => {
+    const { query } = resolveSankeyQuery({ view: { topProject: TOP_PROJECT_MAX + 500 } });
+    expect(query.view.topProject).toBe(TOP_PROJECT_MAX);
+  });
+
+  it('clamps topProject below 1 up to 1', () => {
+    const { query } = resolveSankeyQuery({ view: { topProject: -5 } });
+    expect(query.view.topProject).toBe(1);
+  });
+
+  it('rejects an unsupported year value', () => {
+    const { errors } = resolveSankeyQuery({ year: '2099' as unknown as '2024' });
+    expect(errors.some(e => e.includes('year'))).toBe(true);
+  });
+
+  it('flags unknown accountCategories values', () => {
+    const { errors, query } = resolveSankeyQuery({
+      filter: { accountCategories: ['bogus' as never] },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(query.filter.accountCategories).toEqual([]);
+  });
+});
+
+describe('sankeyQueryToUrlParams / sankeyQueryFromUrlParams round trip', () => {
+  it('round-trips amounts, multiple ministries, and regex flag', () => {
+    const input: SankeyQuery = {
+      year: '2025',
+      filter: {
+        projectName: { query: '子育て|保育', regex: true },
+        recipientName: { query: '株式会社テスト' },
+        ministries: ['デジタル庁', '厚生労働省'],
+        budget: { min: 1_000_000_000_000, max: null },
+        spending: { min: null, max: 5_000_000 },
+      },
+      view: { topProject: 120, topRecipient: 80 },
+    };
+    const { query: resolved } = resolveSankeyQuery(input);
+    const params = sankeyQueryToUrlParams(resolved);
+    const roundTripped = sankeyQueryFromUrlParams(params);
+    const { query: resolvedAgain } = resolveSankeyQuery(roundTripped);
+
+    expect(resolvedAgain.year).toBe('2025');
+    expect(resolvedAgain.filter.projectName).toEqual({ query: '子育て|保育', regex: true });
+    expect(resolvedAgain.filter.recipientName).toEqual({ query: '株式会社テスト', regex: false });
+    expect(resolvedAgain.filter.ministries.sort()).toEqual(['デジタル庁', '厚生労働省'].sort());
+    expect(resolvedAgain.filter.budget).toEqual({ min: 1_000_000_000_000, max: null });
+    expect(resolvedAgain.filter.spending).toEqual({ min: null, max: 5_000_000 });
+    expect(resolvedAgain.view.topProject).toBe(120);
+    expect(resolvedAgain.view.topRecipient).toBe(80);
+  });
+
+  it('omits default-valued fields from the URL and keeps them omitted on reparse', () => {
+    const { query: resolved } = resolveSankeyQuery({});
+    const params = sankeyQueryToUrlParams(resolved);
+    expect(params.has('tp')).toBe(false);
+    expect(params.has('tm')).toBe(false);
+    expect(params.has('tr')).toBe(false);
+    expect(params.has('fp')).toBe(false);
+
+    const roundTripped = sankeyQueryFromUrlParams(params);
+    expect(roundTripped.view?.topProject).toBeUndefined();
+    expect(roundTripped.filter).toBeUndefined();
+  });
+
+  it('always writes yr explicitly even at defaults', () => {
+    const { query: resolved } = resolveSankeyQuery({ year: '2024' });
+    const params = sankeyQueryToUrlParams(resolved);
+    expect(params.get('yr')).toBe('2024');
+  });
+});
+
+// ── summarizeFilteredGraph ──
+
+function makeNode(overrides: Partial<RawNode> & Pick<RawNode, 'id' | 'name' | 'type' | 'value'>): RawNode {
+  return { ...overrides };
+}
+
+describe('summarizeFilteredGraph', () => {
+  // Small synthetic graph: 1 ministry, 2 projects, 3 recipients (one named "その他", one aggregated)
+  const nodes: RawNode[] = [
+    makeNode({ id: 'ministry-A', name: 'A省', type: 'ministry', value: 100 }),
+    makeNode({ id: 'project-budget-1', name: '事業1', type: 'project-budget', value: 1000, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-1', name: '事業1', type: 'project-spending', value: 900, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-budget-2', name: '事業2', type: 'project-budget', value: 500, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-2', name: '事業2', type: 'project-spending', value: 400, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'r-1', name: '受領者A', type: 'recipient', value: 600 }),
+    makeNode({ id: 'r-2', name: 'その他', type: 'recipient', value: 300 }),
+    makeNode({ id: 'r-agg', name: 'その他の支出先', type: 'recipient', value: 400, aggregated: true }),
+  ];
+  const edges: RawEdge[] = [
+    { source: 'project-spending-1', target: 'r-1', value: 600 },
+    { source: 'project-spending-1', target: 'r-2', value: 300 },
+    { source: 'project-spending-2', target: 'r-agg', value: 400 },
+  ];
+
+  it('counts, totals, and topShare1/topShare3 correctly', () => {
+    const summary = summarizeFilteredGraph(nodes, edges, null, 10);
+    expect(summary.projects.count).toBe(2);
+    expect(summary.projects.budgetTotal).toBe(1500);
+    expect(summary.projects.spendingTotal).toBe(1300);
+    expect(summary.recipients.count).toBe(3);
+    // non-aggregated total = 600 + 300 = 900; topShare1 = 600/900, topShare3 = 900/900
+    expect(summary.recipients.topShare1).toBeCloseTo(0.6667, 4);
+    expect(summary.recipients.topShare3).toBe(1);
+  });
+
+  it('includes the real "その他" recipient node in topShare (not excluded like aggregated)', () => {
+    const summary = summarizeFilteredGraph(nodes, edges, null, 10);
+    const names = summary.recipients.top.map(r => r.name);
+    expect(names).toContain('その他');
+  });
+
+  it('excludes aggregated nodes from topShare1/topShare3 denominator', () => {
+    // Verify aggregated recipient (r-agg, 400) does not inflate the denominator:
+    // if it were included, topShare1 would be 600/1300 ≈ 0.4615 instead of 0.6667
+    const summary = summarizeFilteredGraph(nodes, edges, null, 10);
+    expect(summary.recipients.topShare1).not.toBeCloseTo(600 / 1300, 4);
+  });
+
+  it('returns null topShare when non-aggregated inflow total is zero', () => {
+    const zeroEdges: RawEdge[] = [{ source: 'project-spending-2', target: 'r-agg', value: 400 }];
+    const summary = summarizeFilteredGraph(nodes, zeroEdges, null, 10);
+    expect(summary.recipients.topShare1).toBeNull();
+    expect(summary.recipients.topShare3).toBeNull();
+  });
+
+  it('excludes nodes present in excludedIds', () => {
+    const excluded = new Set(['project-budget-2', 'project-spending-2', 'r-agg']);
+    const summary = summarizeFilteredGraph(nodes, edges, excluded, 10);
+    expect(summary.projects.count).toBe(1);
+    expect(summary.projects.budgetTotal).toBe(1000);
+  });
+});
+
+describe('compareYearsSummary', () => {
+  const baseNodes: RawNode[] = [
+    makeNode({ id: 'project-budget-1', name: '事業1', type: 'project-budget', value: 1000, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-1', name: '事業1', type: 'project-spending', value: 900, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-budget-2', name: '消滅事業', type: 'project-budget', value: 200, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-2', name: '消滅事業', type: 'project-spending', value: 150, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'r-1', name: '受領者A', type: 'recipient', value: 900 }),
+  ];
+  const baseEdges: RawEdge[] = [
+    { source: 'project-spending-1', target: 'r-1', value: 900 },
+    { source: 'project-spending-2', target: 'r-1', value: 150 },
+  ];
+
+  const compareNodes: RawNode[] = [
+    makeNode({ id: 'project-budget-1', name: '事業1', type: 'project-budget', value: 0, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-1', name: '事業1', type: 'project-spending', value: 1200, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-budget-3', name: '新規事業', type: 'project-budget', value: 300, projectId: 3, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-3', name: '新規事業', type: 'project-spending', value: 300, projectId: 3, ministry: 'A省' }),
+    makeNode({ id: 'r-1', name: '受領者A', type: 'recipient', value: 1500 }),
+  ];
+  const compareEdges: RawEdge[] = [
+    { source: 'project-spending-1', target: 'r-1', value: 1200 },
+    { source: 'project-spending-3', target: 'r-1', value: 300 },
+  ];
+
+  it('classifies increased/decreased/added/removed projects', () => {
+    const result = compareYearsSummary(
+      { nodes: baseNodes, edges: baseEdges, excludedIds: null },
+      { nodes: compareNodes, edges: compareEdges, excludedIds: null },
+    );
+    expect(result.diff.projects.increased.map(p => p.projectId)).toEqual([1]);
+    expect(result.diff.projects.increased[0].spendingDiff).toBe(300); // 1200 - 900
+    expect(result.diff.projects.added.map(p => p.projectId)).toEqual([3]);
+    expect(result.diff.projects.removed.map(p => p.projectId)).toEqual([2]);
+    expect(result.diff.projects.decreased).toEqual([]);
+  });
+
+  it('returns diffRate null when base spending is 0', () => {
+    // project 1's budget goes 1000 -> 0, so budgetDiffRate should be null
+    const result = compareYearsSummary(
+      { nodes: baseNodes, edges: baseEdges, excludedIds: null },
+      { nodes: compareNodes, edges: compareEdges, excludedIds: null },
+    );
+    const entry = result.diff.projects.increased.find(p => p.projectId === 1);
+    expect(entry).toBeDefined();
+    // budgetBase=1000, budgetCompare=0 -> budgetDiffRate should be -1, not null (base!=0)
+    expect(entry!.budgetDiffRate).toBe(-1);
+    // Now confirm the null path: budgetBase=0 case via a project whose base budget is 0
+    const zeroBaseNodes: RawNode[] = [
+      makeNode({ id: 'project-budget-9', name: '事業9', type: 'project-budget', value: 0, projectId: 9, ministry: 'A省' }),
+      makeNode({ id: 'project-spending-9', name: '事業9', type: 'project-spending', value: 0, projectId: 9, ministry: 'A省' }),
+    ];
+    const zeroCompareNodes: RawNode[] = [
+      makeNode({ id: 'project-budget-9', name: '事業9', type: 'project-budget', value: 500, projectId: 9, ministry: 'A省' }),
+      makeNode({ id: 'project-spending-9', name: '事業9', type: 'project-spending', value: 500, projectId: 9, ministry: 'A省' }),
+    ];
+    const zeroEdges: RawEdge[] = [];
+    const zeroCompareEdges: RawEdge[] = [{ source: 'project-spending-9', target: 'r-1', value: 500 }];
+    const zeroNodesWithRecipient = [...zeroBaseNodes, makeNode({ id: 'r-1', name: 'X', type: 'recipient', value: 0 })];
+    const zeroCompareNodesWithRecipient = [...zeroCompareNodes, makeNode({ id: 'r-1', name: 'X', type: 'recipient', value: 500 })];
+    const result2 = compareYearsSummary(
+      { nodes: zeroNodesWithRecipient, edges: zeroEdges, excludedIds: null },
+      { nodes: zeroCompareNodesWithRecipient, edges: zeroCompareEdges, excludedIds: null },
+    );
+    const e9 = result2.diff.projects.increased.find(p => p.projectId === 9);
+    expect(e9!.spendingDiffRate).toBeNull(); // spendingBase = 0
+  });
+});

--- a/app/lib/search/project-search.test.ts
+++ b/app/lib/search/project-search.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import type { QualityScoreItem } from '@/app/lib/api/quality-scores-loader';
+import type { ProjectDetail, ProjectDetailsData } from '@/types/project-details';
+import { normalizeQuery, searchProjects } from '@/app/lib/search/project-search';
+
+describe('normalizeQuery', () => {
+  it('applies NFKC normalization (full-width -> half-width)', () => {
+    expect(normalizeQuery('ＡＢＣ１２３')).toBe('abc123');
+  });
+
+  it('lowercases the input', () => {
+    expect(normalizeQuery('HELLO')).toBe('hello');
+  });
+
+  it('strips whitespace (including embedded spaces)', () => {
+    expect(normalizeQuery(' foo  bar ')).toBe('foobar');
+  });
+
+  it('returns an empty string for whitespace-only input', () => {
+    expect(normalizeQuery('   ')).toBe('');
+  });
+});
+
+function makeItem(overrides: Partial<QualityScoreItem> & Pick<QualityScoreItem, 'pid' | 'name'>): QualityScoreItem {
+  return {
+    ministry: 'A省',
+    bureau: '',
+    division: '',
+    section: '',
+    office: '',
+    team: '',
+    unit: '',
+    rowCount: 1,
+    validCount: 1,
+    govAgencyCount: 0,
+    suppValidCount: 0,
+    invalidCount: 0,
+    validRatio: 1,
+    cnFilled: 1,
+    cnEmpty: 0,
+    cnFillRatio: 1,
+    budgetAmount: 100,
+    execAmount: 100,
+    spendTotal: 100,
+    spendNetTotal: 100,
+    gapRatio: null,
+    blockCount: 1,
+    orphanBlockCount: 0,
+    hasRedelegation: false,
+    redelegationDepth: 0,
+    opaqueRatio: null,
+    axis1: null,
+    axis2: null,
+    axis3: null,
+    axis4: null,
+    axis5: null,
+    totalScore: null,
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<ProjectDetail> & Pick<ProjectDetail, 'projectId' | 'projectName'>): ProjectDetail {
+  return {
+    ministry: 'A省',
+    bureau: '',
+    purpose: '',
+    currentIssues: '',
+    overview: '',
+    url: null,
+    category: '',
+    startYear: null,
+    startYearUnknown: false,
+    endYear: null,
+    noEndDate: false,
+    majorExpense: '',
+    remarks: '',
+    implementationMethods: [],
+    oldProjectNumber: '',
+    ...overrides,
+  };
+}
+
+describe('searchProjects scope=details matchedIn priority', () => {
+  const items: QualityScoreItem[] = [
+    makeItem({ pid: 'p1', name: '子育て支援事業', budgetAmount: 100 }),
+    makeItem({ pid: 'p2', name: '無関係事業', budgetAmount: 200 }),
+  ];
+  const projectDetails: ProjectDetailsData = {
+    p1: makeDetail({ projectId: 1, projectName: '子育て支援事業', purpose: '子育て世帯への支援' }),
+    p2: makeDetail({ projectId: 2, projectName: '無関係事業', overview: '子育て関連の間接効果' }),
+  };
+
+  it('prioritizes name match over details match when both match', () => {
+    const { items: hits } = searchProjects(items, '子育て', { limit: 10, offset: 0, sortBy: 'budget', scope: 'details', projectDetails });
+    const p1Hit = hits.find(h => h.item.pid === 'p1');
+    expect(p1Hit?.matchedIn).toBe('name');
+  });
+
+  it('falls back to details match when name does not match', () => {
+    const { items: hits } = searchProjects(items, '子育て', { limit: 10, offset: 0, sortBy: 'budget', scope: 'details', projectDetails });
+    const p2Hit = hits.find(h => h.item.pid === 'p2');
+    expect(p2Hit?.matchedIn).toBe('details');
+  });
+
+  it('does not search details when scope=name (default)', () => {
+    const { items: hits, totalHits } = searchProjects(items, '子育て', { limit: 10, offset: 0, sortBy: 'budget' });
+    expect(totalHits).toBe(1);
+    expect(hits[0].item.pid).toBe('p1');
+  });
+
+  it('returns empty result for an empty query', () => {
+    const result = searchProjects(items, '   ', { limit: 10, offset: 0, sortBy: 'budget' });
+    expect(result.totalHits).toBe(0);
+    expect(result.items).toEqual([]);
+  });
+
+  it('sorts by spendTotal when sortBy=spending', () => {
+    const bySpend: QualityScoreItem[] = [
+      makeItem({ pid: 'a', name: 'テスト事業A', spendTotal: 500, budgetAmount: 100 }),
+      makeItem({ pid: 'b', name: 'テスト事業B', spendTotal: 900, budgetAmount: 100 }),
+    ];
+    const { items: hits } = searchProjects(bySpend, 'テスト事業', { limit: 10, offset: 0, sortBy: 'spending' });
+    expect(hits.map(h => h.item.pid)).toEqual(['b', 'a']);
+  });
+
+  it('applies limit/offset paging', () => {
+    const many: QualityScoreItem[] = Array.from({ length: 5 }, (_, i) =>
+      makeItem({ pid: `id${i}`, name: `検索対象事業${i}`, budgetAmount: 100 - i }),
+    );
+    const { items: hits, totalHits } = searchProjects(many, '検索対象事業', { limit: 2, offset: 1, sortBy: 'budget' });
+    expect(totalHits).toBe(5);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].item.pid).toBe('id1');
+  });
+});

--- a/app/lib/search/spending-search.test.ts
+++ b/app/lib/search/spending-search.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { SpendingSearchRow } from '@/app/lib/api/quality-recipients-loader';
+import { normalizeQuery } from '@/app/lib/search/project-search';
+import { searchSpending } from '@/app/lib/search/spending-search';
+
+function makeRow(overrides: Partial<SpendingSearchRow> & Pick<SpendingSearchRow, 'pid' | 'role' | 'cc'>): SpendingSearchRow {
+  const role = overrides.role ?? '';
+  const cc = overrides.cc ?? '';
+  return {
+    n: '受領者',
+    b: '',
+    s: 'valid',
+    c: true,
+    cn: '1234567890123',
+    o: false,
+    a2: 1000,
+    r: false,
+    chain: '',
+    d: 0,
+    roleNorm: normalizeQuery(role),
+    ccNorm: normalizeQuery(cc),
+    ...overrides,
+  };
+}
+
+describe('searchSpending', () => {
+  it('aggregates direct (d=0) and subcontract (d>0) amounts separately', () => {
+    const rows: SpendingSearchRow[] = [
+      makeRow({ pid: '1', role: '広報活動の実施', cc: '', d: 0, a2: 1000 }),
+      makeRow({ pid: '1', role: '広報活動の再委託先', cc: '', d: 1, a2: 300 }),
+    ];
+    const result = searchSpending(rows, '広報', { limit: 10, offset: 0 });
+    expect(result.aggregate.amountDirect).toBe(1000);
+    expect(result.aggregate.amountSubcontract).toBe(300);
+    expect(result.aggregate.hitCount).toBe(2);
+    expect(result.aggregate.projectCount).toBe(1);
+  });
+
+  it('computes topProjects per-category amounts (direct vs subcontract) independently', () => {
+    const rows: SpendingSearchRow[] = [
+      makeRow({ pid: 'A', role: 'システム改修業務', cc: '', d: 0, a2: 5000 }),
+      makeRow({ pid: 'A', role: 'システム改修の再委託', cc: '', d: 2, a2: 2000 }),
+      makeRow({ pid: 'B', role: 'システム改修支援', cc: '', d: 0, a2: 100 }),
+    ];
+    const result = searchSpending(rows, 'システム改修', { limit: 10, offset: 0 });
+    const top = result.aggregate.topProjects;
+    expect(top[0].pid).toBe('A'); // 5000+2000=7000 > 100
+    expect(top[0].amountDirect).toBe(5000);
+    expect(top[0].amountSubcontract).toBe(2000);
+    expect(top[1].pid).toBe('B');
+    expect(top[1].amountDirect).toBe(100);
+    expect(top[1].amountSubcontract).toBe(0);
+  });
+
+  it('finds the excerpt around the match position with embedded whitespace in the query', () => {
+    const longText = 'あ'.repeat(80) + 'キーワード' + 'い'.repeat(80);
+    const rows: SpendingSearchRow[] = [makeRow({ pid: '1', role: longText, cc: '' })];
+    // query has an embedded space that should be stripped by normalization
+    const result = searchSpending(rows, 'キー ワード', { limit: 10, offset: 0 });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].excerpt).toContain('キーワード');
+    // excerpt should be truncated (not the full 165-char text), with ellipsis markers
+    expect(result.items[0].excerpt.length).toBeLessThan(longText.length);
+    expect(result.items[0].excerpt.startsWith('…')).toBe(true);
+    expect(result.items[0].excerpt.endsWith('…')).toBe(true);
+  });
+
+  it('normalizes full-width/half-width (NFKC) differences between query and text', () => {
+    const rows: SpendingSearchRow[] = [makeRow({ pid: '1', role: 'ＡＢＣシステム開発', cc: '' })];
+    const result = searchSpending(rows, 'ABC', { limit: 10, offset: 0 });
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('falls back to the head of the text when the normalized match position cannot be found in excerpt (matches ccNorm not sourceText role)', () => {
+    // matchedIn is determined by roleNorm/ccNorm inclusion, but excerpt always reads from the
+    // matched field's *original* text. Here cc matches, so excerpt should come from cc text, not role.
+    const rows: SpendingSearchRow[] = [
+      makeRow({ pid: '1', role: '無関係な役割テキスト', cc: 'これは契約概要のテキストです' }),
+    ];
+    const result = searchSpending(rows, '契約概要', { limit: 10, offset: 0 });
+    expect(result.items[0].matchedIn).toBe('cc');
+    expect(result.items[0].excerpt).toContain('契約概要');
+  });
+
+  it('applies limit/offset to items while keeping aggregate over all matches', () => {
+    const rows: SpendingSearchRow[] = Array.from({ length: 5 }, (_, i) =>
+      makeRow({ pid: String(i), role: `対象業務${i}`, cc: '', a2: 100 + i }),
+    );
+    const result = searchSpending(rows, '対象業務', { limit: 2, offset: 1 });
+    expect(result.totalHits).toBe(5);
+    expect(result.items).toHaveLength(2);
+    expect(result.aggregate.hitCount).toBe(5);
+  });
+
+  it('returns an empty result for an empty/whitespace query', () => {
+    const rows: SpendingSearchRow[] = [makeRow({ pid: '1', role: 'テスト', cc: '' })];
+    const result = searchSpending(rows, '   ', { limit: 10, offset: 0 });
+    expect(result.totalHits).toBe(0);
+    expect(result.aggregate.hitCount).toBe(0);
+  });
+
+  it('sorts items by amount (a2) descending', () => {
+    const rows: SpendingSearchRow[] = [
+      makeRow({ pid: '1', role: '対象X 小額', cc: '', a2: 50 }),
+      makeRow({ pid: '2', role: '対象X 高額', cc: '', a2: 5000 }),
+    ];
+    const result = searchSpending(rows, '対象X', { limit: 10, offset: 0 });
+    expect(result.items.map(h => h.row.a2)).toEqual([5000, 50]);
+  });
+});

--- a/app/lib/subcontract-layout.test.ts
+++ b/app/lib/subcontract-layout.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import type { SubcontractGraph, BlockNode, BlockEdge } from '@/types/subcontract';
+import { computeDepths, mergeParallelFlows, computeSubcontractLayout, NODE_W } from '@/app/lib/subcontract-layout';
+
+function makeBlock(overrides: Partial<BlockNode> & Pick<BlockNode, 'blockId' | 'blockName' | 'totalAmount'>): BlockNode {
+  return {
+    isDirect: true,
+    originKind: 'direct',
+    isTerminal: true,
+    recipientCount: 1,
+    hasExpenses: false,
+    recipients: [],
+    ...overrides,
+  };
+}
+
+function makeFlow(overrides: Partial<BlockEdge> & Pick<BlockEdge, 'targetBlock'>): BlockEdge {
+  return {
+    sourceBlock: null,
+    origin: 'direct',
+    isReference: false,
+    targetIncomingBlockCount: 1,
+    ...overrides,
+  };
+}
+
+describe('computeDepths', () => {
+  it('assigns depth 1 to direct roots (sourceBlock === null)', () => {
+    const flows: BlockEdge[] = [makeFlow({ targetBlock: 'a' })];
+    const depths = computeDepths(flows);
+    expect(depths.get('a')).toBe(1);
+  });
+
+  it('assigns depth via BFS along the chain', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ targetBlock: 'a' }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b' }),
+      makeFlow({ sourceBlock: 'b', targetBlock: 'c' }),
+    ];
+    const depths = computeDepths(flows);
+    expect(depths.get('a')).toBe(1);
+    expect(depths.get('b')).toBe(2);
+    expect(depths.get('c')).toBe(3);
+  });
+
+  it('handles cycles without infinite loop (adopts the minimum depth reached first)', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ targetBlock: 'a' }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b' }),
+      makeFlow({ sourceBlock: 'b', targetBlock: 'a' }), // cycle back to a
+    ];
+    const depths = computeDepths(flows);
+    expect(depths.get('a')).toBe(1);
+    expect(depths.get('b')).toBe(2);
+    expect(depths.size).toBe(2);
+  });
+
+  it('respects MAX_DEPTH_LIMIT (30) by dropping nodes beyond it', () => {
+    const flows: BlockEdge[] = [makeFlow({ targetBlock: 'n0' })];
+    for (let i = 0; i < 35; i++) {
+      flows.push(makeFlow({ sourceBlock: `n${i}`, targetBlock: `n${i + 1}` }));
+    }
+    const depths = computeDepths(flows);
+    expect(depths.get('n29')).toBe(30);
+    expect(depths.has('n30')).toBe(false);
+    expect(depths.has('n35')).toBe(false);
+  });
+
+  it('starts separate-origin roots at depth 1', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ sourceBlock: 'sep', targetBlock: 'child', origin: 'separate-origin' }),
+    ];
+    const depths = computeDepths(flows);
+    expect(depths.get('sep')).toBe(1);
+    expect(depths.get('child')).toBe(2);
+  });
+});
+
+describe('mergeParallelFlows', () => {
+  it('merges flows sharing the same source/target/origin/isReference key', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', origin: 'subcontract' }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', origin: 'subcontract' }),
+    ];
+    const merged = mergeParallelFlows(flows);
+    expect(merged).toHaveLength(1);
+  });
+
+  it('concatenates distinct notes with " / " and de-duplicates identical notes', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', note: '注記1' }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', note: '注記2' }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', note: '注記1' }), // duplicate, should not repeat
+    ];
+    const merged = mergeParallelFlows(flows);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].note).toBe('注記1 / 注記2');
+  });
+
+  it('does not merge flows differing in isReference', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', isReference: false }),
+      makeFlow({ sourceBlock: 'a', targetBlock: 'b', isReference: true }),
+    ];
+    const merged = mergeParallelFlows(flows);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('treats null sourceBlock as its own group (root flows)', () => {
+    const flows: BlockEdge[] = [
+      makeFlow({ sourceBlock: null, targetBlock: 'a' }),
+      makeFlow({ sourceBlock: null, targetBlock: 'a' }),
+    ];
+    const merged = mergeParallelFlows(flows);
+    expect(merged).toHaveLength(1);
+  });
+
+  it('leaves note undefined when no flow in the group has a note', () => {
+    const flows: BlockEdge[] = [makeFlow({ sourceBlock: 'a', targetBlock: 'b' })];
+    const merged = mergeParallelFlows(flows);
+    expect(merged[0].note).toBeUndefined();
+  });
+});
+
+describe('computeSubcontractLayout band invariants', () => {
+  function makeGraph(): SubcontractGraph {
+    // root -> parentA (amount 1000) -> childA1 (400), childA2 (300)
+    //      -> parentB (amount 200)
+    return {
+      projectId: 1,
+      projectName: 'テスト事業',
+      ministry: 'A省',
+      bureau: '',
+      accountCategory: '一般会計',
+      budget: 1000,
+      execution: 1000,
+      directExpenseTotal: 1000,
+      totalExpense: 1900,
+      blocks: [
+        makeBlock({ blockId: 'parentA', blockName: '親A', totalAmount: 1000, isTerminal: false }),
+        makeBlock({ blockId: 'parentB', blockName: '親B', totalAmount: 200 }),
+        makeBlock({ blockId: 'childA1', blockName: '子A1', totalAmount: 400, isDirect: false, originKind: 'subcontract' }),
+        makeBlock({ blockId: 'childA2', blockName: '子A2', totalAmount: 300, isDirect: false, originKind: 'subcontract' }),
+      ],
+      flows: [
+        makeFlow({ targetBlock: 'parentA' }),
+        makeFlow({ targetBlock: 'parentB' }),
+        makeFlow({ sourceBlock: 'parentA', targetBlock: 'childA1', origin: 'subcontract' }),
+        makeFlow({ sourceBlock: 'parentA', targetBlock: 'childA2', origin: 'subcontract' }),
+      ],
+      maxDepth: 2,
+      directBlockCount: 2,
+      totalBlockCount: 4,
+      totalRecipientCount: 4,
+      indirectCosts: [],
+      hasSeparateOrigin: false,
+      separateOriginCount: 0,
+      strongSeparateOriginCount: 0,
+      separateOriginAmount: 0,
+      hasMerge: false,
+      mergeTargetCount: 0,
+      maxMergeWidth: 0,
+      branchingBlockCount: 1,
+      maxBranchWidth: 2,
+      hasReferenceFlow: false,
+      isInstitutionalFlowOnly: false,
+    };
+  }
+
+  it('places children within their max-amount parent band (no overlap outside parent bounds)', () => {
+    const layout = computeSubcontractLayout(makeGraph());
+    const parentA = layout.blocks.find(b => b.blockId === 'parentA')!;
+    const childA1 = layout.blocks.find(b => b.blockId === 'childA1')!;
+    const childA2 = layout.blocks.find(b => b.blockId === 'childA2')!;
+    const bandLeft = Math.min(childA1.x, childA2.x);
+    const bandRight = Math.max(childA1.x + childA1.w, childA2.x + childA2.w);
+    // parentA's center should fall within its children's combined band
+    const parentCenter = parentA.x + parentA.w / 2;
+    expect(parentCenter).toBeGreaterThanOrEqual(bandLeft);
+    expect(parentCenter).toBeLessThanOrEqual(bandRight);
+  });
+
+  it('has no horizontal overlap between sibling blocks within the same row (depth)', () => {
+    const layout = computeSubcontractLayout(makeGraph());
+    const depth2 = layout.blocks.filter(b => b.depth === 2).sort((a, b) => a.x - b.x);
+    for (let i = 0; i < depth2.length - 1; i++) {
+      expect(depth2[i].x + depth2[i].w).toBeLessThanOrEqual(depth2[i + 1].x);
+    }
+  });
+
+  it('centers a single child directly under its parent (same center x)', () => {
+    const graph = makeGraph();
+    // Reduce to a single-child chain: parentB depth1 has no children; use parentA -> only childA1
+    graph.blocks = graph.blocks.filter(b => b.blockId !== 'childA2' && b.blockId !== 'parentB');
+    graph.flows = graph.flows.filter(f => f.targetBlock !== 'childA2' && f.targetBlock !== 'parentB');
+    const layout = computeSubcontractLayout(graph);
+    const parentA = layout.blocks.find(b => b.blockId === 'parentA')!;
+    const childA1 = layout.blocks.find(b => b.blockId === 'childA1')!;
+    expect(parentA.x + parentA.w / 2).toBeCloseTo(childA1.x + childA1.w / 2, 5);
+  });
+
+  it('assigns depth1 nodes their expected NODE_W width and non-negative coordinates', () => {
+    const layout = computeSubcontractLayout(makeGraph());
+    for (const b of layout.blocks) {
+      expect(b.w).toBe(NODE_W);
+      expect(b.x).toBeGreaterThanOrEqual(0);
+      expect(b.y).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/app/lib/subcontract-layout.test.ts
+++ b/app/lib/subcontract-layout.test.ts
@@ -1,28 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import type { SubcontractGraph, BlockNode, BlockEdge } from '@/types/subcontract';
+import type { SubcontractGraph, BlockEdge } from '@/types/subcontract';
 import { computeDepths, mergeParallelFlows, computeSubcontractLayout, NODE_W } from '@/app/lib/subcontract-layout';
-
-function makeBlock(overrides: Partial<BlockNode> & Pick<BlockNode, 'blockId' | 'blockName' | 'totalAmount'>): BlockNode {
-  return {
-    isDirect: true,
-    originKind: 'direct',
-    isTerminal: true,
-    recipientCount: 1,
-    hasExpenses: false,
-    recipients: [],
-    ...overrides,
-  };
-}
-
-function makeFlow(overrides: Partial<BlockEdge> & Pick<BlockEdge, 'targetBlock'>): BlockEdge {
-  return {
-    sourceBlock: null,
-    origin: 'direct',
-    isReference: false,
-    targetIncomingBlockCount: 1,
-    ...overrides,
-  };
-}
+import { makeBlock, makeFlow } from '@/app/lib/test-utils/subcontract-fixtures';
 
 describe('computeDepths', () => {
   it('assigns depth 1 to direct roots (sourceBlock === null)', () => {

--- a/app/lib/subcontract-ribbon-layout.test.ts
+++ b/app/lib/subcontract-ribbon-layout.test.ts
@@ -1,31 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import type { SubcontractGraph, BlockNode, BlockEdge } from '@/types/subcontract';
+import type { SubcontractGraph } from '@/types/subcontract';
 import {
   computeSubcontractRibbonLayout,
   RIBBON_BAR_MIN_H,
 } from '@/app/lib/subcontract-ribbon-layout';
-
-function makeBlock(overrides: Partial<BlockNode> & Pick<BlockNode, 'blockId' | 'blockName' | 'totalAmount'>): BlockNode {
-  return {
-    isDirect: true,
-    originKind: 'direct',
-    isTerminal: true,
-    recipientCount: 1,
-    hasExpenses: false,
-    recipients: [],
-    ...overrides,
-  };
-}
-
-function makeFlow(overrides: Partial<BlockEdge> & Pick<BlockEdge, 'targetBlock'>): BlockEdge {
-  return {
-    sourceBlock: null,
-    origin: 'direct',
-    isReference: false,
-    targetIncomingBlockCount: 1,
-    ...overrides,
-  };
-}
+import { makeBlock, makeFlow } from '@/app/lib/test-utils/subcontract-fixtures';
 
 function baseGraph(overrides: Partial<SubcontractGraph> = {}): SubcontractGraph {
   return {

--- a/app/lib/subcontract-ribbon-layout.test.ts
+++ b/app/lib/subcontract-ribbon-layout.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import type { SubcontractGraph, BlockNode, BlockEdge } from '@/types/subcontract';
+import {
+  computeSubcontractRibbonLayout,
+  RIBBON_BAR_MIN_H,
+} from '@/app/lib/subcontract-ribbon-layout';
+
+function makeBlock(overrides: Partial<BlockNode> & Pick<BlockNode, 'blockId' | 'blockName' | 'totalAmount'>): BlockNode {
+  return {
+    isDirect: true,
+    originKind: 'direct',
+    isTerminal: true,
+    recipientCount: 1,
+    hasExpenses: false,
+    recipients: [],
+    ...overrides,
+  };
+}
+
+function makeFlow(overrides: Partial<BlockEdge> & Pick<BlockEdge, 'targetBlock'>): BlockEdge {
+  return {
+    sourceBlock: null,
+    origin: 'direct',
+    isReference: false,
+    targetIncomingBlockCount: 1,
+    ...overrides,
+  };
+}
+
+function baseGraph(overrides: Partial<SubcontractGraph> = {}): SubcontractGraph {
+  return {
+    projectId: 1,
+    projectName: 'テスト事業',
+    ministry: 'A省',
+    bureau: '',
+    accountCategory: '一般会計',
+    budget: 1000,
+    execution: 1000,
+    directExpenseTotal: 1000,
+    totalExpense: 1000,
+    blocks: [],
+    flows: [],
+    maxDepth: 1,
+    directBlockCount: 0,
+    totalBlockCount: 0,
+    totalRecipientCount: 0,
+    indirectCosts: [],
+    hasSeparateOrigin: false,
+    separateOriginCount: 0,
+    strongSeparateOriginCount: 0,
+    separateOriginAmount: 0,
+    hasMerge: false,
+    mergeTargetCount: 0,
+    maxMergeWidth: 0,
+    branchingBlockCount: 0,
+    maxBranchWidth: 0,
+    hasReferenceFlow: false,
+    isInstitutionalFlowOnly: false,
+    ...overrides,
+  };
+}
+
+describe('computeSubcontractRibbonLayout', () => {
+  it('entry-ribbon-sum approximately equals target bar height (within 0.5px)', () => {
+    const graph = baseGraph({
+      blocks: [
+        makeBlock({ blockId: 'parentA', blockName: '親A', totalAmount: 600, isTerminal: false }),
+        makeBlock({ blockId: 'parentB', blockName: '親B', totalAmount: 400, isTerminal: false }),
+        makeBlock({ blockId: 'child', blockName: '子', totalAmount: 1000, isDirect: false, originKind: 'subcontract' }),
+      ],
+      flows: [
+        makeFlow({ targetBlock: 'parentA' }),
+        makeFlow({ targetBlock: 'parentB' }),
+        makeFlow({ sourceBlock: 'parentA', targetBlock: 'child', origin: 'subcontract' }),
+        makeFlow({ sourceBlock: 'parentB', targetBlock: 'child', origin: 'subcontract' }),
+      ],
+    });
+    const layout = computeSubcontractRibbonLayout(graph);
+    const childBar = layout.bars.find(b => b.blockId === 'child')!;
+    const incomingFlows = layout.flows.filter(f => f.targetBlock === 'child');
+    const sumThickness = incomingFlows.reduce((sum, f) => sum + (f.y2Bot - f.y2Top), 0);
+    expect(Math.abs(sumThickness - childBar.h)).toBeLessThanOrEqual(0.5);
+  });
+
+  it('leaves partial space when Σ(child totalAmount) < parent bar height (Σexit < bar height)', () => {
+    const graph = baseGraph({
+      blocks: [
+        makeBlock({ blockId: 'parent', blockName: '親', totalAmount: 1000, isTerminal: false }),
+        makeBlock({ blockId: 'child', blockName: '子（一部再委託）', totalAmount: 200, isDirect: false, originKind: 'subcontract' }),
+      ],
+      flows: [
+        makeFlow({ targetBlock: 'parent' }),
+        makeFlow({ sourceBlock: 'parent', targetBlock: 'child', origin: 'subcontract' }),
+      ],
+    });
+    const layout = computeSubcontractRibbonLayout(graph);
+    const parentBar = layout.bars.find(b => b.blockId === 'parent')!;
+    const outgoing = layout.flows.filter(f => f.sourceBlock === 'parent');
+    const sumExitThickness = outgoing.reduce((sum, f) => sum + (f.y1Bot - f.y1Top), 0);
+    // child (200) is a fraction of parent's total (1000), so exit ribbon sum should be
+    // strictly less than the parent bar's full height.
+    expect(sumExitThickness).toBeLessThan(parentBar.h);
+  });
+
+  it('excludes flows whose source-side bar is missing from the flows/backEdges output', () => {
+    // 'ghost' is referenced as a sourceBlock but never appears in graph.blocks, so it never
+    // gets a bar. The flow from 'ghost' must be dropped rather than mis-rendered as a root flow.
+    const graph = baseGraph({
+      blocks: [
+        makeBlock({ blockId: 'real', blockName: '実在ブロック', totalAmount: 500 }),
+      ],
+      flows: [
+        makeFlow({ targetBlock: 'real' }),
+        makeFlow({ sourceBlock: 'ghost', targetBlock: 'real', origin: 'subcontract' }),
+      ],
+    });
+    const layout = computeSubcontractRibbonLayout(graph);
+    expect(layout.flows.some(f => f.sourceBlock === 'ghost')).toBe(false);
+    expect(layout.backEdges.some(f => f.sourceBlock === 'ghost')).toBe(false);
+    // Only the direct root flow into 'real' should exist
+    expect(layout.flows).toHaveLength(1);
+    expect(layout.flows[0].sourceBlock).toBeNull();
+  });
+
+  it('gives a block with totalAmount=0 a minimum bar height (RIBBON_BAR_MIN_H)', () => {
+    const graph = baseGraph({
+      blocks: [
+        makeBlock({ blockId: 'zero', blockName: 'ゼロ円ブロック', totalAmount: 0, recipientCount: 0 }),
+      ],
+      flows: [makeFlow({ targetBlock: 'zero' })],
+    });
+    const layout = computeSubcontractRibbonLayout(graph);
+    const zeroBar = layout.bars.find(b => b.blockId === 'zero')!;
+    expect(zeroBar.h).toBe(RIBBON_BAR_MIN_H);
+    expect(zeroBar.isZeroAmount).toBe(true);
+  });
+
+  it('gives the overall layout a minimum root height when there are no blocks at all', () => {
+    const graph = baseGraph();
+    const layout = computeSubcontractRibbonLayout(graph);
+    expect(layout.root.h).toBeGreaterThanOrEqual(RIBBON_BAR_MIN_H);
+    expect(layout.bars).toEqual([]);
+  });
+});

--- a/app/lib/test-utils/subcontract-fixtures.ts
+++ b/app/lib/test-utils/subcontract-fixtures.ts
@@ -1,0 +1,31 @@
+/**
+ * subcontract 系テスト（layout / ribbon-layout）で共用する合成フィクスチャ。
+ * 各テストで同一の makeBlock/makeFlow を重複定義しないため集約する（ドリフト防止）。
+ */
+import type { BlockNode, BlockEdge } from '@/types/subcontract';
+
+export function makeBlock(
+  overrides: Partial<BlockNode> & Pick<BlockNode, 'blockId' | 'blockName' | 'totalAmount'>,
+): BlockNode {
+  return {
+    isDirect: true,
+    originKind: 'direct',
+    isTerminal: true,
+    recipientCount: 1,
+    hasExpenses: false,
+    recipients: [],
+    ...overrides,
+  };
+}
+
+export function makeFlow(
+  overrides: Partial<BlockEdge> & Pick<BlockEdge, 'targetBlock'>,
+): BlockEdge {
+  return {
+    sourceBlock: null,
+    origin: 'direct',
+    isReference: false,
+    targetIncomingBlockCount: 1,
+    ...overrides,
+  };
+}

--- a/client/components/quality/score-format.ts
+++ b/client/components/quality/score-format.ts
@@ -11,7 +11,8 @@ export function scoreColor(score: number | null): string {
   return 'text-red-600 dark:text-red-400';
 }
 
-export function formatAmount(yen: number): string {
+export function formatAmount(yen: number | null): string {
+  if (yen === null) return '-';
   if (yen >= 1e12) return `${(yen / 1e12).toFixed(2)}兆`;
   if (yen >= 1e8)  return `${(yen / 1e8).toFixed(1)}億`;
   if (yen >= 1e4)  return `${(yen / 1e4).toFixed(0)}万`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -107,21 +108,21 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -129,9 +130,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1603,6 +1604,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1686,6 +1697,289 @@
       "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1697,6 +1991,13 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.15.0.tgz",
       "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1723,14 +2024,25 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-color": {
@@ -1856,6 +2168,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2545,6 +2864,92 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
@@ -2858,6 +3263,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3158,6 +3573,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3334,6 +3759,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3762,8 +4194,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3960,6 +4392,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4511,6 +4950,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4519,6 +4968,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -5854,6 +6313,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -5931,6 +6651,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -6880,9 +7610,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7162,6 +7892,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7319,6 +8063,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7416,9 +8167,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "dev": true,
       "funding": [
         {
@@ -7436,7 +8187,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7885,6 +8636,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8181,6 +8966,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8227,6 +9019,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8693,15 +9499,32 @@
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8729,9 +9552,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8739,6 +9562,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9189,6 +10022,214 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9292,6 +10333,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
@@ -58,6 +60,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+    exclude: ['node_modules', '.next'],
+  },
+});


### PR DESCRIPTION
## 目的

app/lib/ の Pure 関数群（クエリ・検索・highlights・レイアウト・エージェント）が自動テストゼロのまま積み上がり、品質の守りが tsc/lint/手動ハーネスのみである状態を解消するため（`docs/tasks/20260710_2324_技術的懸念の棚卸し` 懸念1・承認済み優先①）。

## 変更内容

- **vitest 導入**（node 環境のみ・React テストはスコープ外）: `vitest.config.ts`（`@/*` エイリアス解決）+ `npm test` / `npm run test:watch`
- **8モジュール・71テスト**（実行約250ms）。テストは対象モジュールの隣に併置:

| モジュール | 件数 | 重点 |
|-----------|-----:|------|
| sankey-query | 17 | resolve検証・URLラウンドトリップ・topShare 0除算→null・compareYears diffRate null |
| subcontract-layout | 14 | 深度サイクル/上限・note結合・**バンド不変条件**（子は親バンド内・重なりなし・単一子は同中心） |
| project-search | 10 | normalizeQuery・scope=details の matchedIn 優先 |
| highlights | 9 | nearest-rank分位点・10億円下限・multiSignal 共起 |
| spending-search | 8 | 直接/再委託の分離集計・excerpt 位置写像（空白/NFKC） |
| ribbon-layout | 5 | **入口整合±0.5px・部分再委託（Σ出口<バー高さ）**・#264レビュー修正の回帰 |
| font-scale | 5 | 丸め・基準値で恒等 |
| sankey-chat-agent | 3 | モック LlmCaller で終了3経路（テキスト/確定/ツール上限） |

- **実データ非依存**: すべて合成フィクスチャ。public/data 未展開の環境・CIでもそのまま走る（fs を触るローダ群は対象外）
- `/quality-check` スキルに `npm test` を追加 — 以後の全PRでテスト実行が標準に
- 境界値テストで**既存バグの発見なし**（0除算・分位点・圧縮フォールバック等すべて仕様どおり）

## テスト方法

```bash
npm test          # 71 passed, ~250ms
npx tsc --noEmit  # クリーン
npm run build     # 影響なし（テストがルートに漏れないことを確認済み）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vitest-based unit test commands, including standard and watch modes.
  * Added automated coverage for chat agents, search, Sankey analysis, highlighting, font scaling, and subcontract layouts.
  * Added a documented quality-check step requiring unit tests alongside linting and type checking.
* **Tests**
  * Added validation for query handling, calculations, filtering, sorting, pagination, layout constraints, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->