### PR TITLE
feat(subcontracts): 再委託→メイン画面の遷移導線を整理し事業列を対象事業に中央寄せ

### DIFF
--- a/app/lib/subcontracts/links.ts
+++ b/app/lib/subcontracts/links.ts
@@ -3,6 +3,14 @@ export function rsSystemProjectSearchUrl(projectName: string, year: number): str
   return `https://rssystem.go.jp/project?q=${encodeURIComponent(query)}&fiscalYear=${year}&isSearchTargetProjectName=true`;
 }
 
+/**
+ * /sankey-svg で対象事業を選択・ピンした状態を開くURL。
+ *
+ * 表示件数（tp/tr）は既定のまま渡さない。ピン事業は TopN 圏外でも必ず描画されるうえ、
+ * 上限300を指定すると「関連ノードのみ」を解除した瞬間に300事業・300支出先が出て視認性が落ちるため。
+ * 事業列のスクロール位置（po）も指定しない — 順位はグラフ読込後でないと決まらないので、
+ * /sankey-svg 側が pp から順位を引いて中央寄せする。
+ */
 export function sankeySvgProjectUrl(projectId: number, projectName: string, year: number): string {
   const budgetNodeId = `project-budget-${projectId}`;
   const spendingNodeId = `project-spending-${projectId}`;
@@ -12,8 +20,6 @@ export function sankeySvgProjectUrl(projectId: number, projectName: string, year
     pp: spendingNodeId,
     fr: '1',
     q: projectName,
-    tp: '300',
-    tr: '300',
   });
   return `/sankey-svg?${params.toString()}`;
 }

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -399,6 +399,10 @@ export default function RealDataSankeyPage() {
   // focusRelated ON中に事業をピンしたときのコンテキスト事業ID
   // projectOffsetMode + r-* 選択後にfocusRelated=OFFしたとき、親事業の特定に使う
   const pinnedContextProjectId = useRef<string | null>(null);
+  // 事業ピン付きディープリンク（/subcontracts からの遷移など）で po= 未指定のとき、
+  // グラフ読込後に一度だけ projectOffset をその事業の順位へ中央寄せするための保留ID。
+  // 順位は graphData がないと決まらないため、リンク側では po を計算せずここで解決する。
+  const pendingProjectOffsetPinId = useRef<string | null>(null);
   // Zoom URL state
   const urlRestoredZoomRef = useRef<number | null>(null); // zoom to restore on first layout (no sel= case)
   const zoomRef = useRef(1);                              // always-current zoom for debounce callbacks
@@ -448,6 +452,10 @@ export default function RealDataSankeyPage() {
     if (parsed.topProject !== undefined) prevTopProjectRef.current = parsed.topProject;
     if (parsed.selectedNodeId !== undefined) { setSelectedNodeId(parsed.selectedNodeId); pendingFocusId.current = parsed.selectedNodeId; }
     if (parsed.pinnedProjectId !== undefined) setPinnedProjectId(parsed.pinnedProjectId);
+    // po= 明示がない事業ピン付きリンクは、グラフ読込後に順位へ中央寄せする（下の useEffect）
+    if (parsed.pinnedProjectId && parsed.projectOffset === undefined && parsed.offsetTarget !== 'recipient') {
+      pendingProjectOffsetPinId.current = parsed.pinnedProjectId;
+    }
     if (parsed.pinnedRecipientId !== undefined) setPinnedRecipientId(parsed.pinnedRecipientId);
     if (parsed.pinnedMinistryName !== undefined) setPinnedMinistryName(parsed.pinnedMinistryName);
     if (parsed.recipientOffset !== undefined) setRecipientOffset(parsed.recipientOffset);
@@ -1929,6 +1937,24 @@ export default function RealDataSankeyPage() {
       });
     return new Map(ranked.map((n, i) => [n.id, i]));
   }, [graphData, filterExcludedIds, topMinistry, projectSortBy, focusRelated, pinnedRecipientId, pinnedMinistryName]);
+
+  // 事業ピン付きディープリンク（po= 未指定）の projectOffset 中央寄せ。
+  // ピン事業は TopN 圏外でも表示されるが、関連ノードのみを解除した瞬間に
+  // 先頭50事業へ飛んでしまうため、順位が判明した時点で一度だけウィンドウを合わせる。
+  // 計算は事業クリック時の jumpToProjectRank と同一。
+  useEffect(() => {
+    const pinId = pendingProjectOffsetPinId.current;
+    if (!pinId || allProjectRanks.size === 0) return;
+    pendingProjectOffsetPinId.current = null;
+    const rank = allProjectRanks.get(pinId);
+    if (rank === undefined) return;
+    const maxOffset = Math.max(0, allProjectRanks.size - topProject);
+    const newOffset = Math.max(0, Math.min(rank - Math.floor(topProject / 2), maxOffset));
+    if (newOffset > 0) {
+      pendingHistoryAction.current = 'replace';
+      setProjectOffset(newOffset);
+    }
+  }, [allProjectRanks, topProject]);
 
   // Recipient count per project-spending node (from raw graphData)
   const projectRecipientCount = useMemo(() => {

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -452,7 +452,10 @@ export default function RealDataSankeyPage() {
     if (parsed.topProject !== undefined) prevTopProjectRef.current = parsed.topProject;
     if (parsed.selectedNodeId !== undefined) { setSelectedNodeId(parsed.selectedNodeId); pendingFocusId.current = parsed.selectedNodeId; }
     if (parsed.pinnedProjectId !== undefined) setPinnedProjectId(parsed.pinnedProjectId);
-    // po= 明示がない事業ピン付きリンクは、グラフ読込後に順位へ中央寄せする（下の useEffect）
+    // po= 明示がない事業ピン付きリンクは、グラフ読込後に順位へ中央寄せする（下の useEffect）。
+    // 初回マウント限定なのは意図的。popstate・探索履歴・AI結果の復元（applyUrlState）は
+    // 「記録された表示状態をそのまま戻す」経路であり、po 非出力＝当時 offset 0 を意味する。
+    // そこで中央寄せすると戻り先が記録時と別のウィンドウになり、URL も書き換わってしまう。
     if (parsed.pinnedProjectId && parsed.projectOffset === undefined && parsed.offsetTarget !== 'recipient') {
       pendingProjectOffsetPinId.current = parsed.pinnedProjectId;
     }

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -30,7 +30,7 @@ import type { BudgetBreakdownItem, BudgetSummary } from '@/types/sankey-svg';
 import { BudgetExecutionSection } from '@/client/components/BudgetExecutionSection';
 import { ProjectOverviewSection } from '@/client/components/subcontract/ProjectOverviewSection';
 import type { ProjectDetail } from '@/types/project-details';
-import { ProjectReferenceLinks } from '@/components/subcontracts/ProjectReferenceLinks';
+import { sankeySvgProjectUrl } from '@/app/lib/subcontracts/links';
 import {
   computeSubcontractLayout,
   backEdgePath,
@@ -580,7 +580,6 @@ function SidePane({
               </div>
             )}
           </div>
-          <ProjectReferenceLinks projectId={graph.projectId} projectName={graph.projectName} year={year} compact />
         </div>
         {/* メイン画面と同型: 事業タグ＋PID＋省庁＋組織のみ（構造サマリは下の「再委託」節へ） */}
         <div style={{ display: 'flex', gap: 5, marginTop: 8, flexWrap: 'wrap', alignItems: 'center', fontSize: PANEL_META_FONT_PX }}>
@@ -598,6 +597,7 @@ function SidePane({
           detail={projectDetail}
           projectName={graph.projectName}
           year={year}
+          sankeyHref={sankeySvgProjectUrl(graph.projectId, graph.projectName, year)}
           scaleFont={scaleFont}
           expanded={overviewOpen}
           onToggle={() => setOverviewOpen(o => !o)}

--- a/client/components/subcontract/ProjectOverviewSection.tsx
+++ b/client/components/subcontract/ProjectOverviewSection.tsx
@@ -8,13 +8,15 @@ import type { ProjectDetail } from '@/types/project-details';
  *
  * 折りたたみ時プレビューの高さドラッグ変更はページ側の状態を props で受ける
  * （onResizeStart 指定時のみハンドル表示）。subcontractHref を渡すと再委託アイコンを出す
- * （再委託ページ自身では自己参照になるため渡さない）。
+ * （再委託ページ自身では自己参照になるため渡さない）。逆に再委託ページからは sankeyHref を
+ * 渡してメイン画面（/sankey-svg）へのアイコンを出す。どちらも同じタブで遷移する。
  */
 export function ProjectOverviewSection({
   detail,
   projectName,
   year,
   subcontractHref,
+  sankeyHref,
   scaleFont,
   expanded,
   onToggle,
@@ -27,6 +29,7 @@ export function ProjectOverviewSection({
   projectName: string;
   year: string | number;
   subcontractHref?: string;
+  sankeyHref?: string;
   scaleFont: (px: number) => number;
   expanded: boolean;
   onToggle: () => void;
@@ -69,6 +72,16 @@ export function ProjectOverviewSection({
         {subcontractHref && (
           <a href={subcontractHref}
             title="再委託構造を見る（同じタブで開きます）"
+            style={{ display: 'flex', alignItems: 'center', color: '#4a90d9', textDecoration: 'none', flexShrink: 0 }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="#4a90d9">
+              <path d="M760-120q-39 0-70-22.5T647-200H440q-66 0-113-47t-47-113q0-66 47-113t113-47h80q33 0 56.5-23.5T600-600q0-33-23.5-56.5T520-680H313q-13 35-43.5 57.5T200-600q-50 0-85-35t-35-85q0-50 35-85t85-35q39 0 69.5 22.5T313-760h207q66 0 113 47t47 113q0 66-47 113t-113 47h-80q-33 0-56.5 23.5T360-360q0 33 23.5 56.5T440-280h207q13-35 43.5-57.5T760-360q50 0 85 35t35 85q0 50-35 85t-85 35ZM228.5-691.5Q240-703 240-720t-11.5-28.5Q217-760 200-760t-28.5 11.5Q160-737 160-720t11.5 28.5Q183-680 200-680t28.5-11.5Z"/>
+            </svg>
+          </a>
+        )}
+        {sankeyHref && (
+          <a href={sankeyHref}
+            title="メイン画面でこの事業を表示（同じタブで開きます）"
             style={{ display: 'flex', alignItems: 'center', color: '#4a90d9', textDecoration: 'none', flexShrink: 0 }}
           >
             <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 -960 960 960" fill="#4a90d9">

--- a/components/subcontracts/ProjectReferenceLinks.tsx
+++ b/components/subcontracts/ProjectReferenceLinks.tsx
@@ -74,7 +74,7 @@ export function ProjectReferenceLinks({
       </a>
       <Link
         href={sankeySvgProjectUrl(projectId, projectName, year)}
-        aria-label="メイン画面でこの事業を表示"
+        aria-label="メイン画面でこの事業を表示（同じタブで開きます）"
         title="メイン画面でこの事業を表示（同じタブで開きます）"
         style={itemStyle}
       >

--- a/components/subcontracts/ProjectReferenceLinks.tsx
+++ b/components/subcontracts/ProjectReferenceLinks.tsx
@@ -74,10 +74,8 @@ export function ProjectReferenceLinks({
       </a>
       <Link
         href={sankeySvgProjectUrl(projectId, projectName, year)}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="/sankey-svgでこの事業を表示"
-        title="/sankey-svgでこの事業を表示"
+        aria-label="メイン画面でこの事業を表示"
+        title="メイン画面でこの事業を表示（同じタブで開きます）"
         style={itemStyle}
       >
         <SankeyIcon />


### PR DESCRIPTION
## 目的（Why）

再委託ビュー（`/subcontracts`）からメイン画面（`/sankey-svg`）へ移動したユーザーが、**遷移先で目的の事業を見失わない**ようにするため。

- サイドパネルヘッダーにメイン画面と異なる参照リンクが並んでいて、画面間で導線の位置が揃っていなかった
- 遷移リンクが別タブで開くため、行き来のたびにタブが増えていた
- ディープリンクが `tp=300&tr=300`（表示件数の上限値）を渡しており、「関連ノードのみ」を解除した瞬間に300事業・300支出先が展開されて視認性が著しく落ちていた

## 変更内容

### 導線の整理

- `/subcontracts/[projectId]` サイドパネルヘッダーの `ProjectReferenceLinks`（RS / Sankey アイコン）を削除し、メイン画面と同じヘッダー構成に揃えた。RSシステムへのリンクは事業概要行に元からあるため失われていない
- `ProjectOverviewSection` に `sankeyHref` prop を追加。渡すとメイン画面へのアイコンが出る（メイン画面側の `subcontractHref` と対の関係）。遷移は同じタブ
- 一覧 `/subcontracts` 側の Sankey リンクからも `target="_blank"` を外して同タブ遷移に統一（RSシステムは外部サイトなので別タブのまま）

### 遷移先の表示状態

- `sankeySvgProjectUrl` から `tp` / `tr` を削除。ピンされた事業は TopN 圏外でも必ず描画される（`sankey-svg-filter.ts` の pinned 例外）ため上限指定は不要で、解除時のノード氾濫だけが残っていた
- 代わりに `/sankey-svg` 側で、`pp=` 付き・`po=` 未指定のリンクを開いたときにグラフ読込後の事業順位から `projectOffset` を一度だけ中央寄せする初期化を追加。計算式は事業クリック時の `jumpToProjectRank` と同一。順位はグラフデータがないと確定しないため、リンク生成側ではなく描画側で解決している。履歴は replace 扱い

結果として、遷移先は「対象事業を中央に置いた50事業ウィンドウ＋関連ノードのみ」で開き、関連ノードのみを解除しても対象事業の周辺が見える。

## テスト方法

```bash
npm run dev
```

1. `/subcontracts` の一覧で任意の事業の Sankey アイコンを押す → 同じタブでメイン画面が開く
2. `/subcontracts/<事業ID>` の事業概要行の Sankey アイコンを押す → 同じタブでメイン画面が開き、対象事業が選択・ピンされている
3. 遷移先で「関連ノードのみ」を解除 → 事業列に対象事業が含まれ、その周辺約50事業が表示される（従来は先頭50事業に飛ぶか、300事業が展開されていた）
4. サイドパネルヘッダーに RS / Sankey アイコンが出ていないこと、事業概要行の RS リンクは残っていることを確認

`npm run lint` / `npx tsc --noEmit` は新規エラー・警告なし（既存の警告のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a link from project overview pages to open the selected project in the main Sankey view.
  - Sankey deep links now automatically center the selected project when no project position is specified.
  - Updated link labels to clarify that the main view opens in the same tab.

- **Bug Fixes**
  - Simplified Sankey view URLs by removing unnecessary parameters, improving link clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->