### PR TITLE
feat: 共通ナビ配線とサンキー図の政策評価スコア足きり（rs-vis逆流 PR-3）

### DIFF
--- a/app/lib/sankey-query.test.ts
+++ b/app/lib/sankey-query.test.ts
@@ -336,3 +336,45 @@ describe('buildFilterExcludedIds (subcontract)', () => {
     expect(sankeyQueryFromUrlParams(p3).filter?.recipientName).toEqual({ query: 'NEDO', regex: false, includeSubcontract: true });
   });
 });
+
+// ── buildFilterExcludedIds: excludeProject（政策評価スコアの足きり用フック） ──
+
+describe('buildFilterExcludedIds (excludeProject)', () => {
+  const nodes: RawNode[] = [
+    makeNode({ id: 'ministry-A', name: 'A省', type: 'ministry', value: 100 }),
+    makeNode({ id: 'project-budget-1', name: '事業1', type: 'project-budget', value: 1000, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-1', name: '事業1', type: 'project-spending', value: 900, projectId: 1, ministry: 'A省' }),
+    makeNode({ id: 'project-budget-2', name: '事業2', type: 'project-budget', value: 500, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'project-spending-2', name: '事業2', type: 'project-spending', value: 400, projectId: 2, ministry: 'A省' }),
+    makeNode({ id: 'r-1', name: '受領者A', type: 'recipient', value: 600 }),
+    makeNode({ id: 'r-2', name: '受領者B', type: 'recipient', value: 300 }),
+  ];
+  const edges: RawEdge[] = [
+    { source: 'ministry-A', target: 'project-budget-1', value: 1000 },
+    { source: 'ministry-A', target: 'project-budget-2', value: 500 },
+    { source: 'project-spending-1', target: 'r-1', value: 600 },
+    { source: 'project-spending-2', target: 'r-2', value: 300 },
+  ];
+  const baseFilter = () => resolveSankeyQuery({}).query.filter;
+
+  it('returns null when no filter and no excludeProject is given', () => {
+    expect(buildFilterExcludedIds(nodes, edges, baseFilter(), [], null)).toBeNull();
+  });
+
+  it('excludes the project budget/spending pair the predicate rejects', () => {
+    const excluded = buildFilterExcludedIds(nodes, edges, baseFilter(), [], pid => pid === 2)!;
+    expect(excluded.has('project-budget-2')).toBe(true);
+    expect(excluded.has('project-spending-2')).toBe(true);
+    expect(excluded.has('project-budget-1')).toBe(false);
+  });
+
+  it('cascades to the ministry when every project is rejected', () => {
+    const excluded = buildFilterExcludedIds(nodes, edges, baseFilter(), [], () => true)!;
+    expect(excluded.has('ministry-A')).toBe(true);
+  });
+
+  it('returns null when the predicate rejects nothing', () => {
+    // 足きりが有効でも全事業が通れば除外セットは空＝null（呼び出し側でフィルタ無しと同じ扱いになる）
+    expect(buildFilterExcludedIds(nodes, edges, baseFilter(), [], () => false)).toBeNull();
+  });
+});

--- a/app/lib/sankey-query.ts
+++ b/app/lib/sankey-query.ts
@@ -195,6 +195,12 @@ export function buildFilterExcludedIds(
   edges: RawEdge[],
   filter: ResolvedSankeyQuery['filter'],
   protectedNodeIds: readonly (string | null)[] = [],
+  /**
+   * 事業単位の追加除外。true を返した事業は予算・執行ノードごと落ちる。
+   * 政策評価スコアの足きりのように、クエリスキーマに載せず画面側でしか
+   * 材料を持てない条件を差し込むための口。
+   */
+  excludeProject?: ((projectId: number) => boolean) | null,
 ): Set<string> | null {
   const protectedProjectIds = new Set<string>();
   for (const nodeId of protectedNodeIds) {
@@ -222,7 +228,8 @@ export function buildFilterExcludedIds(
   // 再委託フィルタ: 実効下限（hasRedelegation=2、minDepth 指定時はそちらを優先）
   const subMinDepth = filter.subcontract.minDepth ?? (filter.subcontract.hasRedelegation ? 2 : null);
   const hasSubcontract = subMinDepth != null;
-  if (!hasBudget && !hasSpending && !hasProjectName && !hasRecipientName && !hasMinistry && !hasAccountFilter && !hasSubcontract) return null;
+  const hasExtraProject = excludeProject != null;
+  if (!hasBudget && !hasSpending && !hasProjectName && !hasRecipientName && !hasMinistry && !hasAccountFilter && !hasSubcontract && !hasExtraProject) return null;
 
   const selectedMinistrySet = new Set(filter.ministries);
   const minBudget = minBudgetYen ?? -Infinity;
@@ -273,7 +280,8 @@ export function buildFilterExcludedIds(
         (sn != null && projectsWithDirectNameMatch.has(sn.id)) ||
         (n.subcontractRecipients ?? []).some(matchesRecipient!)
       );
-      if (failBudget || failProjectName || failMinistry || failAccount || failSubcontract || failAnyRecipient) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
+      const failExtra = hasExtraProject && excludeProject!(n.projectId);
+      if (failBudget || failProjectName || failMinistry || failAccount || failSubcontract || failAnyRecipient || failExtra) { excluded.add(n.id); if (sn) excluded.add(sn.id); }
     } else if (n.type === 'recipient') {
       const failSpending = hasSpending && (n.value < minSpending || n.value > maxSpending);
       // includeSubcontract モードでは支出先ノードを名前で隠さない（事業単位判定のみ）
@@ -282,7 +290,7 @@ export function buildFilterExcludedIds(
     }
   }
   // Pass 2: 支出先・予算フィルタが有効な場合、残存支出先のない事業／孤立支出先を除外
-  if (hasSpending || hasBudget || hasMinistry || hasRecipientName || hasSubcontract) {
+  if (hasSpending || hasBudget || hasMinistry || hasRecipientName || hasSubcontract || hasExtraProject) {
     const projectsWithSurvivingRecipients = new Set(
       edges
         .filter(e => e.target.startsWith('r-') && !excluded.has(e.target))

--- a/app/mof-budget-overview/page.tsx
+++ b/app/mof-budget-overview/page.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@/types/mof-budget-overview';
 import type { SankeyNode } from '@/types/sankey';
 import LoadingSpinner from '@/client/components/LoadingSpinner';
+import { PageNavMenu } from '@/components/navigation/PageNavMenu';
 import { formatBudgetFromYen } from '@/client/lib/formatBudget';
 
 export default function MOFBudgetOverviewPage() {
@@ -92,14 +93,9 @@ export default function MOFBudgetOverviewPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* 固定ボタン */}
-      <div className="fixed top-4 right-4 z-40 flex gap-2">
-        <Link
-          href="/sankey-svg"
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors shadow-lg"
-        >
-          ホームに戻る
-        </Link>
+      {/* ページ切替。全ページ共通で右上に置く */}
+      <div className="fixed top-3 right-3 z-40">
+        <PageNavMenu current="/mof-budget-overview" theme="light" />
       </div>
 
       <div className="max-w-7xl mx-auto px-8">

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4,12 +4,14 @@ import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } fr
 import { createPortal } from 'react-dom';
 import type { GraphData, LayoutNode, LayoutLink } from '@/types/sankey-svg';
 import type { ProjectDetail } from '@/types/project-details';
+import type { PolicySummaryResponse } from '@/app/api/policy-summary/route';
 import {
   COL_LABELS, MARGIN, NODE_W, NODE_PAD,
   MAX_RECIPIENT_GAP_PX, MAX_MINISTRY_GAP_PX,
   TYPE_COLORS, TYPE_LABELS,
   getColumn, getNodeColor, getLinkColor, ribbonPath, formatYen, sortPriority,
 } from '@/app/lib/sankey-svg-constants';
+import { PageNavMenu } from '@/components/navigation/PageNavMenu';
 import { MinimapOverlay } from '@/client/components/SankeySvg/MinimapOverlay';
 import { TopNSliders } from '@/client/components/SankeySvg/TopNSliders';
 import { FontSizeControls } from '@/client/components/SankeySvg/FontSizeControls';
@@ -93,6 +95,10 @@ interface SankeyUrlState {
   filterMaxBudgetText?: string;
   filterMinSpendingText?: string;
   filterMaxSpendingText?: string;
+  /** 政策評価スコアの足きり "min-max"（0-100・片側空欄可）。o=総合 x=費用対内容 n=必要性 */
+  filterScoreO?: string;
+  filterScoreX?: string;
+  filterScoreN?: string;
   acGeneral?: boolean;
   acSpecial?: boolean;
   /** 再委託フィルタ: 階層下限の文字列（'2'=あり〜'9'）。空/未指定 = フィルタなし */
@@ -100,6 +106,18 @@ interface SankeyUrlState {
   filterRecipientIncludeSub?: boolean;
   acBoth?: boolean;
   acNone?: boolean;
+}
+
+/** 政策評価スコア足きりの範囲（0-100の数値文字列・空欄=指定なし） */
+type ScoreRange = { min: string; max: string };
+const EMPTY_SCORE_RANGE: ScoreRange = { min: '', max: '' };
+/** URLの "min-max" 表現との相互変換 */
+function parseScoreRangeParam(v: string): ScoreRange {
+  const i = v.indexOf('-');
+  return i < 0 ? { min: v, max: '' } : { min: v.slice(0, i), max: v.slice(i + 1) };
+}
+function scoreRangeToParam(r: ScoreRange): string | null {
+  return r.min || r.max ? `${r.min}-${r.max}` : null;
 }
 
 const SCREEN_LEFT_PADDING_PX = 32;
@@ -245,6 +263,9 @@ function parseSearchParams(search: string): Partial<SankeyUrlState> {
   const fxb = p.get('fxb'); if (fxb !== null) result.filterMaxBudgetText = fxb;
   const fms = p.get('fms'); if (fms !== null) result.filterMinSpendingText = fms;
   const fxs = p.get('fxs'); if (fxs !== null) result.filterMaxSpendingText = fxs;
+  const fso = p.get('fso'); if (fso !== null) result.filterScoreO = fso;
+  const fsx = p.get('fsx'); if (fsx !== null) result.filterScoreX = fsx;
+  const fsn = p.get('fsn'); if (fsn !== null) result.filterScoreN = fsn;
   const ac = p.get('ac');
   if (ac !== null) {
     result.acGeneral = ac.includes('g');
@@ -379,6 +400,10 @@ export default function RealDataSankeyPage() {
   const [filterMaxBudgetText, setFilterMaxBudgetText] = useState('');
   const [filterMinSpendingText, setFilterMinSpendingText] = useState('');
   const [filterMaxSpendingText, setFilterMaxSpendingText] = useState('');
+  // 政策評価スコアの足きり（0-100の数値文字列。"min-max" でURLに載せる）
+  const [filterScoreO, setFilterScoreO] = useState<ScoreRange>(EMPTY_SCORE_RANGE);
+  const [filterScoreX, setFilterScoreX] = useState<ScoreRange>(EMPTY_SCORE_RANGE);
+  const [filterScoreN, setFilterScoreN] = useState<ScoreRange>(EMPTY_SCORE_RANGE);
   const [acGeneral, setAcGeneral] = useState(true);
   const [acSpecial, setAcSpecial] = useState(true);
   const [acBoth,    setAcBoth]    = useState(true);
@@ -492,6 +517,9 @@ export default function RealDataSankeyPage() {
     if (parsed.filterMaxBudgetText !== undefined) setFilterMaxBudgetText(parsed.filterMaxBudgetText);
     if (parsed.filterMinSpendingText !== undefined) setFilterMinSpendingText(parsed.filterMinSpendingText);
     if (parsed.filterMaxSpendingText !== undefined) setFilterMaxSpendingText(parsed.filterMaxSpendingText);
+    if (parsed.filterScoreO !== undefined) setFilterScoreO(parseScoreRangeParam(parsed.filterScoreO));
+    if (parsed.filterScoreX !== undefined) setFilterScoreX(parseScoreRangeParam(parsed.filterScoreX));
+    if (parsed.filterScoreN !== undefined) setFilterScoreN(parseScoreRangeParam(parsed.filterScoreN));
     if (parsed.acGeneral !== undefined) setAcGeneral(parsed.acGeneral);
     if (parsed.acSpecial !== undefined) setAcSpecial(parsed.acSpecial);
     if (parsed.acBoth    !== undefined) setAcBoth(parsed.acBoth);
@@ -545,6 +573,9 @@ export default function RealDataSankeyPage() {
       setFilterMaxBudgetText(parsed.filterMaxBudgetText ?? '');
       setFilterMinSpendingText(parsed.filterMinSpendingText ?? '');
       setFilterMaxSpendingText(parsed.filterMaxSpendingText ?? '');
+      setFilterScoreO(parsed.filterScoreO !== undefined ? parseScoreRangeParam(parsed.filterScoreO) : EMPTY_SCORE_RANGE);
+      setFilterScoreX(parsed.filterScoreX !== undefined ? parseScoreRangeParam(parsed.filterScoreX) : EMPTY_SCORE_RANGE);
+      setFilterScoreN(parsed.filterScoreN !== undefined ? parseScoreRangeParam(parsed.filterScoreN) : EMPTY_SCORE_RANGE);
       setAcGeneral(parsed.acGeneral ?? true);
       setAcSpecial(parsed.acSpecial ?? true);
       setAcBoth(parsed.acBoth ?? true);
@@ -615,6 +646,9 @@ export default function RealDataSankeyPage() {
     if (filterMaxBudgetText) p.set('fxb', filterMaxBudgetText);
     if (filterMinSpendingText) p.set('fms', filterMinSpendingText);
     if (filterMaxSpendingText) p.set('fxs', filterMaxSpendingText);
+    const fso = scoreRangeToParam(filterScoreO); if (fso) p.set('fso', fso);
+    const fsx = scoreRangeToParam(filterScoreX); if (fsx) p.set('fsx', fsx);
+    const fsn = scoreRangeToParam(filterScoreN); if (fsn) p.set('fsn', fsn);
     if (!acGeneral || !acSpecial || !acBoth || !acNone) {
       p.set('ac', `${acGeneral ? 'g' : ''}${acSpecial ? 's' : ''}${acBoth ? 'b' : ''}${acNone ? 'n' : ''}`);
     }
@@ -628,7 +662,7 @@ export default function RealDataSankeyPage() {
       window.history.replaceState(null, '', url);
     }
     scheduleExplorationRecord(qs);
-  }, [scheduleExplorationRecord, selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, filterOnMinistryClick, year, searchQuery, showFilterPanel, filterProjectName, filterProjectNameRegex, filterRecipientName, filterRecipientNameRegex, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub]);
+  }, [scheduleExplorationRecord, selectedNodeId, pinnedProjectId, pinnedRecipientId, pinnedMinistryName, recipientOffset, offsetTarget, projectOffset, topMinistry, topProject, topRecipient, showLabels, showAggRecipient, showAggProject, projectSortBy, scaleBudgetToVisible, focusRelated, autoFocusRelated, filterOnMinistryClick, year, searchQuery, showFilterPanel, filterProjectName, filterProjectNameRegex, filterRecipientName, filterRecipientNameRegex, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub, filterScoreO, filterScoreX, filterScoreN]);
 
   // Keep zoomRef in sync for debounce callbacks
   // (declared before zoom state so the effect below can reference it)
@@ -1096,7 +1130,7 @@ export default function RealDataSankeyPage() {
     pendingHistoryAction.current = 'replace';
     setRecipientOffset(0);
     setProjectOffset(0);
-  }, [filterMinistryNames, debouncedFilterProjectName, debouncedFilterRecipientName, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, filterSubcontract, filterRecipientIncludeSub]);
+  }, [filterMinistryNames, debouncedFilterProjectName, debouncedFilterRecipientName, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, filterSubcontract, filterRecipientIncludeSub, filterScoreO, filterScoreX, filterScoreN]);
 
   // Sync URL when filter name query changes (separate from above to avoid double reset)
   const filterQueryInitRef = useRef(false);
@@ -1610,6 +1644,50 @@ export default function RealDataSankeyPage() {
     return m;
   }, [graphData]);
 
+  // 政策評価サマリ（事業単位）。サーバ側で算出済みの軽量データを年度ごとに取得する。
+  // 取得に失敗しても Sankey 本体の表示は妨げない（スコア欄が出ないだけ）。
+  const [policySummary, setPolicySummary] = useState<PolicySummaryResponse | null>(null);
+  const [policyError, setPolicyError] = useState<string | null>(null);
+  useEffect(() => {
+    let aborted = false;
+    setPolicySummary(null);
+    setPolicyError(null);
+    fetch(`/api/policy-summary?year=${year}`)
+      .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((json: PolicySummaryResponse) => { if (!aborted) setPolicySummary(json); })
+      .catch((e: Error) => { if (!aborted) setPolicyError(e.message || '取得失敗'); });
+    return () => { aborted = true; };
+  }, [year]);
+
+  // 政策評価スコアの足きり（総合点・費用対内容・必要性）。API のクエリスキーマには載せず、
+  // buildFilterExcludedIds の事業単位フックとして差し込む（policySummary は画面側にしか無いため）。
+  const scoreExcludeProject = useMemo(() => {
+    const parseBound = (t: string): number | null => {
+      const trimmed = t.trim();
+      if (trimmed === '') return null;
+      const v = Number(trimmed);
+      return Number.isFinite(v) ? v : null;
+    };
+    const scoreFilters = ([
+      ['o', filterScoreO], ['x', filterScoreX], ['n', filterScoreN],
+    ] as const)
+      .map(([key, r]) => ({ key, min: parseBound(r.min), max: parseBound(r.max) }))
+      .filter(f => f.min !== null || f.max !== null);
+    // 未ロード時は効かせない（スコア取得前に事業が消えるのを避ける）
+    if (scoreFilters.length === 0 || policySummary === null) return null;
+    return (projectId: number) => {
+      const entry = policySummary.items[String(projectId)];
+      for (const f of scoreFilters) {
+        const v = entry?.[f.key];
+        // 足きり指定時、未評価（スコア無し）の事業は落とす。0点扱いで残すと絞り込みの意味が薄れる
+        if (v === null || v === undefined) return true;
+        if (f.min !== null && v < f.min) return true;
+        if (f.max !== null && v > f.max) return true;
+      }
+      return false;
+    };
+  }, [filterScoreO, filterScoreX, filterScoreN, policySummary]);
+
   // Pre-filter exclusion set: built from filter conditions, applied before filterTopN
   // (除外ロジック本体は app/lib/sankey-query.ts に移設。ここでは UI 状態 → フィルタ条件への変換のみ行う)
   const filterExcludedIds = useMemo(() => {
@@ -1639,8 +1717,10 @@ export default function RealDataSankeyPage() {
         },
       },
       [selectedNodeId, pinnedProjectId],
+      // 政策評価スコアの足きり。事業単位フックとして差し込む（policySummary は画面側にしか無い）
+      scoreExcludeProject,
     );
-  }, [graphData, selectedNodeId, pinnedProjectId, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedFilterProjectName, debouncedFilterRecipientName, filterProjectNameRegex, filterRecipientNameRegex, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub]);
+  }, [graphData, selectedNodeId, pinnedProjectId, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedFilterProjectName, debouncedFilterRecipientName, filterProjectNameRegex, filterRecipientNameRegex, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub, filterScoreO, filterScoreX, filterScoreN, scoreExcludeProject]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -2613,6 +2693,9 @@ export default function RealDataSankeyPage() {
     filterRecipientName !== '' ||
     filterMinBudgetText !== '' || filterMaxBudgetText !== '' ||
     filterMinSpendingText !== '' || filterMaxSpendingText !== '' ||
+    scoreRangeToParam(filterScoreO) !== null ||
+    scoreRangeToParam(filterScoreX) !== null ||
+    scoreRangeToParam(filterScoreN) !== null ||
     !(acGeneral && acSpecial && acBoth && acNone) ||
     filterSubcontract !== '';
 
@@ -2629,6 +2712,9 @@ export default function RealDataSankeyPage() {
     setFilterMaxBudgetText('');
     setFilterMinSpendingText('');
     setFilterMaxSpendingText('');
+    setFilterScoreO(EMPTY_SCORE_RANGE);
+    setFilterScoreX(EMPTY_SCORE_RANGE);
+    setFilterScoreN(EMPTY_SCORE_RANGE);
     setAcGeneral(true);
     setAcSpecial(true);
     setAcBoth(true);
@@ -2980,6 +3066,125 @@ export default function RealDataSankeyPage() {
       numberFontPx={META_FONT_PX_DEFAULT}
     />
   );
+
+  // 右上クラスタに入れるツール群（TopN・オフセット操作）。スマホ幅では従来どおり左下に絶対配置
+  const offsetControlsBlock = filtered ? (() => {
+        // Recipient offset mode
+        const maxRecipOffset = Math.max(0, filtered.totalRecipientCount - topRecipient);
+        const clampedOffset = Math.min(recipientOffset, maxRecipOffset);
+        const recipRangeStart = clampedOffset + 1;
+        const recipRangeEnd = Math.min(clampedOffset + topRecipient, filtered.totalRecipientCount);
+        const recipMaxStartRank = maxRecipOffset + 1;
+        // Project offset mode
+        const maxProjOffset = Math.max(0, filtered.totalProjectCount - topProject);
+        const clampedProjOffset = Math.min(projectOffset, maxProjOffset);
+        const projRangeStart = clampedProjOffset + 1;
+        const projRangeEnd = Math.min(clampedProjOffset + topProject, filtered.totalProjectCount);
+        // Active values for shared controls
+        const isProjectMode = offsetTarget === 'project';
+        const activeOffset = isProjectMode ? clampedProjOffset : clampedOffset;
+        const activeMax = isProjectMode ? maxProjOffset : maxRecipOffset;
+        const activeTotalCount = isProjectMode ? filtered.totalProjectCount : filtered.totalRecipientCount;
+        const activeRangeStart = isProjectMode ? projRangeStart : recipRangeStart;
+        const activeRangeEnd = isProjectMode ? projRangeEnd : recipRangeEnd;
+        const activeMaxStartRank = isProjectMode ? maxProjOffset + 1 : recipMaxStartRank;
+        const setActiveOffset = (v: number) => {
+          pendingHistoryAction.current = 'replace';
+          if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
+        };
+        return (
+          <div ref={offsetControlRef} style={ isCompactWidth
+            ? { position: 'absolute', bottom: 12, left: isLandscapeCompact && selectedNodeId !== null && !isPanelCollapsed ? effectiveSidePanelWidth + 8 : 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)', transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }
+            : { display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
+            {/* Row 1: オフセットスライダー（2列スパン） */}
+            <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 8, alignItems: 'center' }}>
+              {/* オフセット対象コンボボックス */}
+              <select
+                data-testid={testId('offset-target-select')}
+                value={offsetTarget}
+                onChange={e => { pendingHistoryAction.current = 'replace'; setOffsetTarget(e.target.value as 'recipient' | 'project'); }}
+                style={{ fontSize: META_FONT_PX, border: '1px solid #ccc', borderRadius: 3, padding: '1px 2px', background: '#fff', color: '#555', cursor: 'pointer' }}
+              >
+                <option value="project">事業</option>
+                <option value="recipient">支出先</option>
+              </select>
+              <label style={{ flex: isCompactWidth ? '0 0 auto' : 1, display: 'flex', alignItems: 'center', gap: 4 }}>
+                {/* スマホ幅では「Top」ラベルを省き数値だけ表示 */}
+                {!isCompactWidth && <span style={{ color: '#555', fontSize: META_FONT_PX }}>Top</span>}
+                {isEditingOffset ? (
+                  <input
+                    type="number"
+                    autoFocus
+                    min={1} max={activeMaxStartRank} step={1}
+                    value={offsetInputValue}
+                    onChange={e => { setOffsetInputValue(e.target.value); const v = Number(e.target.value); if (!isNaN(v) && v >= 1) setActiveOffset(Math.max(0, Math.min(activeMax, v - 1))); }}
+                    onBlur={() => setIsEditingOffset(false)}
+                    onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setIsEditingOffset(false); }}
+                    style={{ width: `${Math.max(40, String(activeMaxStartRank).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: CONTROL_SMALL_FONT_PX }}
+                  />
+                ) : (
+                  <button
+                    onClick={() => { setOffsetInputValue(String(activeRangeStart)); setIsEditingOffset(true); }}
+                    title="クリックして開始位置を入力"
+                    style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
+                  >{activeRangeStart}</button>
+                )}
+                <span style={{ color: '#999', fontSize: META_FONT_PX }}>~{activeRangeEnd}</span>
+                <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
+                {/* 総件数表示は幅を取るためスマホ幅では非表示 */}
+                {!isCompactWidth && <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>}
+                <div style={{ display: 'flex', flexDirection: 'row', gap: 2, alignItems: 'center' }}>
+                  {([
+                    [-1, 'M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6z', '前へ'],
+                    [1,  'M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z', '次へ'],
+                  ] as [number, string, string][]).map(([delta, path, title]) => (
+                    <button key={delta} title={title} aria-label={title}
+                      data-testid={testId(delta > 0 ? 'recipient-offset-next' : 'recipient-offset-prev')}
+                      {...offsetRepeat(() => {
+                        pendingHistoryAction.current = 'replace';
+                        pendingFocusId.current = null;
+                        if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
+                        else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
+                      }, { stopPropagation: true })}
+                      onClick={(e) => {
+                        if (e.detail === 0) {
+                          setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));
+                        }
+                      }}
+                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
+                    </button>
+                  ))}
+                </div>
+                {/* Material Icons: vertical_align_top — オフセットリセット */}
+                <button onClick={e => { e.preventDefault(); setActiveOffset(0); }} title="先頭へリセット" aria-label="先頭へリセット"
+                  onContextMenu={(e) => e.preventDefault()}
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555" style={{ transform: 'rotate(-90deg)' }}><path d="M8 11h3v10h2V11h3l-4-4-4 4zM4 3v2h16V3H4z"/></svg>
+                </button>
+              </label>
+            </div>
+            {/* Row 2: 事業・支出先 TopN スライダー（スマホ幅では設定ダイアログへ移動） */}
+            {!isCompactWidth && showTopNSliders && topNSlidersFragment}
+          </div>
+          {/* トグルボタン（パネル外・下部）— スマホ幅では設定ダイアログにTopNを移すため非表示 */}
+          {!isCompactWidth && (
+          <button
+            onClick={() => setShowTopNSliders(s => !s)}
+            title={showTopNSliders ? 'TopN設定 を隠す' : 'TopN設定 を表示'}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: '1px solid #e0e0e0', borderRight: '1px solid #e0e0e0', borderBottom: '1px solid #e0e0e0', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#bbb">
+              <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
+            </svg>
+          </button>
+          )}
+          </div>
+        );
+  })() : null;
 
   return (
     <div
@@ -3849,6 +4054,70 @@ export default function RealDataSankeyPage() {
                 </div>
               </div>
 
+              {/* 政策評価 — 事業ノード（非集約）でスコアが取得できているときのみ */}
+              {selectedNode && (selectedNode.type === 'project-budget' || selectedNode.type === 'project-spending')
+                && !selectedNode.aggregated && selectedNode.projectId != null && policyError && (
+                <div style={{ borderBottom: '1px solid #f0f0f0', flexShrink: 0, padding: '7px 14px' }}>
+                  <span style={{ fontSize: PANEL_META_FONT_PX, fontWeight: 600, color: '#555' }}>政策評価</span>
+                  <span style={{ marginLeft: 8, fontSize: META_FONT_PX, color: '#c0392b' }}>
+                    読み込めませんでした（{policyError}）
+                  </span>
+                </div>
+              )}
+              {selectedNode && (selectedNode.type === 'project-budget' || selectedNode.type === 'project-spending')
+                && !selectedNode.aggregated && selectedNode.projectId != null && policySummary && (() => {
+                const entry = policySummary.items[String(selectedNode.projectId)];
+                if (!entry) return null;
+                const rec = entry.r ? policySummary.recommendations[entry.r] : null;
+                const act = entry.a ? policySummary.actions[entry.a] : null;
+                // /quality と同じ配色。判断の強さで色を変える
+                const recColor = !rec ? '#999'
+                  : rec === '継続' ? '#2d7d46'
+                  : rec === '要改善' ? '#3b82f6'
+                  : rec === '再設計' || rec === '終了・廃止候補' ? '#d94545'
+                  : '#d98a20';
+                const scoreColor = (v: number | null) => v == null ? '#999'
+                  : v >= 90 ? '#2d7d46' : v >= 70 ? '#3b82f6' : v >= 50 ? '#d98a20' : '#d94545';
+                const category = entry.c ? policySummary.categories[entry.c] : null;
+                // 5軸のうち、総合点への寄与が最も大きく所管庁の作文が支配しにくい2軸を並べる。
+                // 残り3軸（成果設計・検証可能性・執行透明性）は /quality 側で確認する。
+                const cells: Array<[string, number | null]> = [
+                  ['総合点', entry.o], ['費用対内容', entry.x], ['必要性', entry.n],
+                ];
+                return (
+                  <div style={{ borderBottom: '1px solid #f0f0f0', flexShrink: 0, padding: '8px 14px' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+                      <span style={{ fontSize: PANEL_META_FONT_PX, fontWeight: 600, color: '#555' }}>政策評価</span>
+                      <span style={{ fontSize: META_FONT_PX, color: '#aaa' }}>暫定</span>
+                      {category && (
+                        <span style={{ background: '#f0f0f0', color: '#666', padding: '1px 6px', borderRadius: 9, fontSize: META_FONT_PX, whiteSpace: 'nowrap' }}>{category}</span>
+                      )}
+                      <a href={`/quality?pid=${selectedNode.projectId}`} target="_blank" rel="noopener noreferrer"
+                        style={{ marginLeft: 'auto', fontSize: META_FONT_PX, color: '#4a90d9', textDecoration: 'none' }}
+                      >一覧で見る →</a>
+                    </div>
+                    <div style={{ display: 'flex', gap: 14, alignItems: 'flex-end' }}>
+                      {cells.map(([label, value]) => (
+                        <div key={label} style={{ textAlign: 'center' }}>
+                          <div style={{ fontSize: PANEL_META_FONT_PX + 4, fontWeight: 700, lineHeight: 1, color: scoreColor(value), fontFamily: 'monospace' }}>
+                            {value ?? '—'}
+                          </div>
+                          <div style={{ fontSize: META_FONT_PX, color: '#999', marginTop: 3 }}>{label}</div>
+                        </div>
+                      ))}
+                      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginLeft: 'auto', justifyContent: 'flex-end' }}>
+                        {rec && (
+                          <span style={{ background: recColor, color: '#fff', padding: '2px 7px', borderRadius: 10, fontSize: META_FONT_PX, fontWeight: 600, whiteSpace: 'nowrap' }}>{rec}</span>
+                        )}
+                        {act && (
+                          <span style={{ background: '#e8f1fb', color: '#2b6cb0', padding: '2px 7px', borderRadius: 10, fontSize: META_FONT_PX, fontWeight: 600, whiteSpace: 'nowrap' }}>{act}</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
+
               {/* 事業概要アコーディオン — project-budget / project-spending（非集約）のみ。共有コンポーネント */}
               {selectedNode && (selectedNode.type === 'project-budget' || selectedNode.type === 'project-spending') && !selectedNode.aggregated && selectedNode.projectId != null && (
                 <ProjectOverviewSection
@@ -4462,7 +4731,7 @@ export default function RealDataSankeyPage() {
                       placeholder="例: 100億、50万"
                       style={{ flex: 1, minWidth: 0, fontSize: CONTROL_SMALL_FONT_PX, border: `1px solid ${parseAmountToYen(minText) !== null || !minText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
                     />
-                    <span style={{ fontSize: CONTROL_SMALL_FONT_PX, color: '#aaa', flexShrink: 0 }}>〜</span>
+                    <span style={{ fontSize: CONTROL_SMALL_FONT_PX, color: '#aaa', flexShrink: 0 }}>~</span>
                     <input type="text" value={maxText} onChange={e => setMax(e.target.value)}
                       placeholder="例: 1兆、500億"
                       style={{ flex: 1, minWidth: 0, fontSize: CONTROL_SMALL_FONT_PX, border: `1px solid ${parseAmountToYen(maxText) !== null || !maxText ? '#ddd' : '#e53935'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
@@ -4473,6 +4742,40 @@ export default function RealDataSankeyPage() {
                     )}
                   </div>
                 ))}
+                {/* 政策評価スコアの足きり（0-100）。/quality の総合点・費用対内容・必要性と同じ値。
+                    ラベルにマウスを乗せると軸の意味が出る */}
+                {([
+                  { label: '総合点', title: 'AI政策評価の総合点（0-100）。/quality の総合点と同じ値', range: filterScoreO, set: setFilterScoreO },
+                  { label: '費用対', title: '費用対内容（0-100）。金額が活動の規模に見合っているか', range: filterScoreX, set: setFilterScoreX },
+                  { label: '必要性', title: '必要性（0-100）。廃止したら誰が具体的に困るか', range: filterScoreN, set: setFilterScoreN },
+                ] as const).map(({ label, title, range, set }) => {
+                  const bad = (t: string) => {
+                    const s = t.trim();
+                    if (s === '') return false;
+                    const v = Number(s);
+                    return !Number.isFinite(v) || v < 0 || v > 100;
+                  };
+                  return (
+                    <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                      <span title={title} style={{ fontSize: CONTROL_SMALL_FONT_PX, color: '#555', width: 40, flexShrink: 0, cursor: 'help' }}>{label}</span>
+                      <input type="text" inputMode="numeric" value={range.min}
+                        onChange={e => { pendingHistoryAction.current = 'replace'; set({ ...range, min: e.target.value }); }}
+                        placeholder="下限 0"
+                        style={{ flex: 1, minWidth: 0, fontSize: CONTROL_SMALL_FONT_PX, border: `1px solid ${bad(range.min) ? '#e53935' : '#ddd'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                      />
+                      <span style={{ fontSize: CONTROL_SMALL_FONT_PX, color: '#aaa', flexShrink: 0 }}>~</span>
+                      <input type="text" inputMode="numeric" value={range.max}
+                        onChange={e => { pendingHistoryAction.current = 'replace'; set({ ...range, max: e.target.value }); }}
+                        placeholder="上限 100"
+                        style={{ flex: 1, minWidth: 0, fontSize: CONTROL_SMALL_FONT_PX, border: `1px solid ${bad(range.max) ? '#e53935' : '#ddd'}`, borderRadius: 4, padding: '3px 5px', background: '#fafafa', color: '#333', outline: 'none' }}
+                      />
+                      {(range.min || range.max) && (
+                        <button type="button" onClick={() => { pendingHistoryAction.current = 'replace'; set(EMPTY_SCORE_RANGE); }}
+                          style={{ fontSize: META_FONT_PX, color: '#aaa', background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px', flexShrink: 0 }}>×</button>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>{/* end card */}
@@ -4693,6 +4996,14 @@ export default function RealDataSankeyPage() {
           </div>
         );
       })()}
+
+      {/* ページ切替メニュー — 表示設定(⋮)の左隣。
+          rs-vis は右上を［ツール - 年度 - メニュー］に組み替えているが、marumie の右上は
+          AIチャットパネル展開時に rightControlsOffset ぶん左へ退避する制御を持つため、
+          現行の配置を保ったままメニューだけを足している（配置の見直しは別途）。 */}
+      <div style={{ position: 'absolute', top: 14, right: 52 + rightControlsOffset, zIndex: 200, transition: isResizingAiPanel ? 'none' : 'right 0.2s ease' }}>
+        <PageNavMenu current="/sankey-svg" theme="light" />
+      </div>
 
       {/* Settings button — independent, top right（ダイアログを最前面にするため高いzIndex） */}
       <div style={{ position: 'absolute', top: 14, right: 12 + rightControlsOffset, zIndex: 200, transition: isResizingAiPanel ? 'none' : 'right 0.2s ease' }}>

--- a/app/subcontracts/page.tsx
+++ b/app/subcontracts/page.tsx
@@ -27,6 +27,7 @@ import { FilterRow } from '@/components/filters/FilterRow';
 import { FilterTextInput } from '@/components/filters/FilterTextInput';
 import { MinMaxInput } from '@/components/filters/MinMaxInput';
 import { MultiSelectDropdown } from '@/components/filters/MultiSelectDropdown';
+import { PageNavMenu } from '@/components/navigation/PageNavMenu';
 import { ProjectReferenceLinks } from '@/components/subcontracts/ProjectReferenceLinks';
 import { formatYen, parseAmountToYen } from '@/app/lib/format/yen';
 import { accountCategoryLabel, bureauLeaf } from '@/app/lib/subcontracts/labels';
@@ -585,59 +586,6 @@ function SubcontractsPageInner() {
       <div style={{ flexShrink: 0, padding: '12px 16px', maxWidth: 1600, margin: '0 auto', width: '100%', boxSizing: 'border-box' }}>
         {/* コントロール（/sankey-svg と同じトーン） */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-          {/* トップへ戻る（矢印のみ） */}
-          {/* href は "/"（リダイレクト元）ではなく実体の /sankey-svg を指す。
-              "/" は 307 リダイレクトのため Link のプリフェッチがキャッシュできず、
-              dev コンソールに GET / 307 が繰り返し出る */}
-          <Link
-            href="/sankey-svg"
-            aria-label="トップへ戻る"
-            title="トップへ戻る"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 32,
-              height: 32,
-              borderRadius: 8,
-              border: '1px solid #e0e0e0',
-              background: 'rgba(255,255,255,0.95)',
-              boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
-              color: '#666',
-              textDecoration: 'none',
-              flexShrink: 0,
-            }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
-            </svg>
-          </Link>
-
-          {/* 年度切替 */}
-          <div style={{ position: 'relative', flexShrink: 0 }}>
-            <select
-              value={year}
-              onChange={(e) => setYear(Number(e.target.value))}
-              style={{
-                fontSize: 13,
-                border: '1px solid #e0e0e0',
-                borderRadius: 8,
-                padding: '6px 28px 6px 10px',
-                background: 'rgba(255,255,255,0.95)',
-                boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
-                color: '#333',
-                cursor: 'pointer',
-                appearance: 'none',
-                WebkitAppearance: 'none',
-              }}
-            >
-              <option value={2025}>2025年度</option>
-              <option value={2024}>2024年度</option>
-            </select>
-            <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-              <path d="M7 10l5 5 5-5z"/>
-            </svg>
-          </div>
 
           {/* 検索 */}
           <div style={{ position: 'relative', flex: 1, minWidth: 240 }}>
@@ -722,6 +670,36 @@ function SubcontractsPageInner() {
           >
             列幅リセット
           </button>
+
+          {/* 年度とページ切替。全ページ共通で右上に置く */}
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+            <div style={{ position: 'relative' }}>
+              <select
+                value={year}
+                onChange={(e) => setYear(Number(e.target.value))}
+                aria-label="年度"
+                style={{
+                  fontSize: 13,
+                  border: '1px solid #e0e0e0',
+                  borderRadius: 8,
+                  padding: '8px 28px 8px 10px',
+                  background: 'rgba(255,255,255,0.95)',
+                  boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
+                  color: '#333',
+                  cursor: 'pointer',
+                  appearance: 'none',
+                  WebkitAppearance: 'none',
+                }}
+              >
+                <option value={2025}>2025年度</option>
+                <option value={2024}>2024年度</option>
+              </select>
+              <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
+                <path d="M7 10l5 5 5-5z"/>
+              </svg>
+            </div>
+            <PageNavMenu current="/subcontracts" theme="light" />
+          </div>
         </div>
 
         {/* 折りたたみフィルタパネル（/sankey-svg ライク） */}

--- a/docs/tasks/20260728_0616_rs-vis逆流取り込みの対応案.md
+++ b/docs/tasks/20260728_0616_rs-vis逆流取り込みの対応案.md
@@ -188,3 +188,16 @@ rs-vis はフィルタ除外ロジックをページ内にインラインで持�
 - `app/sankey-svg/page.tsx`: rs-vis が追加する `projectDetailCache` の `useState` は、marumie の `useProjectPidCache` と重複するため取り込んでいない
 
 検証: `tsc --noEmit` クリーン、`next lint` エラーなし、`vitest` 100件パス（+4）、`npm run build` 成功、`check-traces` 違反なし。dev で全5ページ 200、`PageNavMenu` が `/sankey-svg`・`/subcontracts`・`/project-bubble` の初期HTMLに出ること（`/quality`・`/mof-budget-overview` は初期ローディング画面を返す構造のため描画後に出る）を確認。
+
+### PR-3 のレビュー指摘（2026-07-29・#294）
+
+**これまでの18件と性質が違う。** rs-vis 由来のバグではなく、**右上の再構成3ハンクを除外したことで生じた取り込み側の後始末漏れ**であり、どちらも `next lint` に新規警告として出ている（このリポジトリは「新規警告を増やさない」運用）。
+
+| 指摘 | 内容 |
+|---|---|
+| `offsetControlsBlock` が未使用（Major） | `app/sankey-svg/page.tsx` L3071-3187 の117行。rs-vis がオフセットスライダーを変数へ抽出したもので、それを描画するハンク（`@@ -4381,207`）を除外したため宣言だけが残った。実際に描画されているのは L4881 以降の既存JSX。lint 警告 `'offsetControlsBlock' is assigned a value but never used` |
+| スコア足きり述語の置き場所（Trivial） | `scoreExcludeProject` の閾値パース・比較は純ロジックなので `app/lib` 側へ、という指摘。Layer Design Rules（ページは状態管理・API呼び出し・レイアウトのみ）に照らすと妥当 |
+
+あわせて、`filterExcludedIds` の依存配列に足した `filterScoreO`/`filterScoreX`/`filterScoreN` が冗長になっている（スコアは `scoreExcludeProject` 経由でしか参照しないため）。lint 警告 `useMemo has unnecessary dependencies`。
+
+**対応方針**: 2026-07-29 時点でユーザー判断により見送り。ただし1件目は117行の純粋な削除で挙動に影響がなく、2件目・3件目も小さい。**次に `app/sankey-svg/page.tsx` を触るとき（品質スコアデザインの展開タスク）に片付けるのが自然。**

--- a/docs/tasks/20260728_0616_rs-vis逆流取り込みの対応案.md
+++ b/docs/tasks/20260728_0616_rs-vis逆流取り込みの対応案.md
@@ -150,3 +150,41 @@ rs-vis の route.ts は型定義もローダも1ファイルに同居した旧�
 検証: `tsc --noEmit` クリーン、`vitest` 96件パス、`npm run build` 成功、`check-traces` 違反なし。dev で全5ページの 200、`/api/quality-scores?year=2025` が 5,794件中 5,682件に `yearsRunning` を返すこと、`/api/quality-scores/recipients?pid=1&year=2025` の応答形が rs-vis 版ページの要求と一致することを確認。
 
 `next lint` に rs-vis 由来の新規警告が2件出る（`react-hooks/exhaustive-deps`・`app/quality/page.tsx` L304/L356）。as-is 維持のため修正していない。
+
+## 7. 実施記録 — PR-3（2026-07-29）
+
+ブランチ `feat/rsvis-nav-and-score-filters`。**rs-vis による右上コントロール群の再構成は取り込まず、機能だけを載せた。**
+
+### 取り込んだもの
+
+- `components/navigation/PageNavMenu`（PR-1 で導入済み）を `/sankey-svg`・`/subcontracts`・`/mof-budget-overview` へ配線
+- サンキー図の政策評価スコア足きり（総合点・費用対内容・必要性／URL `fso`・`fsx`・`fsn`）とフィルタパネルの入力UI
+- サイドパネルの政策評価ブロック（総合点・費用対内容・必要性、推奨判断／改善アクションのバッジ、`/quality` への導線）
+- `/api/policy-summary` の取得と取得失敗時の表示
+
+### 右上の再構成は見送った
+
+`76c6f09` は `app/sankey-svg/page.tsx` の右上を［ツール - 年度 - メニュー］へ組み替え、表示設定(⋮)を検索ボックス隣へ移す。marumie の右上は **AIチャットパネル展開時に `rightControlsOffset` ぶん左へ退避する制御**と `isCompactWidth` 分岐、探索履歴の入口を抱えており、rs-vis にはこれらが無い。そのまま持ち込むと退避ロジックと衝突し、年度セレクタが二重になる。
+
+そこで、差分から次の3ハンクを除外して適用した（`git diff 84e6e59 76c6f09 -- app/sankey-svg/page.tsx` の該当ハンク）:
+
+```text
+@@ -3991,24 +4254,6   中央クラスタ（年度セレクタ＋探索履歴）の削除
+@@ -4326,6 +4605,91   表示設定(⋮) を検索ボックス隣へ移動
+@@ -4381,207 +4745,30  右上クラスタの全面置換
+```
+
+`PageNavMenu` は既存の表示設定ボタンの左隣（`right: 52 + rightControlsOffset`）に置き、退避のトランジションを合わせた。**配置の最終形は現物を見てから調整する**前提。
+
+### スコア足きりは `buildFilterExcludedIds` のフックとして実装した
+
+rs-vis はフィルタ除外ロジックをページ内にインラインで持ち、そこに `failScore` を足している。marumie は #242 以降このロジックを `app/lib/sankey-query.ts` の `buildFilterExcludedIds` へ抽出済みで、`/api/sankey/query` と共用しユニットテストも持つ。rs-vis 版をそのまま採ると抽出が巻き戻り、再委託フィルタ（`subcontract.minDepth`・`recipientName.includeSubcontract`）も失われる。
+
+そこで `buildFilterExcludedIds` に **事業単位の追加除外フック** `excludeProject?: (projectId: number) => boolean` を足し、画面側で `policySummary` から作った述語を渡す形にした。API のクエリスキーマ（`ResolvedSankeyQuery['filter']`）は変えていない。スコアは画面側にしか無いデータなので、スキーマに載せるのは筋が悪いという判断。フックの動作（対の除外・省庁へのカスケード・空なら null）はユニットテスト4件を追加した。
+
+### 細かい追随
+
+- `app/subcontracts/page.tsx`: rs-vis は年度変更時に `router.replace` を呼ぶが、marumie は `history.replaceState` で年度を含む全状態をURL同期済み（#263）。重複するため `router.replace` は入れていない
+- `app/sankey-svg/page.tsx`: rs-vis が追加する `projectDetailCache` の `useState` は、marumie の `useProjectPidCache` と重複するため取り込んでいない
+
+検証: `tsc --noEmit` クリーン、`next lint` エラーなし、`vitest` 100件パス（+4）、`npm run build` 成功、`check-traces` 違反なし。dev で全5ページ 200、`PageNavMenu` が `/sankey-svg`・`/subcontracts`・`/project-bubble` の初期HTMLに出ること（`/quality`・`/mof-budget-overview` は初期ローディング画面を返す構造のため描画後に出る）を確認。


### PR DESCRIPTION
rs-vis の `76c6f09` を marumie へ逆流させる3分割取り込みの **3本目（最終）**。PR-1 は #292、PR-2 は #293 でマージ済み。

> **方針**: rs-vis の機能は取り込むが、**右上コントロール群の再構成は見送っています**（理由は下記）。配置の最終形は現物を見てから本 PR 内で調整する前提です。

## 取り込み

- **`PageNavMenu` を3ページへ配線** — `/sankey-svg`・`/subcontracts`・`/mof-budget-overview`
- **サンキー図の政策評価スコア足きり** — 総合点・費用対内容・必要性（URL `fso`・`fsx`・`fsn`）とフィルタパネルの入力UI
- **サイドパネルの政策評価ブロック** — 3指標＋推奨判断／改善アクションのバッジ、`/quality` への導線、`/api/policy-summary` の取得と失敗時表示

## 右上の再構成は見送りました（要確認）

`76c6f09` は `app/sankey-svg/page.tsx` の右上を［ツール - 年度 - メニュー］へ組み替え、表示設定(⋮)を検索ボックス隣へ移します。しかし marumie の右上は

- **AIチャットパネル展開時に `rightControlsOffset` ぶん左へ退避する制御**
- `isCompactWidth` によるスマホ幅分岐
- 探索履歴（`ExplorationHistory`）の入口

を抱えており、rs-vis にはこれらがありません。そのまま持ち込むと退避ロジックと衝突し、年度セレクタが二重になります。

そこで差分から次の3ハンクを除外して適用しました:

```text
@@ -3991,24 +4254,6   中央クラスタ（年度セレクタ＋探索履歴）の削除
@@ -4326,6 +4605,91   表示設定(⋮) を検索ボックス隣へ移動
@@ -4381,207 +4745,30  右上クラスタの全面置換
```

`PageNavMenu` は既存の表示設定ボタンの左隣（`right: 52 + rightControlsOffset`）に置き、退避のトランジションを合わせています。

## スコア足きりは `buildFilterExcludedIds` のフックとして実装しました

rs-vis は除外ロジックをページ内にインラインで持ち、そこに `failScore` を足しています。marumie は #242 以降このロジックを `app/lib/sankey-query.ts` の `buildFilterExcludedIds` へ抽出済みで、`/api/sankey/query` と共用しユニットテストも持ちます。**rs-vis 版をそのまま採ると抽出が巻き戻り、再委託フィルタ（`subcontract.minDepth`・`recipientName.includeSubcontract`）も失われます。**

そこで `buildFilterExcludedIds` に事業単位の追加除外フックを足しました:

```ts
excludeProject?: ((projectId: number) => boolean) | null
```

画面側で `policySummary` から作った述語を渡す形です。**API のクエリスキーマ（`ResolvedSankeyQuery['filter']`）は変えていません** — スコアは画面側にしか無いデータなので、スキーマに載せるのは筋が悪いという判断です。フックの動作（対の除外・省庁へのカスケード・空なら null）にユニットテスト4件を追加しました。

## 細かい追随（2件）

| 箇所 | 内容 |
|---|---|
| `app/subcontracts/page.tsx` | rs-vis は年度変更時に `router.replace` を呼ぶが、marumie は `history.replaceState` で年度を含む全状態をURL同期済み（#263）。重複するため入れていない |
| `app/sankey-svg/page.tsx` | rs-vis が追加する `projectDetailCache` の `useState` は marumie の `useProjectPidCache` と重複するため取り込んでいない |

## 検証

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | クリーン |
| `npm run lint` | エラーなし |
| `npx vitest run` | 100件パス（+4） |
| `npm run build` | 成功 |
| `npm run check-traces` | 違反なし |
| dev サーバ | 全5ページ 200 |

`PageNavMenu` は `/sankey-svg`・`/subcontracts`・`/project-bubble` の初期HTMLに出ることを確認しています（`/quality`・`/mof-budget-overview` は初期ローディング画面を返す構造のため、描画後に出ます）。

## 既知の不具合について

PR-1・PR-2 と同様、取り込むコードには既知の不具合が残っています。修正はブランチ `fix/policy-eval-corrections`、一覧は `docs/tasks/20260728_0741_rs-vis由来の既知不具合18件の棚卸し.md`。本 PR でサンキー図にも政策評価が乗るため、`percentileRank` の同点バグの露出面がさらに広がります。

## 次のタスク

本 PR のマージ後、品質スコアのデザインを `/sankey-svg`・`/subcontracts` のダイアログへ展開する予定です（`docs/tasks/20260729_1827_品質スコアデザインをサンキー図と再委託ビューへ展開.md`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 政策評価スコア（総合点・費用対内容・必要性）による範囲フィルターを追加しました。
  - フィルター条件をURLに保存・復元できるようになりました。
  - プロジェクト詳細に評価スコア、推奨アクション、品質評価ページへのリンクを表示します。
  - 複数ページに共通のページナビゲーションを追加しました。

- **改善**
  - 政策評価が未登録のプロジェクトも、指定条件に応じて適切に除外します。
  - サンキーダイアグラムの操作パネルと各ページの上部ナビゲーションを整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->