### PR TITLE
fix(sankey-svg): graphデータのfetchをno-cache化 — 更新後の古いキャッシュで機能が壊れる問題を解消

### DIFF
--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -829,7 +829,9 @@ export default function RealDataSankeyPage() {
     if (y === year && graphData) return graphData;
     const cached = byokGraphCacheRef.current.get(y);
     if (cached) return cached;
-    const res = await fetch(`/data/sankey-svg-${y}-graph.json`);
+    // no-cache: 必ず ETag 再検証（更新時のみ本体取得・未更新は304）。データ構造更新後の
+    // 古いキャッシュ配信を防ぐ（graph はフィルタ機能追加でフィールドが増えるため）
+    const res = await fetch(`/data/sankey-svg-${y}-graph.json`, { cache: 'no-cache' });
     if (!res.ok) throw new Error(`${y}年度のグラフデータの取得に失敗しました（HTTP ${res.status}）`);
     const data = await res.json() as GraphData;
     byokGraphCacheRef.current.set(y, data);
@@ -1566,7 +1568,9 @@ export default function RealDataSankeyPage() {
     setGraphData(null);
     setLoading(true);
     setError(null);
-    fetch(`/data/sankey-svg-${year}-graph.json`)
+    // no-cache: 必ず ETag 再検証（未更新は304・帯域ゼロ、更新時のみ本体取得）。
+    // データ構造更新後に古いキャッシュ版を掴み続ける問題（再委託フィルタで顕在化）の対策
+    fetch(`/data/sankey-svg-${year}-graph.json`, { cache: 'no-cache' })
       .then(res => {
         if (!res.ok) throw new Error(`Fetch error: ${res.status}`);
         return res.json();


### PR DESCRIPTION
## 目的（Why）

再委託フィルタ（PR #275）のデプロイ後、**本番でフィルタが効かない**事象が報告された（例: 支出先「朝倉」+ 再委託先ON でローカル5件に対し Vercel 0件）。

調査の結果、本番のデータもコードも正しく反映されていた:

- 本番 graph JSON: `subcontractRecipients=1991`、朝倉を含む再委託先=5、北海道=227（curl で確認）
- 本番 JS バンドル: `subcontractRecipients` ロジックを含む（Service Worker なし）

真因は、ブラウザが更新前の graph JSON を**キャッシュし続けていた**こと。`/data/sankey-svg-{year}-graph.json` は年度だけの固定URL（コンテンツハッシュなし）で `Cache-Control: max-age=3600, stale-while-revalidate=86400` が付くため、機能追加でデータ構造が変わっても古い版（`subcontractRecipients` 未収録）を配信し続け、**ハードリロードでも `fetch()` がバイパスされなかった**。ユーザー環境の `fetch(url,{cache:'no-store'})` で最新（1991件）取得を確認して確定。

## 変更内容

graph の fetch 2箇所（メイン `graphData` 取得・BYOKツールの他年度取得）に `cache: 'no-cache'` を付与。

- ブラウザは必ず ETag で**再検証**（未更新は304=帯域ゼロ、更新時のみ本体取得）
- `no-store`（毎回フル取得）ではなく `no-cache` とすることで 304 活用により帯域を抑える
- 対象は graph のみ。フィルタ機能追加のたびにフィールドが増える（`subcontractDepth`/`subcontractRecipients` 等）ため確実な再検証が適切。subcontracts 等は構造が安定しており現状の SWR キャッシュを維持
- `vercel.json`（サーバ側 Cache-Control）は変更せず既存の帯域設計を尊重

## テスト・検証

- tsc OK・lint エラー0
- 実データでフィルタ動作を確認（支出先「朝倉」+ 再委託先ON = 5件）
- `no-cache` の再検証挙動は「既にキャッシュを持つブラウザ」でのみ効くため、**最終確認は本番デプロイ後**（マージ後、ユーザーが次にページを開いた時点でブラウザが自動再検証し最新 graph に切り替わる）

### レビュー後の動作確認手順

```bash
npm run dev
# /sankey-svg → 支出先「朝倉」+「再委託先」チェックON → 5件
# DevTools Network で sankey-svg-*-graph.json のリクエストが再検証（キャッシュあり時は304）されること
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)