### PR TITLE
fix(ui): 戻るリンクの href="/" を /sankey-svg 直リンクに — GET / 307 連発の解消

### DIFF
--- a/app/mof-budget-overview/page.tsx
+++ b/app/mof-budget-overview/page.tsx
@@ -95,7 +95,7 @@ export default function MOFBudgetOverviewPage() {
       {/* 固定ボタン */}
       <div className="fixed top-4 right-4 z-40 flex gap-2">
         <Link
-          href="/"
+          href="/sankey-svg"
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors shadow-lg"
         >
           ホームに戻る

--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -221,7 +221,7 @@ export default function QualityPage() {
       <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-4">
         <div className="max-w-[1600px] mx-auto">
           <div className="flex items-center gap-3 mb-1">
-            <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline text-sm">
+            <Link href="/sankey-svg" className="text-blue-600 dark:text-blue-400 hover:underline text-sm">
               ← トップ
             </Link>
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">


### PR DESCRIPTION
## 目的

`app/page.tsx` が `redirect('/sankey-svg')` のため、`href="/"` の Link は 307 リダイレクトになる。Next の Link プリフェッチがリダイレクト応答をキャッシュできず、dev コンソールに `GET / 307` が繰り返し出続ける（ユーザー報告）。

## 変更内容

戻るリンクを実体の `/sankey-svg` 直リンクに変更:
- `app/quality/page.tsx:224`（← トップ）
- `app/mof-budget-overview/page.tsx:98`（ホームに戻る）

`/subcontracts` の同種リンクは PR #264 で対応済み。本PRで `href="/"` は全ページから解消（grep 残存ゼロ確認）。

## テスト方法

```bash
npm run dev
# /quality・/mof-budget-overview を開き、コンソールに GET / 307 が出続けないこと
# 戻るリンクで /sankey-svg に遷移すること
```

- `npx tsc --noEmit` クリーン / 両ページ200確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)