### PR TITLE
feat(subcontracts): 予算・執行ノード列を追加し事業を緑/オレンジ結合ノードに（F1）

### DIFF
--- a/app/lib/subcontract-ribbon-layout.ts
+++ b/app/lib/subcontract-ribbon-layout.ts
@@ -251,7 +251,10 @@ export function computeSubcontractRibbonLayout(graph: RibbonLayoutInput): Subcon
   const depthMap = computeDepths(graph.flows); // blockId -> depth(>=1)。root は depth 0 相当（別管理）
   // 予算・執行列（最左）: 歳出予算項目を金額降順で緑ノードに。予算総額は事業ノードの予算側の高さになる
   const budgetBreakdown = [...(graph.budgetBreakdown ?? [])].filter((b) => b.amount > 0).sort((a, b) => b.amount - a.amount);
-  const budgetTotal = graph.budgetSummary?.totalBudget ?? budgetBreakdown.reduce((s, b) => s + b.amount, 0);
+  // 予算総額は「実際に描画する予算内訳ノードの合計」を採用する（budgetSummary.totalBudget を
+  // 優先すると、公式合計と内訳合計がズレる事業で funnel が root.budgetH まで届かず緑側に隙間が
+  // できたり、逆にはみ出したりする）。公式合計との差分は側パネル側で別途警告表示している。
+  const budgetTotal = budgetBreakdown.reduce((s, b) => s + b.amount, 0);
   const mergedFlows = mergeParallelFlows(graph.flows);
 
   const blockById = new Map<string, BlockNode>();
@@ -455,9 +458,10 @@ export function computeSubcontractRibbonLayout(graph: RibbonLayoutInput): Subcon
     RIBBON_BAR_MIN_H,
     rootOutgoing.reduce((sum, f) => sum + (sourceThickness.get(f) ?? 0), 0),
   );
-  // 予算・執行ノードを最左（col0）に置くため、事業(root)以降を1列右へずらす基準x
-  const CONTENT_BASE_X = RIBBON_MARGIN.left + RIBBON_COL_W + RIBBON_COL_GAP;
   const hasBudgetCol = budgetBreakdown.length > 0 && budgetTotal > 0;
+  // 予算・執行ノード列がある場合のみ、事業(root)以降を1列右へずらす基準x。
+  // 予算データが無い事業では左端に余分な空列を作らず root を最左に置く。
+  const CONTENT_BASE_X = hasBudgetCol ? RIBBON_MARGIN.left + RIBBON_COL_W + RIBBON_COL_GAP : RIBBON_MARGIN.left;
   const budgetH = hasBudgetCol ? Math.max(rootH, budgetTotal * k) : 0;
   const rootY = Math.max(RIBBON_MARGIN.top, directMidY - rootH / 2);
   // 事業ノード: メインの mergedProjectPath 相当。予算(左・緑, budgetH)＋支出(右・オレンジ, rootH)の結合。
@@ -498,7 +502,9 @@ export function computeSubcontractRibbonLayout(graph: RibbonLayoutInput): Subcon
   const separateTopLevel = [...depth1Nodes.filter((n) => isSeparateOriginKind(n.originKind)), ...separateOrphans];
   let separateLane: RibbonSeparateLane | null = null;
   if (separateTopLevel.length > 0) {
-    const directContentBottom = Math.max(directBandBottom, hasDirectBand ? root.y + root.h : RIBBON_MARGIN.top);
+    // 事業ノードは top 揃えの結合形状で、緑側(budgetH)が支出側(h)より下へ伸び得るため、
+    // 別財源レーンは root.h ではなく max(h, budgetH) の下端を基準に配置して重なりを防ぐ。
+    const directContentBottom = Math.max(directBandBottom, hasDirectBand ? root.y + Math.max(root.h, root.budgetH ?? 0) : RIBBON_MARGIN.top);
     bandCursor = directContentBottom + RIBBON_LANE_GAP;
     const laneTop = bandCursor;
     for (const node of separateTopLevel) {

--- a/app/lib/subcontract-ribbon-layout.ts
+++ b/app/lib/subcontract-ribbon-layout.ts
@@ -47,10 +47,11 @@ export const RIBBON_BAR_W = 20;
 export const RIBBON_LABEL_W = 190;
 export const RIBBON_COL_W = RIBBON_BAR_W + RIBBON_LABEL_W;
 export const RIBBON_COL_GAP = 40;
-export const RIBBON_ROW_GAP = 14;
+// ノード縦間隔は /sankey-svg（NODE_PAD=2）の密な詰め方を参考に小さめに取る
+export const RIBBON_ROW_GAP = 6;
 // 直接系バンド群と別財源レーンの間の追加ギャップ（通常の兄弟間ギャップより大きく取り、
 // 視覚的に「別レーン」であることを示す）
-export const RIBBON_LANE_GAP = 56;
+export const RIBBON_LANE_GAP = 28;
 // /sankey-svg の computeLayout に合わせ、最低高さは「読みやすさのための下駄」ではなく
 // 描画上のハード床（1px）とする。金額差はすべて線形スケールの高さ差として表現する。
 export const RIBBON_BAR_MIN_H = 1;

--- a/app/lib/subcontract-ribbon-layout.ts
+++ b/app/lib/subcontract-ribbon-layout.ts
@@ -110,6 +110,8 @@ export interface RibbonSeparateLane {
 }
 
 export interface SubcontractRibbonLayout {
+  /** 予算・執行ノード（事業ノードの左・最左列）。メイン画面の 総計→事業 に相当する足場 */
+  budgetNode: RibbonRoot;
   root: RibbonRoot;
   bars: RibbonBar[];
   flows: RibbonFlow[];
@@ -424,13 +426,22 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
     RIBBON_BAR_MIN_H,
     rootOutgoing.reduce((sum, f) => sum + (sourceThickness.get(f) ?? 0), 0),
   );
+  // 予算・執行ノードを最左（col0）に置くため、事業(root)以降を1列右へずらす基準x
+  const CONTENT_BASE_X = RIBBON_MARGIN.left + RIBBON_COL_W + RIBBON_COL_GAP;
   const root: RibbonRoot = {
     label: graph.projectName,
-    x: RIBBON_MARGIN.left,
-    // バー幅は他ノードと同じスリム幅（sankeyノード風）。列内容幅(RIBBON_COL_W)は
-    // ラベル領域込みでdepth1列との間隔に使われるため、xの起点は変えない
+    x: CONTENT_BASE_X,
+    // バー幅は他ノードと同じスリム幅（sankeyノード風）
     w: RIBBON_BAR_W,
     y: Math.max(RIBBON_MARGIN.top, directMidY - rootH / 2),
+    h: rootH,
+  };
+  // 予算・執行ノード（最左）。事業への流出総額(rootH)と同じ高さで、予算→事業リボンを一定太さにする
+  const budgetNode: RibbonRoot = {
+    label: '予算・執行',
+    x: RIBBON_MARGIN.left,
+    w: RIBBON_BAR_W,
+    y: root.y,
     h: rootH,
   };
 
@@ -456,7 +467,7 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
   const bars: RibbonBar[] = [];
   const barByBlockId = new Map<string, RibbonBar>();
   for (const [depth, nodes] of [...byDepth.entries()].sort((a, b) => a[0] - b[0])) {
-    const colX = RIBBON_MARGIN.left + depth * (RIBBON_COL_W + RIBBON_COL_GAP);
+    const colX = CONTENT_BASE_X + depth * (RIBBON_COL_W + RIBBON_COL_GAP);
     for (const node of nodes) {
       const h = barH(node);
       const y = nodeY.get(node.blockId) ?? RIBBON_MARGIN.top;
@@ -568,11 +579,12 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
 
   // SVGサイズ
   const maxColDepth = byDepth.size > 0 ? Math.max(...byDepth.keys()) : 0;
-  const maxRight = RIBBON_MARGIN.left + (maxColDepth + 1) * (RIBBON_COL_W + RIBBON_COL_GAP) - RIBBON_COL_GAP + RIBBON_MARGIN.right;
+  const maxRight = CONTENT_BASE_X + (maxColDepth + 1) * (RIBBON_COL_W + RIBBON_COL_GAP) - RIBBON_COL_GAP + RIBBON_MARGIN.right;
   const maxBottomBars = bars.length > 0 ? Math.max(...bars.map((b) => b.y + b.h)) : 0;
   const maxBottom = Math.max(maxBottomBars, root.y + root.h, RIBBON_MARGIN.top + 100) + RIBBON_MARGIN.bottom;
 
   return {
+    budgetNode,
     root,
     bars,
     flows,

--- a/app/lib/subcontract-ribbon-layout.ts
+++ b/app/lib/subcontract-ribbon-layout.ts
@@ -4,7 +4,24 @@ import type {
   BlockOriginKind,
   FlowOrigin,
 } from '@/types/subcontract';
+import type { BudgetBreakdownItem, BudgetSummary } from '@/types/sankey-svg';
 import { computeDepths, mergeParallelFlows } from '@/app/lib/subcontract-layout';
+
+/** レイアウト入力: 再委託グラフ ＋ API 合成の予算内訳（予算・執行列の描画に使う） */
+export type RibbonLayoutInput = SubcontractGraph & {
+  budgetBreakdown?: BudgetBreakdownItem[];
+  budgetSummary?: BudgetSummary | null;
+};
+
+/** 予算・執行列の1ノード（歳出予算項目＝budgetType 単位。緑） */
+export interface RibbonBudgetItem {
+  label: string;
+  amount: number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
 
 /**
  * B案（サンキー風横フロー・リボン表現）のレイアウト計算。
@@ -67,7 +84,13 @@ export interface RibbonRoot {
   x: number;
   y: number;
   w: number;
+  /** 事業ノードでは支出側(右・オレンジ)の高さ。予算内訳ノードでは通常の高さ */
   h: number;
+  /** 事業ノードのみ: 予算側(左・緑)の高さ。h(支出) と別（メインの mergedProjectPath 相当のドッキング） */
+  budgetH?: number;
+  /** 事業ノードのみ: 予算総額・支出額（左右のラベル用） */
+  budgetAmount?: number;
+  spendingAmount?: number;
 }
 
 /** 順方向フロー（col間を繋ぐ帯）。両端の太さは接続先バーの高さから配分され、異なる値を取り得る（テーパー付き） */
@@ -110,8 +133,10 @@ export interface RibbonSeparateLane {
 }
 
 export interface SubcontractRibbonLayout {
-  /** 予算・執行ノード（事業ノードの左・最左列）。メイン画面の 総計→事業 に相当する足場 */
-  budgetNode: RibbonRoot;
+  /** 予算・執行列（最左）。歳出予算項目ごとの緑ノード。事業ノードの予算側へ流入する */
+  budgetItems: RibbonBudgetItem[];
+  /** 予算→事業(予算側) のリボン。budgetItems[i] に対応 */
+  budgetFlows: { x1: number; y1Top: number; y1Bot: number; x2: number; y2Top: number; y2Bot: number }[];
   root: RibbonRoot;
   bars: RibbonBar[];
   flows: RibbonFlow[];
@@ -141,8 +166,8 @@ export function ribbonAmountScale(amount: number, k: number): number {
  * 全ブロックが 0 円（制度フローのみ等）の場合は k=1 にフォールバックする
  * （その場合は全バーが RIBBON_BAR_MIN_H の床に張り付く）。
  */
-export function computeRibbonK(byDepth: Map<number, BlockNode[]>): number {
-  let maxColTotal = 0;
+export function computeRibbonK(byDepth: Map<number, BlockNode[]>, extraColTotal = 0): number {
+  let maxColTotal = Math.max(0, extraColTotal); // 予算・執行列（予算総額）も列合計の最大候補に含める
   for (const nodes of byDepth.values()) {
     const total = nodes.reduce((s, n) => s + Math.max(0, n.totalAmount), 0);
     if (total > maxColTotal) maxColTotal = total;
@@ -221,8 +246,11 @@ export function truncateRibbonLabelName(
 
 // ─── メインレイアウト関数 ──────────────────────────────────────────────
 
-export function computeSubcontractRibbonLayout(graph: SubcontractGraph): SubcontractRibbonLayout {
+export function computeSubcontractRibbonLayout(graph: RibbonLayoutInput): SubcontractRibbonLayout {
   const depthMap = computeDepths(graph.flows); // blockId -> depth(>=1)。root は depth 0 相当（別管理）
+  // 予算・執行列（最左）: 歳出予算項目を金額降順で緑ノードに。予算総額は事業ノードの予算側の高さになる
+  const budgetBreakdown = [...(graph.budgetBreakdown ?? [])].filter((b) => b.amount > 0).sort((a, b) => b.amount - a.amount);
+  const budgetTotal = graph.budgetSummary?.totalBudget ?? budgetBreakdown.reduce((s, b) => s + b.amount, 0);
   const mergedFlows = mergeParallelFlows(graph.flows);
 
   const blockById = new Map<string, BlockNode>();
@@ -291,7 +319,7 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
   // 各トップレベルノード（depth1 または orphan）は、自分の子孫全体が専有する縦バンドを持つ。
   // 親は自分のバンドの中央に置かれる（単一子の連鎖は真横に一直線になる）。
   const maxAmount = Math.max(0, ...graph.blocks.map((b) => b.totalAmount));
-  const k = computeRibbonK(byDepth);
+  const k = computeRibbonK(byDepth, budgetTotal);
   const barH = (node: BlockNode): number => ribbonAmountScale(node.totalAmount, k);
 
   // ─── フロー分類（順方向 / バックエッジ）とテーパー太さ配分 ──────────────────────
@@ -428,22 +456,34 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
   );
   // 予算・執行ノードを最左（col0）に置くため、事業(root)以降を1列右へずらす基準x
   const CONTENT_BASE_X = RIBBON_MARGIN.left + RIBBON_COL_W + RIBBON_COL_GAP;
+  const hasBudgetCol = budgetBreakdown.length > 0 && budgetTotal > 0;
+  const budgetH = hasBudgetCol ? Math.max(rootH, budgetTotal * k) : 0;
+  const rootY = Math.max(RIBBON_MARGIN.top, directMidY - rootH / 2);
+  // 事業ノード: メインの mergedProjectPath 相当。予算(左・緑, budgetH)＋支出(右・オレンジ, rootH)の結合。
+  // 幅は 2*RIBBON_BAR_W（左半分=予算, 右半分=支出）。支出側(右)から blocks へ流出する
   const root: RibbonRoot = {
     label: graph.projectName,
     x: CONTENT_BASE_X,
-    // バー幅は他ノードと同じスリム幅（sankeyノード風）
-    w: RIBBON_BAR_W,
-    y: Math.max(RIBBON_MARGIN.top, directMidY - rootH / 2),
+    w: hasBudgetCol ? RIBBON_BAR_W * 2 : RIBBON_BAR_W,
+    y: rootY,
     h: rootH,
+    budgetH: hasBudgetCol ? budgetH : undefined,
+    budgetAmount: hasBudgetCol ? budgetTotal : undefined,
+    spendingAmount: hasBudgetCol ? graph.execution : undefined,
   };
-  // 予算・執行ノード（最左）。事業への流出総額(rootH)と同じ高さで、予算→事業リボンを一定太さにする
-  const budgetNode: RibbonRoot = {
-    label: '予算・執行',
-    x: RIBBON_MARGIN.left,
-    w: RIBBON_BAR_W,
-    y: root.y,
-    h: rootH,
-  };
+  // 予算・執行列（最左・緑）: 歳出予算項目を上から積む（合計高さ = budgetH = budgetTotal*k）
+  const budgetItems: RibbonBudgetItem[] = [];
+  const budgetFlows: SubcontractRibbonLayout['budgetFlows'] = [];
+  if (hasBudgetCol) {
+    let cursor = rootY;
+    for (const bi of budgetBreakdown) {
+      const h = Math.max(RIBBON_BAR_MIN_H, bi.amount * k);
+      budgetItems.push({ label: bi.budgetType || '—', amount: bi.amount, x: RIBBON_MARGIN.left, y: cursor, w: RIBBON_BAR_W, h });
+      // 予算内訳ノード右端 → 事業(予算側=左端 root.x) へ水平の帯
+      budgetFlows.push({ x1: RIBBON_MARGIN.left + RIBBON_BAR_W, y1Top: cursor, y1Bot: cursor + h, x2: root.x, y2Top: cursor, y2Bot: cursor + h });
+      cursor += h;
+    }
+  }
 
   // 別財源グループ（separate-origin の depth1 + orphan）を、直接系グループ（バー・ルート
   // カードの両方）の下に追加ギャップを空けて独立レーンとして配置する
@@ -581,10 +621,12 @@ export function computeSubcontractRibbonLayout(graph: SubcontractGraph): Subcont
   const maxColDepth = byDepth.size > 0 ? Math.max(...byDepth.keys()) : 0;
   const maxRight = CONTENT_BASE_X + (maxColDepth + 1) * (RIBBON_COL_W + RIBBON_COL_GAP) - RIBBON_COL_GAP + RIBBON_MARGIN.right;
   const maxBottomBars = bars.length > 0 ? Math.max(...bars.map((b) => b.y + b.h)) : 0;
-  const maxBottom = Math.max(maxBottomBars, root.y + root.h, RIBBON_MARGIN.top + 100) + RIBBON_MARGIN.bottom;
+  const maxBudgetBottom = budgetItems.length > 0 ? Math.max(...budgetItems.map((b) => b.y + b.h)) : 0;
+  const maxBottom = Math.max(maxBottomBars, maxBudgetBottom, root.y + Math.max(root.h, root.budgetH ?? 0), RIBBON_MARGIN.top + 100) + RIBBON_MARGIN.bottom;
 
   return {
-    budgetNode,
+    budgetItems,
+    budgetFlows,
     root,
     bars,
     flows,

--- a/app/lib/subcontract-ribbon-layout.ts
+++ b/app/lib/subcontract-ribbon-layout.ts
@@ -476,13 +476,20 @@ export function computeSubcontractRibbonLayout(graph: RibbonLayoutInput): Subcon
   const budgetItems: RibbonBudgetItem[] = [];
   const budgetFlows: SubcontractRibbonLayout['budgetFlows'] = [];
   if (hasBudgetCol) {
+    // ブロック列と同じ RIBBON_ROW_GAP を予算内訳ノード間にも入れて詰め方を揃える。
+    // ノード群は事業ノードの緑側(高さ budgetH)より縦に広がるため、フローは金額按分で
+    // 緑側へ収束（ファネル）させる（メインの sankey と同じ流儀）。
     let cursor = rootY;
+    let cumAmount = 0;
     for (const bi of budgetBreakdown) {
       const h = Math.max(RIBBON_BAR_MIN_H, bi.amount * k);
       budgetItems.push({ label: bi.budgetType || '—', amount: bi.amount, x: RIBBON_MARGIN.left, y: cursor, w: RIBBON_BAR_W, h });
-      // 予算内訳ノード右端 → 事業(予算側=左端 root.x) へ水平の帯
-      budgetFlows.push({ x1: RIBBON_MARGIN.left + RIBBON_BAR_W, y1Top: cursor, y1Bot: cursor + h, x2: root.x, y2Top: cursor, y2Bot: cursor + h });
-      cursor += h;
+      // 予算内訳ノード右端 → 事業(予算側=左端 root.x)。事業側の着地は金額按分位置に収束
+      const y2Top = rootY + (cumAmount / budgetTotal) * budgetH;
+      const y2Bot = rootY + ((cumAmount + bi.amount) / budgetTotal) * budgetH;
+      budgetFlows.push({ x1: RIBBON_MARGIN.left + RIBBON_BAR_W, y1Top: cursor, y1Bot: cursor + h, x2: root.x, y2Top, y2Bot });
+      cursor += h + RIBBON_ROW_GAP;
+      cumAmount += bi.amount;
     }
   }
 

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -1627,8 +1627,10 @@ function SubcontractDetailPageInner() {
   // ラベルが次列のバーへ食い込まないよう、列ごとに clipPath でラベル領域を切り取る
   // （sankey の clip-col-* と同じ流儀）。最終列だけはラベルが右マージンへ自由に伸びてよい
   const ribbonMaxDepth = safeRibbonLayout.bars.length > 0 ? Math.max(...safeRibbonLayout.bars.map((b) => b.depth)) : 0;
-  // 予算・執行ノードを最左に置くため、事業(depth0相当)以降は1列右。depth d のブロック列 x。
-  const ribbonColX = (depth: number) => RIBBON_MARGIN.left + (depth + 1) * (RIBBON_COL_W + RIBBON_COL_GAP);
+  // 予算・執行ノード列がある場合のみ、事業(depth0相当)以降を1列右へずらす。
+  // 予算データが無い事業ではオフセットせず、レイアウト側 CONTENT_BASE_X と整合させる。
+  const ribbonHasBudgetCol = safeRibbonLayout.root.budgetH != null;
+  const ribbonColX = (depth: number) => RIBBON_MARGIN.left + (depth + (ribbonHasBudgetCol ? 1 : 0)) * (RIBBON_COL_W + RIBBON_COL_GAP);
   return (
     <div style={{ display: 'flex', height: '100vh', background: COLOR_CANVAS, overflow: 'hidden' }}>
       {/* SVGキャンバス */}
@@ -2327,7 +2329,8 @@ function SubcontractDetailPageInner() {
           type Col = { key: string; label: string; amountLines: string[]; xCenter: number; topY: number };
           const cols: Col[] = [];
           if (L.budgetItems.length > 0) {
-            const budgetTotal = L.root.budgetAmount ?? L.budgetItems.reduce((s, b) => s + b.amount, 0);
+            // 実際に描画している予算内訳ノードの合計を見出しに出す（レイアウトの funnel と一致）
+            const budgetTotal = L.budgetItems.reduce((s, b) => s + b.amount, 0);
             cols.push({
               key: 'budget', label: '予算・執行', amountLines: [formatYen(budgetTotal)],
               xCenter: L.budgetItems[0].x + L.budgetItems[0].w / 2,

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -1617,7 +1617,8 @@ function SubcontractDetailPageInner() {
   // ラベルが次列のバーへ食い込まないよう、列ごとに clipPath でラベル領域を切り取る
   // （sankey の clip-col-* と同じ流儀）。最終列だけはラベルが右マージンへ自由に伸びてよい
   const ribbonMaxDepth = safeRibbonLayout.bars.length > 0 ? Math.max(...safeRibbonLayout.bars.map((b) => b.depth)) : 0;
-  const ribbonColX = (depth: number) => RIBBON_MARGIN.left + depth * (RIBBON_COL_W + RIBBON_COL_GAP);
+  // 予算・執行ノードを最左に置くため、事業(depth0相当)以降は1列右。depth d のブロック列 x。
+  const ribbonColX = (depth: number) => RIBBON_MARGIN.left + (depth + 1) * (RIBBON_COL_W + RIBBON_COL_GAP);
   return (
     <div style={{ display: 'flex', height: '100vh', background: COLOR_CANVAS, overflow: 'hidden' }}>
       {/* SVGキャンバス */}
@@ -2055,6 +2056,11 @@ function SubcontractDetailPageInner() {
           <>
             {/* 列ラベルの clipPath（ラベルが次列のバーへ食い込むのを防ぐ。sankeyのclip-col-*と同じ流儀） */}
             <defs>
+              {/* 予算(緑)→事業/執行(オレンジ) のリボン用グラデーション（メインの 予算→執行 に対応） */}
+              <linearGradient id="budget-exec-grad" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stopColor={SEMANTIC_PROJECT} />
+                <stop offset="100%" stopColor="#e07040" />
+              </linearGradient>
               {Array.from({ length: ribbonMaxDepth }, (_, i) => i + 1).map((d) => (
                 <clipPath id={`ribbon-clip-col-${d}`} key={d}>
                   <rect
@@ -2147,6 +2153,51 @@ function SubcontractDetailPageInner() {
               />
             ))}
 
+            {/* 予算・執行 → 事業リボン（緑→オレンジ。メインの 予算→執行 の流れに対応） */}
+            <path
+              d={ribbonFlowPath(
+                safeRibbonLayout.budgetNode.x + safeRibbonLayout.budgetNode.w,
+                safeRibbonLayout.budgetNode.y,
+                safeRibbonLayout.budgetNode.y + safeRibbonLayout.budgetNode.h,
+                safeRibbonLayout.root.x,
+                safeRibbonLayout.root.y,
+                safeRibbonLayout.root.y + safeRibbonLayout.root.h,
+              )}
+              fill="url(#budget-exec-grad)"
+              fillOpacity={0.28}
+              style={{ pointerEvents: 'none' }}
+            />
+
+            {/* 予算・執行ノード（最左・緑。メインの project-budget 相当） */}
+            <g style={{ cursor: 'default' }}>
+              <rect
+                x={safeRibbonLayout.budgetNode.x}
+                y={safeRibbonLayout.budgetNode.y}
+                width={safeRibbonLayout.budgetNode.w}
+                height={Math.max(1, safeRibbonLayout.budgetNode.h)}
+                rx={1}
+                fill={SEMANTIC_PROJECT}
+                vectorEffect="non-scaling-stroke"
+              />
+              <foreignObject
+                x={safeRibbonLayout.budgetNode.x + safeRibbonLayout.budgetNode.w + 6}
+                y={safeRibbonLayout.budgetNode.y - 4}
+                width={RIBBON_LABEL_W - 6}
+                height={Math.max(safeRibbonLayout.budgetNode.h + 8, 44)}
+                style={{ pointerEvents: 'none' }}
+              >
+                <div style={{ fontFamily: 'inherit', userSelect: 'none', display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%' }}>
+                  <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: '#94a3b8' }}>予算・執行</div>
+                  <div style={{ fontSize: scaleFont(10), fontWeight: 600, color: '#333', marginTop: 2 }}>
+                    予算 {graph.budget > 0 ? formatYen(graph.budget) : '—'}
+                  </div>
+                  <div style={{ fontSize: scaleFont(9), fontWeight: 500, color: '#888', marginTop: 1 }}>
+                    執行 {graph.execution > 0 ? formatYen(graph.execution) : '—'}
+                  </div>
+                </div>
+              </foreignObject>
+            </g>
+
             {/* 事業コンテキストノード（ルート。他ノードと同じスリムバー + 横のラベル。sankeyノード風） */}
             <g
               onClick={handleDeselect}
@@ -2160,7 +2211,7 @@ function SubcontractDetailPageInner() {
                 width={safeRibbonLayout.root.w}
                 height={Math.max(1, safeRibbonLayout.root.h)}
                 rx={1}
-                fill={COLOR_ROOT}
+                fill="#e07040"
                 stroke={hoveredNodeRaw?.kind === 'root' ? '#111827' : 'none'}
                 strokeWidth={hoveredNodeRaw?.kind === 'root' ? 1.5 : 0}
                 vectorEffect="non-scaling-stroke"
@@ -2180,9 +2231,7 @@ function SubcontractDetailPageInner() {
                   <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: '#333', lineHeight: `${scaleFont(13)}px`, marginTop: 2, ...CLAMP_2_LINES }}>
                     {graph.projectName}
                   </div>
-                  <div style={{ fontSize: scaleFont(9), fontWeight: 500, color: '#888', marginTop: 2 }}>
-                    予算 {graph.budget > 0 ? formatYen(graph.budget) : '—'} ・ 支出 {graph.execution > 0 ? formatYen(graph.execution) : '—'}
-                  </div>
+                  {/* 予算・支出額は左の「予算・執行」ノードに表示するためここでは省略 */}
                 </div>
               </foreignObject>
             </g>

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -2315,6 +2315,72 @@ function SubcontractDetailPageInner() {
 
         </svg>
 
+        {/* 列見出し（メイン /sankey-svg の列ラベル方式）。列ごとの合計金額を列の上に
+            Sticky 表示する。pan/zoom に追従しつつ、スクロールで列頭が上に隠れても
+            上部ツールバーの直下に張り付く（top を max でクランプ）。 */}
+        {viewMode === 'ribbon' && (() => {
+          const L = safeRibbonLayout;
+          const scale = transform.scale;
+          const HEADER_TOP_RESERVE = 52; // 上部ツールバー（一覧/年度/タブ）の下端目安
+          const labelPx = scaleFont(11);
+          const amountPx = scaleFont(10);
+          type Col = { key: string; label: string; amountLines: string[]; xCenter: number; topY: number };
+          const cols: Col[] = [];
+          if (L.budgetItems.length > 0) {
+            const budgetTotal = L.root.budgetAmount ?? L.budgetItems.reduce((s, b) => s + b.amount, 0);
+            cols.push({
+              key: 'budget', label: '予算・執行', amountLines: [formatYen(budgetTotal)],
+              xCenter: L.budgetItems[0].x + L.budgetItems[0].w / 2,
+              topY: Math.min(...L.budgetItems.map((b) => b.y)),
+            });
+          }
+          cols.push({
+            key: 'root', label: '事業',
+            amountLines: L.root.budgetH != null
+              ? [`${formatYen(L.root.budgetAmount ?? 0)} / ${formatYen(L.root.spendingAmount ?? graph.execution)}`]
+              : [formatYen(graph.execution)],
+            xCenter: L.root.x + L.root.w / 2,
+            topY: L.root.y,
+          });
+          const depths = [...new Set(L.bars.map((b) => b.depth))].sort((a, b) => a - b);
+          for (const d of depths) {
+            const barsAtD = L.bars.filter((b) => b.depth === d);
+            if (barsAtD.length === 0) continue;
+            const total = barsAtD.reduce((s, b) => s + b.totalAmount, 0);
+            cols.push({
+              key: `d${d}`,
+              label: d === 1 ? '支出先' : d === 2 ? '再委託先' : `再委託先${d - 1}`,
+              amountLines: [formatYen(total)],
+              xCenter: barsAtD[0].x + barsAtD[0].w / 2,
+              topY: Math.min(...barsAtD.map((b) => b.y)),
+            });
+          }
+          return cols.map((col) => {
+            const screenX = transform.x + col.xCenter * scale;
+            const colTopScreenY = transform.y + col.topY * scale;
+            const blockH = Math.round(labelPx * 1.4 + col.amountLines.length * amountPx * 1.4 + 6);
+            const top = Math.max(HEADER_TOP_RESERVE, colTopScreenY - blockH - 6);
+            return (
+              <div
+                key={col.key}
+                style={{
+                  position: 'absolute', left: screenX, top,
+                  transform: 'translateX(-50%)', textAlign: 'center',
+                  fontSize: labelPx, color: '#999', whiteSpace: 'nowrap',
+                  userSelect: 'none', cursor: 'default', pointerEvents: 'none',
+                  zIndex: 6, lineHeight: 1.4,
+                  background: 'rgba(255,255,255,0.82)', padding: '2px 8px', borderRadius: 4,
+                }}
+              >
+                <div>{col.label}</div>
+                {col.amountLines.map((a, i) => (
+                  <div key={i} style={{ fontSize: amountPx }}>{a}</div>
+                ))}
+              </div>
+            );
+          });
+        })()}
+
         {/* ホバーツールチップ — サンキー流儀のマウス追従 HTML div（220ms遅延・パン/ズーム直後は抑制） */}
         {hoveredNodeStable && !isPanning.current && !isHoverSuppressed && (() => {
           const isRoot = hoveredNodeStable.kind === 'root';

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -229,6 +229,16 @@ const CLAMP_2_LINES: CSSProperties = {
   overflow: 'hidden',
 } as CSSProperties;
 
+/**
+ * 事業ノードの結合シェイプ（予算=左・緑・高さbH / 支出=右・オレンジ・高さsH。上端揃え）。
+ * メイン /sankey-svg の mergedProjectPath と同型（絶対座標版）。幅は barW*2。
+ */
+function mergedProjectPath(x0: number, yTop: number, barW: number, bH: number, sH: number): string {
+  const x2 = x0 + barW * 2;
+  const mx = (x0 + x2) / 2;
+  return `M${x0},${yTop} L${x2},${yTop} L${x2},${yTop + sH} C${mx},${yTop + sH} ${mx},${yTop + bH} ${x0},${yTop + bH} Z`;
+}
+
 interface ProjectQualityOrg {
   pid: string;
   bureau?: string;
@@ -508,9 +518,9 @@ function SidePane({
             <div style={{ fontWeight: 700, fontSize: PANEL_TITLE_FONT_PX, color: '#111', wordBreak: 'break-all', lineHeight: 1.4 }}>
               {graph.projectName}
             </div>
-            {/* 予算額 / 執行額（メイン画面と同じ2列＋1円単位のサブ表記） */}
+            {/* 予算額 / 支出額（メイン画面と同じ2列＋1円単位のサブ表記。予算vs支出で用語統一） */}
             <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', columnGap: 12, rowGap: 4, marginTop: 5 }}>
-              {([['予算額', graph.budget], ['執行額', graph.execution]] as [string, number][]).map(([label, value]) => (
+              {([['予算額', graph.budget], ['支出額', graph.execution]] as [string, number][]).map(([label, value]) => (
                 <div key={label} style={{ flex: `1 1 ${scaleFont(112)}px`, minWidth: 0 }}>
                   <span style={{ display: 'block', fontSize: PANEL_META_FONT_PX, color: '#aaa', fontWeight: 400, marginBottom: 1 }}>{label}</span>
                   <span style={{ display: 'block', fontSize: PANEL_PRIMARY_VALUE_FONT_PX, fontWeight: 600, color: '#222', whiteSpace: 'nowrap' }}>
@@ -2056,9 +2066,11 @@ function SubcontractDetailPageInner() {
           <>
             {/* 列ラベルの clipPath（ラベルが次列のバーへ食い込むのを防ぐ。sankeyのclip-col-*と同じ流儀） */}
             <defs>
-              {/* 予算(緑)→事業/執行(オレンジ) のリボン用グラデーション（メインの 予算→執行 に対応） */}
-              <linearGradient id="budget-exec-grad" x1="0" y1="0" x2="1" y2="0">
+              {/* 事業ノードの 予算(緑)｜支出(オレンジ) ドッキング用グラデ（メインの proj-node-grad と同じ 44/56 分割） */}
+              <linearGradient id="budget-exec-grad" x1="0%" y1="0%" x2="100%" y2="0%">
                 <stop offset="0%" stopColor={SEMANTIC_PROJECT} />
+                <stop offset="44%" stopColor={SEMANTIC_PROJECT} />
+                <stop offset="56%" stopColor="#e07040" />
                 <stop offset="100%" stopColor="#e07040" />
               </linearGradient>
               {Array.from({ length: ribbonMaxDepth }, (_, i) => i + 1).map((d) => (
@@ -2153,70 +2165,65 @@ function SubcontractDetailPageInner() {
               />
             ))}
 
-            {/* 予算・執行 → 事業リボン（緑→オレンジ。メインの 予算→執行 の流れに対応） */}
-            <path
-              d={ribbonFlowPath(
-                safeRibbonLayout.budgetNode.x + safeRibbonLayout.budgetNode.w,
-                safeRibbonLayout.budgetNode.y,
-                safeRibbonLayout.budgetNode.y + safeRibbonLayout.budgetNode.h,
-                safeRibbonLayout.root.x,
-                safeRibbonLayout.root.y,
-                safeRibbonLayout.root.y + safeRibbonLayout.root.h,
-              )}
-              fill="url(#budget-exec-grad)"
-              fillOpacity={0.28}
-              style={{ pointerEvents: 'none' }}
-            />
-
-            {/* 予算・執行ノード（最左・緑。メインの project-budget 相当） */}
-            <g style={{ cursor: 'default' }}>
-              <rect
-                x={safeRibbonLayout.budgetNode.x}
-                y={safeRibbonLayout.budgetNode.y}
-                width={safeRibbonLayout.budgetNode.w}
-                height={Math.max(1, safeRibbonLayout.budgetNode.h)}
-                rx={1}
+            {/* 予算・執行列 → 事業(予算側) のリボン（緑） */}
+            {safeRibbonLayout.budgetFlows.map((bf, i) => (
+              <path
+                key={`bflow-${i}`}
+                d={ribbonFlowPath(bf.x1, bf.y1Top, bf.y1Bot, bf.x2, bf.y2Top, bf.y2Bot)}
                 fill={SEMANTIC_PROJECT}
-                vectorEffect="non-scaling-stroke"
-              />
-              <foreignObject
-                x={safeRibbonLayout.budgetNode.x + safeRibbonLayout.budgetNode.w + 6}
-                y={safeRibbonLayout.budgetNode.y - 4}
-                width={RIBBON_LABEL_W - 6}
-                height={Math.max(safeRibbonLayout.budgetNode.h + 8, 44)}
+                fillOpacity={0.22}
                 style={{ pointerEvents: 'none' }}
-              >
-                <div style={{ fontFamily: 'inherit', userSelect: 'none', display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%' }}>
-                  <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: '#94a3b8' }}>予算・執行</div>
-                  <div style={{ fontSize: scaleFont(10), fontWeight: 600, color: '#333', marginTop: 2 }}>
-                    予算 {graph.budget > 0 ? formatYen(graph.budget) : '—'}
-                  </div>
-                  <div style={{ fontSize: scaleFont(9), fontWeight: 500, color: '#888', marginTop: 1 }}>
-                    執行 {graph.execution > 0 ? formatYen(graph.execution) : '—'}
-                  </div>
-                </div>
-              </foreignObject>
-            </g>
+              />
+            ))}
 
-            {/* 事業コンテキストノード（ルート。他ノードと同じスリムバー + 横のラベル。sankeyノード風） */}
+            {/* 予算・執行ノード列（最左・緑）。ラベルは 名前(金額) */}
+            {safeRibbonLayout.budgetItems.map((bi, i) => (
+              <g key={`bnode-${i}`}>
+                <rect x={bi.x} y={bi.y} width={bi.w} height={Math.max(1, bi.h)} rx={1} fill={SEMANTIC_PROJECT} vectorEffect="non-scaling-stroke" />
+                <text
+                  x={bi.x + bi.w + 6}
+                  y={bi.y + bi.h / 2}
+                  dominantBaseline="middle"
+                  fontSize={scaleFont(10)}
+                  fill="#333"
+                  style={{ userSelect: 'none', pointerEvents: 'none' }}
+                >
+                  {bi.label.length > 16 ? bi.label.slice(0, 15) + '…' : bi.label}
+                  <tspan fill="#888"> ({formatYen(bi.amount)})</tspan>
+                </text>
+              </g>
+            ))}
+
+            {/* 事業ノード（予算=緑 / 支出=オレンジ の結合ドッキング。メインの mergedProjectPath 相当） */}
             <g
               onClick={handleDeselect}
               onMouseEnter={() => setHoveredNodeRaw({ kind: 'root' })}
               onMouseLeave={() => setHoveredNodeRaw(null)}
               style={{ cursor: 'pointer' }}
             >
-              <rect
-                x={safeRibbonLayout.root.x}
-                y={safeRibbonLayout.root.y}
-                width={safeRibbonLayout.root.w}
-                height={Math.max(1, safeRibbonLayout.root.h)}
-                rx={1}
-                fill="#e07040"
-                stroke={hoveredNodeRaw?.kind === 'root' ? '#111827' : 'none'}
-                strokeWidth={hoveredNodeRaw?.kind === 'root' ? 1.5 : 0}
-                vectorEffect="non-scaling-stroke"
-                style={{ pointerEvents: 'all' }}
-              />
+              {safeRibbonLayout.root.budgetH != null ? (
+                <path
+                  d={mergedProjectPath(safeRibbonLayout.root.x, safeRibbonLayout.root.y, RIBBON_BAR_W, safeRibbonLayout.root.budgetH, safeRibbonLayout.root.h)}
+                  fill="url(#budget-exec-grad)"
+                  stroke={hoveredNodeRaw?.kind === 'root' ? '#111827' : 'none'}
+                  strokeWidth={hoveredNodeRaw?.kind === 'root' ? 1.5 : 0}
+                  vectorEffect="non-scaling-stroke"
+                  style={{ pointerEvents: 'all' }}
+                />
+              ) : (
+                <rect
+                  x={safeRibbonLayout.root.x}
+                  y={safeRibbonLayout.root.y}
+                  width={safeRibbonLayout.root.w}
+                  height={Math.max(1, safeRibbonLayout.root.h)}
+                  rx={1}
+                  fill="#e07040"
+                  stroke={hoveredNodeRaw?.kind === 'root' ? '#111827' : 'none'}
+                  strokeWidth={hoveredNodeRaw?.kind === 'root' ? 1.5 : 0}
+                  vectorEffect="non-scaling-stroke"
+                  style={{ pointerEvents: 'all' }}
+                />
+              )}
               <foreignObject
                 x={safeRibbonLayout.root.x + safeRibbonLayout.root.w + 6}
                 y={safeRibbonLayout.root.y - 4}
@@ -2225,13 +2232,11 @@ function SubcontractDetailPageInner() {
                 style={{ pointerEvents: 'none' }}
               >
                 <div style={{ fontFamily: 'inherit', userSelect: 'none', display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%' }}>
-                  <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: '#94a3b8' }}>
-                    事業 / PID {graph.projectId}
-                  </div>
+                  <div style={{ fontSize: scaleFont(9), fontWeight: 700, color: '#94a3b8' }}>事業 / PID {graph.projectId}</div>
                   <div style={{ fontSize: scaleFont(11), fontWeight: 700, color: '#333', lineHeight: `${scaleFont(13)}px`, marginTop: 2, ...CLAMP_2_LINES }}>
                     {graph.projectName}
+                    <span style={{ fontWeight: 500, color: '#888' }}> （支出 {graph.execution > 0 ? formatYen(graph.execution) : '—'}）</span>
                   </div>
-                  {/* 予算・支出額は左の「予算・執行」ノードに表示するためここでは省略 */}
                 </div>
               </foreignObject>
             </g>


### PR DESCRIPTION
## 目的（Why）

再委託UI刷新（`/subcontracts/[projectId]`）で、フロー図の見え方をメイン画面 `/sankey-svg` に揃えるため。利用者が「事業の予算がどの歳出項目由来で、予算と支出（執行）の差、そして各支出先・再委託先への流れ」を、メイン画面と同じ読み方で追えるようにする。

## 変更内容

**F1: 予算・執行ノード列＋事業の緑/オレンジ結合ノード**

- **予算・執行列（最左）**: 歳出予算内訳を項目ごとの緑ノードとして表示（`名前 (金額)` ラベル）。ノード間隔はブロック列と揃え、事業ノードの緑側へ金額按分でファネル収束。
- **事業ノード**: メインの `mergedProjectPath` を移植し、予算（左・緑）＋支出（右・オレンジ）を結合した1ノードに（44/56 グラデ）。
- **ノード縦間隔**: メイン（`NODE_PAD=2`）の密度を参考に `RIBBON_ROW_GAP 14→6`・`RIBBON_LANE_GAP 56→28` に調整。
- **列見出し（Sticky）**: メインの列ラベル方式を移植。予算・執行／事業（`予算 / 支出`）／支出先／再委託先… の各列合計を列中央上部に表示し、pan/zoom 追従＋上部固定。
- **用語統一**: サイドパネルの「執行額」→「支出額」など、予算 vs 支出 の表記に統一。

対象は再委託ページのみ。メイン `/sankey-svg` には変更なし。

## テスト方法

```bash
npm run dev
# http://localhost:3000/subcontracts/7?year=2025   （5歳出項目・階層3）
# http://localhost:3000/subcontracts/4119?year=2025 （18歳出項目・階層2）
```

- 予算・執行列に歳出項目の緑ノードが並び、事業ノードが緑/オレンジ結合で表示されること
- 各列上部に列合計がSticky表示され、パン/ズームで上部固定されること

lint / `tsc --noEmit` グリーン。Playwright で PID 7・4119 を目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added budget breakdown visualization to subcontract ribbon charts.
  * Budget items and budget-to-spending flows now appear as a dedicated leftmost column.
  * Added sticky column headers with column totals for easier navigation.
  * Project ribbons now visually combine budget and spending amounts.

* **UI Improvements**
  * Updated labels to “予算額 / 支出額”.
  * Simplified project ribbon labels to emphasize spending amounts.
  * Improved ribbon positioning and budget/spending color presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->