### PR TITLE
feat(security): CSPヘッダ導入 — XSS成立時のBYOKキー外部送信を遮断

### DIFF
--- a/docs/tasks/20260718_1542_AIチャットBYOK設計_使用者APIキー外部化.md
+++ b/docs/tasks/20260718_1542_AIチャットBYOK設計_使用者APIキー外部化.md
@@ -209,9 +209,14 @@ UI は2つの判定を重ねてモードを決める:
 - 「あなたのAPIキーを使って」の文言・導線設計はサイト UI 一般名称ルール
   （AIアシスタント等）に従う。
 
-### バックログ: CSP 導入（XSS 時のキー外部送信の遮断・優先度高）
+### CSP 導入（XSS 時のキー外部送信の遮断）— 実装済（2026-07-19）
 
-**BYOK の一般公開前に実施する価値が高い**（2026-07-18 合意）。
+**BYOK の一般公開前に実施する価値が高い**（2026-07-18 合意）→ 翌日実装。
+`next.config.ts` の `headers()` で本番のみ付与（dev は HMR が eval/ws を使うため除外）:
+`default-src 'self'` / `script-src 'self' 'unsafe-inline'`（Next hydration 用。静的ページ
+主体のため nonce 不採用）/ `connect-src 'self' https://openrouter.ai`（本命）/
+`object-src 'none'` ほか + `X-Content-Type-Options: nosniff`。
+検証: 公開4ページで CSP 違反ゼロ・OpenRouter 到達可・他ホスト fetch は遮断を Playwright で確認。
 
 - 脅威整理: IndexedDB は同一オリジン隔離のため他サイトからは盗めない。現実的な経路は
   (1) 当サイト自身の XSS（本命）、(2) 悪意あるブラウザ拡張、(3) 端末への物理アクセス。

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,45 @@
 import type { NextConfig } from "next";
 
+/**
+ * CSP（Content-Security-Policy）。目的は XSS 成立時の被害限定、特に BYOK の
+ * APIキー（IndexedDB保存）の外部送信遮断（設計: docs/tasks/20260718_1542 9節バックログ）。
+ *
+ * - connect-src: 自オリジン + OpenRouter（BYOKチャットのブラウザ直接呼び出し）のみ。
+ *   XSS が成立しても fetch/XHR/sendBeacon での任意ホストへの送出を遮断する（本命の効果）
+ * - script-src 'unsafe-inline': Next.js の hydration インラインスクリプトに必要
+ *   （静的ページ主体のため per-request nonce は使えない）。スクリプト注入自体の防御は
+ *   React の既定エスケープ + react-markdown（生HTML非描画）が一次防御
+ * - style-src 'unsafe-inline': コンポーネント内 <style> タグ（chat-markdown 等）と
+ *   インライン style 属性に必要
+ * - 外部フォント・外部画像・worker は不使用（実測）のため許可しない
+ */
+const CSP_HEADER = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' https://openrouter.ai",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+].join('; ');
+
 const nextConfig: NextConfig = {
+  async headers() {
+    // dev は HMR/React Refresh が eval・ws を使うため付与しない（本番のみ）
+    if (process.env.NODE_ENV !== 'production') return [];
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Content-Security-Policy', value: CSP_HEADER },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+        ],
+      },
+    ];
+  },
   // データ JSON の関数同梱はトレーサーの推測に任せず明示制御する。
   // 生 .json（展開後 96MB級）が同梱されると Vercel の関数上限 250MB を超えるため
   // （PR #259 で /api/ai/sankey-chat が実測 270MB でデプロイ失敗）、


### PR DESCRIPTION
## 目的（Why）

BYOK（PR #268。使用者APIキーの IndexedDB 保存）の一般公開に向け、XSS 成立時の被害を限定する二段目の防御を入れる。IndexedDB は同一オリジン隔離のため他サイトからは盗めないが、自サイトに XSS が成立した場合にキーを外部へ送出される経路が残っていた（検討記録: `docs/tasks/20260718_1542_AIチャットBYOK設計_使用者APIキー外部化.md` 9節）。

## 変更内容

`next.config.ts` の `headers()` で**本番のみ** CSP + `X-Content-Type-Options: nosniff` を全ルートに付与。

```text
default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';
img-src 'self' data:; font-src 'self'; connect-src 'self' https://openrouter.ai;
object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
```

- **本命は `connect-src`**: XSS が成立しても fetch/XHR/sendBeacon での任意ホストへのキー送出を遮断（OpenRouter は BYOK のブラウザ直接呼び出しに必要なため許可）
- `script-src 'unsafe-inline'` は Next.js の hydration インラインスクリプトの制約（静的ページ主体のため per-request nonce は不採用）。注入自体の一次防御は React の既定エスケープ + react-markdown（生HTML非描画）が担う（コード内コメントに役割分担を明記）
- 外部フォント・外部画像・worker は不使用（事前調査で実測）のため許可しない
- dev は HMR/React Refresh が eval・WebSocket を使うため付与対象外

## テスト・検証

- 本番ビルド + Playwright:
  - 公開4ページ（/sankey-svg・/subcontracts・/mof-budget-overview・/quality）すべて描画正常・**CSP違反ゼロ**
  - ページ内から `openrouter.ai` への fetch は許可（HTTP 401 = 認証層まで到達）、UI のキー接続テストも機能
  - `example.com` への fetch は CSP が正しく遮断
- `curl -I` でヘッダ配信を確認
- lint エラー0・tsc OK・vitest 71件パス・build + check-traces 違反なし

### レビュー後の動作確認手順

```bash
npm run build && npm run start
curl -sI http://localhost:3000/sankey-svg | grep -i content-security
# ブラウザで各ページを開き DevTools Console に CSP violation が出ないこと、
# AIチャットのキー接続テストが機能することを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)