### PR TITLE
fix(api): 政策評価系3ルートが本番でデータを読めない問題を修正

### DIFF
--- a/app/api/execution-history/route.ts
+++ b/app/api/execution-history/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as zlib from 'zlib';
 import { API_CACHE_CONTROL, parseYear, serverErrorResponse } from '@/app/lib/api/api-notes';
+import { tryReadDataJson } from '@/app/lib/api/data-file';
 
 /**
  * 前年度の執行実績だけを最小限で返す API。
@@ -28,14 +26,9 @@ type QualityRow = { pid: string; budgetAmount: number; execAmount: number };
 
 const cache = new Map<string, ExecutionHistoryResponse>();
 
-/** 展開済み .json を優先。無ければ .gz をその場で展開する */
+// パス解決は data-file.ts に一元化する（Vercel の関数バンドルは data/server の .gz のみ）
 function readQualityScores(year: string): QualityRow[] | null {
-  const base = path.join(process.cwd(), 'public', 'data', `project-quality-scores-${year}.json`);
-  if (fs.existsSync(base)) return JSON.parse(fs.readFileSync(base, 'utf-8'));
-  if (fs.existsSync(`${base}.gz`)) {
-    return JSON.parse(zlib.gunzipSync(fs.readFileSync(`${base}.gz`)).toString('utf-8'));
-  }
-  return null;
+  return tryReadDataJson<QualityRow[]>(`project-quality-scores-${year}.json`);
 }
 
 function loadData(year: string): ExecutionHistoryResponse {

--- a/app/api/policy-summary/route.ts
+++ b/app/api/policy-summary/route.ts
@@ -1,7 +1,4 @@
 import { NextResponse } from 'next/server';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as zlib from 'zlib';
 import {
   buildPolicyEvaluations,
   POLICY_CATEGORY_LABELS,
@@ -11,6 +8,7 @@ import {
   type PolicyQualityInput,
 } from '@/app/lib/policy-evaluation';
 import { API_CACHE_CONTROL, parseYear, serverErrorResponse } from '@/app/lib/api/api-notes';
+import { readDataJson, tryReadDataJson } from '@/app/lib/api/data-file';
 
 /**
  * Sankey 図に重ねるための、事業ごとの政策評価サマリ。
@@ -62,13 +60,13 @@ export interface PolicySummaryResponse {
 
 const cache = new Map<string, PolicySummaryResponse>();
 
+// Vercel の関数バンドルに public/data は同梱されない（data/server の .gz だけ）。
+// パス解決は data-file.ts に一元化する（直に public/data を読むと本番で必ず落ちる）。
 function loadQuality(year: string): PolicyQualityInput[] {
-  const base = path.join(process.cwd(), 'public', 'data', `project-quality-scores-${year}.json`);
-  if (fs.existsSync(base)) return JSON.parse(fs.readFileSync(base, 'utf-8'));
-  if (fs.existsSync(`${base}.gz`)) {
-    return JSON.parse(zlib.gunzipSync(fs.readFileSync(`${base}.gz`)).toString('utf-8'));
-  }
-  throw new Error(`project-quality-scores-${year}.json(.gz) が見つかりません。`);
+  return readDataJson<PolicyQualityInput[]>(
+    `project-quality-scores-${year}.json`,
+    `python3 scripts/score-project-quality-ai.py --year ${year} を実行してください。`,
+  );
 }
 
 function invert(order: Record<string, number>): Record<number, string> {

--- a/app/api/project-map/route.ts
+++ b/app/api/project-map/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as zlib from 'zlib';
 import { API_CACHE_CONTROL, parseYear, serverErrorResponse } from '@/app/lib/api/api-notes';
 import { joinProjectMap, type MapQualityRow } from '@/app/lib/project-map';
 import type { ProjectMapFile, ProjectMapResponse } from '@/types/project-map';
+// パス解決は data-file.ts に一元化する（Vercel の関数バンドルは data/server の .gz のみ）
+import { tryReadDataJson as readDataJson } from '@/app/lib/api/data-file';
 
 /**
  * 事業の意味的2次元マップ API（/project-map のバブルチャート用）。
@@ -19,15 +18,6 @@ import type { ProjectMapFile, ProjectMapResponse } from '@/types/project-map';
 
 const cache = new Map<string, ProjectMapResponse>();
 
-/** 展開済み .json を優先。無ければ .gz をその場で展開する（prebuild未実行のローカルでも動く） */
-function readDataJson<T>(basename: string): T | null {
-  const base = path.join(process.cwd(), 'public', 'data', basename);
-  if (fs.existsSync(base)) return JSON.parse(fs.readFileSync(base, 'utf-8')) as T;
-  if (fs.existsSync(`${base}.gz`)) {
-    return JSON.parse(zlib.gunzipSync(fs.readFileSync(`${base}.gz`)).toString('utf-8')) as T;
-  }
-  return null;
-}
 
 type DetailPeriod = { startYear?: number | null };
 


### PR DESCRIPTION
Vercel のサンキー図サイドパネルで政策評価が読み込めない、という報告の修正です。**本番が壊れている状態**なので優先度が高いものです。

## 原因

PR-1（#292）で rs-vis から as-is 取り込みした3ルートが、`public/data` を `process.cwd()` から直接読んでいました。

marumie は関数バンドルの 250MB 対策として `public/data` を全関数から除外し、`data/server` の `.gz` だけを include しています（`next.config.ts`・`docs/tasks/20260718_1421_関数バンドル250MB問題の設計的回避.md`）。そのため**本番では対象ファイルが存在しません**。

```ts
// 修正前（3ルートとも同型）
const base = path.join(process.cwd(), 'public', 'data', `project-quality-scores-${year}.json`);
if (fs.existsSync(base)) return JSON.parse(fs.readFileSync(base, 'utf-8'));
```

`/quality` が無事だったのは、クライアント側で全件から政策評価を組み立てており、これらのAPIを使わないためです。

## 影響（`public/data` を一時退避し、本番と同条件で実測）

| ルート | 修正前 | 修正後 |
|---|---|---|
| `/api/policy-summary` | **500** | 200 |
| `/api/project-map` | **404** | 200 |
| `/api/execution-history` | 200（**中身が空**） | 200 |
| `/api/quality-scores` | 200 | 200（元から `data-file` 経由） |

報告された症状以外にも波及していました。

- **`/api/policy-summary` の 500** が、サンキー図サイドパネルで政策評価が出ない直接原因
- **`/api/project-map` の 404** により `/project-bubble` は本番で「未生成」表示になっていたはず
- **`/api/execution-history` はサイレントに劣化**。200 を返すものの前年度スコアが読めず `priorExecutionRates` が全件欠落し、`/quality`・`/sankey-svg` の**「縮小」判定**（単年度の不用と2年連続の構造的な計上過大の区別）が効いていなかった

## 修正

パス解決を `app/lib/api/data-file.ts` に一元化しました。`public/data` → `data/server` の順に探索する marumie の正典で、他のローダ7本は元からこれを使っています。

```ts
// 修正後
return readDataJson<PolicyQualityInput[]>(
  `project-quality-scores-${year}.json`,
  `python3 scripts/score-project-quality-ai.py --year ${year} を実行してください。`,
);
```

3ルートから `fs` / `path` / `zlib` の import と自前リーダーを削除し、「直に `public/data` を読むと本番で必ず落ちる」旨をコメントに残しています。

## 検証

`public/data` をディレクトリごと退避して dev で確認しました（Vercel の関数バンドルと同じ条件）。修正前は上表のとおり失敗し、修正後は4ルートとも 200 です。

他に `public/data` を直読みするサーバコードが無いことも確認済み。

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | クリーン |
| `npm run lint` | エラーなし |
| `npx vitest run` | 100件パス |
| `npm run build` | 成功 |
| `npm run check-traces` | 違反なし |

## 再発防止について

同じ落とし穴は「rs-vis から as-is で取り込んだコードが marumie 固有のインフラ制約を知らない」という構造から来ています。`docs/data-pipeline-guide.md` あたりに「サーバからデータを読むときは必ず `data-file.ts` を経由する」旨を明記しておくべきかもしれません（本PRには含めていません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading execution history, policy summaries, and project-map data.
  * Standardized data access and error handling across these views.
  * Preserved existing quality-score, project-detail, and prior-execution information while reducing inconsistencies in data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->