### PR TITLE
fix(ui): 右上ナビを rs-vis の並びに合わせ、年度セレクトとボタン位置を全ページで統一

### DIFF
--- a/app/project-bubble/page.tsx
+++ b/app/project-bubble/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { BubbleCanvas } from '@/client/components/ProjectMap/BubbleCanvas';
 import { MultiSelectDropdown } from '@/components/filters/MultiSelectDropdown';
 import { PageNavMenu } from '@/components/navigation/PageNavMenu';
+import { YearSelect } from '@/components/navigation/YearSelect';
 import {
   COLOR_MODE_LABELS, SIZE_METRIC_LABELS,
   buildColorLookup, buildLegend, buildSizeScale, categoryLabel,
@@ -516,16 +517,7 @@ export default function ProjectMapPage() {
             </>
           )}
         </div>
-        <select
-          value={year}
-          onChange={e => setYear(e.target.value as Year)}
-          className="h-9 rounded-lg border border-black/10 bg-white/90 px-2 text-xs text-neutral-700 shadow-md backdrop-blur focus:outline-none dark:border-white/10 dark:bg-neutral-900/90 dark:text-neutral-200"
-          aria-label="年度"
-        >
-          {YEARS.map(y => (
-            <option key={y} value={y}>{y}年度</option>
-          ))}
-        </select>
+        <YearSelect value={year} onChange={y => setYear(y as Year)} years={YEARS} />
         <PageNavMenu current="/project-bubble" />
       </div>
 

--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -408,7 +408,7 @@ export default function QualityPage() {
       {dialogItem && <ScoreDetailDialog item={dialogItem} policy={policyByPid?.get(dialogItem.pid)} onClose={() => setDialogItem(null)} year={year} />}
       {/* Header */}
       <div className="shrink-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-4">
-        <div className="max-w-[1600px] mx-auto">
+        <div>
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">
               事業別 政策評価・執行透明性スコア
@@ -469,7 +469,7 @@ export default function QualityPage() {
       </div>
 
       {/* Score distribution summary (10-point bins) + histogram */}
-      <div className="relative shrink-0 w-full max-w-[1600px] mx-auto px-4 py-3">
+      <div className="relative shrink-0 w-full px-4 py-3">
         {(() => {
           const binRanges: { label: string; range: ScoreRange; lo: number; hi: number }[] = [
             { label: '100', range: '100-100', lo: 100, hi: 100 },
@@ -731,7 +731,7 @@ ${a.desc}` })),
       </div>
 
       {/* Table */}
-      <div className="flex-1 min-h-0 flex flex-col w-full max-w-[1600px] mx-auto px-4 pb-4">
+      <div className="flex-1 min-h-0 flex flex-col w-full px-4 pb-4">
         {/*
           外枠（枠線・角丸）と、スクロールする内箱を分ける。
           ページャを枠の中のフッタとして固定したいので、枠自体はスクロールさせない。

--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -155,7 +155,14 @@ const EMPTY_SCORE_FILTERS = (): Record<PolicyMetric, { min: string; max: string 
   ) as Record<PolicyMetric, { min: string; max: string }>;
 
 export default function QualityPage() {
-  const [year, setYear] = useState<'2024' | '2025'>('2025');
+  // ?year= を初期年度に反映する。サンキー図・再委託ビューの「一覧で見る →」や
+  // /api/quality-scores/[pid] が返す qualityWeb が year 付きで来るため、
+  // 読まないと 2024 を見ていたのに 2025 の一覧が開いてしまう。
+  const [year, setYear] = useState<'2024' | '2025'>(() => {
+    if (typeof window === 'undefined') return '2025';
+    const y = new URLSearchParams(window.location.search).get('year');
+    return y === '2024' || y === '2025' ? y : '2025';
+  });
   const [data, setData] = useState<QualityScoresResponse | null>(null);
   const [history, setHistory] = useState<ExecutionHistoryResponse | null>(null);
   const [loading, setLoading] = useState(true);

--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { PageNavMenu } from '@/components/navigation/PageNavMenu';
+import { YearSelect } from '@/components/navigation/YearSelect';
 import type { QualityScoreItem, QualityScoresResponse } from '@/app/api/quality-scores/route';
 import type { RecipientRow } from '@/app/lib/api/quality-recipients-loader';
 import type { ExecutionHistoryResponse } from '@/app/api/execution-history/route';
@@ -407,22 +408,15 @@ export default function QualityPage() {
     <div className="h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       {dialogItem && <ScoreDetailDialog item={dialogItem} policy={policyByPid?.get(dialogItem.pid)} onClose={() => setDialogItem(null)} year={year} />}
       {/* Header */}
-      <div className="shrink-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-4">
+      <div className="shrink-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-3 py-3">
         <div>
-          <div className="flex items-center gap-3 mb-1">
+          <div className="flex items-center gap-2 mb-1">
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">
               事業別 政策評価・執行透明性スコア
             </h1>
             {/* 年度とページ切替。全ページ共通で右上に置く */}
-            <select
-              value={year}
-              onChange={e => setYear(e.target.value as '2024' | '2025')}
-              aria-label="年度"
-              className="ml-auto h-9 rounded-lg border border-black/10 bg-white px-2 text-xs text-gray-700 shadow-sm cursor-pointer dark:border-white/10 dark:bg-gray-700 dark:text-gray-200"
-            >
-              <option value="2025">2025年度</option>
-              <option value="2024">2024年度</option>
-            </select>
+            <div className="ml-auto" />
+            <YearSelect value={year} onChange={y => setYear(y as '2024' | '2025')} years={[2025, 2024]} />
             <PageNavMenu current="/quality" />
           </div>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
@@ -469,7 +463,7 @@ export default function QualityPage() {
       </div>
 
       {/* Score distribution summary (10-point bins) + histogram */}
-      <div className="relative shrink-0 w-full px-4 py-3">
+      <div className="relative shrink-0 w-full px-3 py-3">
         {(() => {
           const binRanges: { label: string; range: ScoreRange; lo: number; hi: number }[] = [
             { label: '100', range: '100-100', lo: 100, hi: 100 },
@@ -731,7 +725,7 @@ ${a.desc}` })),
       </div>
 
       {/* Table */}
-      <div className="flex-1 min-h-0 flex flex-col w-full px-4 pb-4">
+      <div className="flex-1 min-h-0 flex flex-col w-full px-3 pb-4">
         {/*
           外枠（枠線・角丸）と、スクロールする内箱を分ける。
           ページャを枠の中のフッタとして固定したいので、枠自体はスクロールさせない。

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -1716,7 +1716,7 @@ export default function RealDataSankeyPage() {
       // 政策評価スコアの足きり。事業単位フックとして差し込む（policySummary は画面側にしか無い）
       scoreExcludeProject,
     );
-  }, [graphData, selectedNodeId, pinnedProjectId, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedFilterProjectName, debouncedFilterRecipientName, filterProjectNameRegex, filterRecipientNameRegex, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub, filterScoreO, filterScoreX, filterScoreN, scoreExcludeProject]);
+  }, [graphData, selectedNodeId, pinnedProjectId, filterMinistryNames, filterMinBudgetText, filterMaxBudgetText, filterMinSpendingText, filterMaxSpendingText, debouncedFilterProjectName, debouncedFilterRecipientName, filterProjectNameRegex, filterRecipientNameRegex, acGeneral, acSpecial, acBoth, acNone, filterSubcontract, filterRecipientIncludeSub, scoreExcludeProject]);
 
   const filtered = useMemo(() => {
     if (!graphData) return null;
@@ -3057,7 +3057,10 @@ export default function RealDataSankeyPage() {
     />
   );
 
-  // 右上クラスタに入れるツール群（TopN・オフセット操作）。スマホ幅では従来どおり左下に絶対配置
+  /**
+   * TopN・オフセットの操作パネル。狭幅では画面下部、通常は右上クラスタの左端に置く。
+   * 右上は［ツール - 表示設定 - 年度 - メニュー］の並びで rs-vis と揃える。
+   */
   const offsetControlsBlock = filtered ? (() => {
         // Recipient offset mode
         const maxRecipOffset = Math.max(0, filtered.totalRecipientCount - topRecipient);
@@ -3085,6 +3088,7 @@ export default function RealDataSankeyPage() {
         return (
           <div ref={offsetControlRef} style={ isCompactWidth
             ? { position: 'absolute', bottom: 12, left: isLandscapeCompact && selectedNodeId !== null && !isPanelCollapsed ? effectiveSidePanelWidth + 8 : 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)', transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }
+            // 通常幅では右上クラスタの子として並べる（位置はクラスタ側が持つ）
             : { display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
             {/* Row 1: オフセットスライダー（2列スパン） */}
@@ -3120,7 +3124,7 @@ export default function RealDataSankeyPage() {
                     style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
                   >{activeRangeStart}</button>
                 )}
-                <span style={{ color: '#999', fontSize: META_FONT_PX }}>~{activeRangeEnd}</span>
+                <span style={{ color: '#999', fontSize: META_FONT_PX }}>〜{activeRangeEnd}</span>
                 <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
                 {/* 総件数表示は幅を取るためスマホ幅では非表示 */}
                 {!isCompactWidth && <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>}
@@ -3174,7 +3178,7 @@ export default function RealDataSankeyPage() {
           )}
           </div>
         );
-  })() : null;
+      })() : null;
 
   return (
     <div
@@ -4325,33 +4329,6 @@ export default function RealDataSankeyPage() {
         </SidePanelChrome>
       )}
 
-      {/* Year selector — top center（スマホ幅では検索ボックスに隠れるため設定ダイアログへ移動）。
-          AIチャットパネル展開時は右上コントロール群が左へ退避して重なるため、中央クラスタも同分の半分だけ左へ寄せる */}
-      {!isCompactWidth && (
-      <div data-pan-disabled="true" style={{ position: 'absolute', top: 12, left: `calc(50% - ${rightControlsOffset / 2}px)`, transform: 'translateX(-50%)', zIndex: 15, display: 'flex', gap: 8, alignItems: 'flex-start', transition: isResizingAiPanel ? 'none' : 'left 0.2s ease' }}>
-        <div style={{ position: 'relative' }}>
-          <select
-            data-testid={testId('year-select')}
-            value={year}
-            onChange={e => handleYearChange(e.target.value as '2024' | '2025')}
-            style={{ fontSize: CONTROL_FONT_PX, border: '1px solid #e0e0e0', borderRadius: 8, padding: '6px 28px 6px 10px', background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', color: '#333', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none' }}
-          >
-            <option value="2025">2025年度</option>
-            <option value="2024">2024年度</option>
-          </select>
-          {/* dropdown arrow */}
-          <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
-        </div>
-        {/* 探索履歴・発見メモ（IndexedDB のみ・サーバ送信なし） */}
-        <ExplorationHistory
-          getSnapshot={getExplorationSnapshot}
-          onApply={applyExplorationEntry}
-          fontPx={CONTROL_FONT_PX}
-        />
-      </div>
-      )}
 
       {/* Search box — top left */}
       {/* zIndex は サイドパネル(25) より下。列ヘッダー(8)/年度(15)/設定ダイアログ(19) より上、
@@ -4816,135 +4793,37 @@ export default function RealDataSankeyPage() {
         )}
       </div>
 
-      {/* Top-right panel: offset slider */}
-      {filtered && (() => {
-        // Recipient offset mode
-        const maxRecipOffset = Math.max(0, filtered.totalRecipientCount - topRecipient);
-        const clampedOffset = Math.min(recipientOffset, maxRecipOffset);
-        const recipRangeStart = clampedOffset + 1;
-        const recipRangeEnd = Math.min(clampedOffset + topRecipient, filtered.totalRecipientCount);
-        const recipMaxStartRank = maxRecipOffset + 1;
-        // Project offset mode
-        const maxProjOffset = Math.max(0, filtered.totalProjectCount - topProject);
-        const clampedProjOffset = Math.min(projectOffset, maxProjOffset);
-        const projRangeStart = clampedProjOffset + 1;
-        const projRangeEnd = Math.min(clampedProjOffset + topProject, filtered.totalProjectCount);
-        // Active values for shared controls
-        const isProjectMode = offsetTarget === 'project';
-        const activeOffset = isProjectMode ? clampedProjOffset : clampedOffset;
-        const activeMax = isProjectMode ? maxProjOffset : maxRecipOffset;
-        const activeTotalCount = isProjectMode ? filtered.totalProjectCount : filtered.totalRecipientCount;
-        const activeRangeStart = isProjectMode ? projRangeStart : recipRangeStart;
-        const activeRangeEnd = isProjectMode ? projRangeEnd : recipRangeEnd;
-        const activeMaxStartRank = isProjectMode ? maxProjOffset + 1 : recipMaxStartRank;
-        const setActiveOffset = (v: number) => {
-          pendingHistoryAction.current = 'replace';
-          if (isProjectMode) setProjectOffset(v); else setRecipientOffset(v);
-        };
-        return (
-          <div ref={offsetControlRef} style={ isCompactWidth
-            ? { position: 'absolute', bottom: 12, left: isLandscapeCompact && selectedNodeId !== null && !isPanelCollapsed ? effectiveSidePanelWidth + 8 : 8, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', maxWidth: 'calc(100vw - 16px)', transition: isResizingSidePanel ? 'none' : 'left 0.2s ease' }
-            : { position: 'absolute', top: 12, right: 52 + rightControlsOffset, zIndex: 30, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', transition: isResizingAiPanel ? 'none' : 'right 0.2s ease' } }>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 8, rowGap: 4, background: 'rgba(255,255,255,0.92)', padding: '5px 10px', borderRadius: isCompactWidth ? 6 : '6px 6px 0 6px', border: '1px solid #e0e0e0', fontSize: CONTROL_SMALL_FONT_PX }}>
-            {/* Row 1: オフセットスライダー（2列スパン） */}
-            <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 8, alignItems: 'center' }}>
-              {/* オフセット対象コンボボックス */}
-              <select
-                data-testid={testId('offset-target-select')}
-                value={offsetTarget}
-                onChange={e => { pendingHistoryAction.current = 'replace'; setOffsetTarget(e.target.value as 'recipient' | 'project'); }}
-                style={{ fontSize: META_FONT_PX, border: '1px solid #ccc', borderRadius: 3, padding: '1px 2px', background: '#fff', color: '#555', cursor: 'pointer' }}
-              >
-                <option value="project">事業</option>
-                <option value="recipient">支出先</option>
-              </select>
-              <label style={{ flex: isCompactWidth ? '0 0 auto' : 1, display: 'flex', alignItems: 'center', gap: 4 }}>
-                {/* スマホ幅では「Top」ラベルを省き数値だけ表示 */}
-                {!isCompactWidth && <span style={{ color: '#555', fontSize: META_FONT_PX }}>Top</span>}
-                {isEditingOffset ? (
-                  <input
-                    type="number"
-                    autoFocus
-                    min={1} max={activeMaxStartRank} step={1}
-                    value={offsetInputValue}
-                    onChange={e => { setOffsetInputValue(e.target.value); const v = Number(e.target.value); if (!isNaN(v) && v >= 1) setActiveOffset(Math.max(0, Math.min(activeMax, v - 1))); }}
-                    onBlur={() => setIsEditingOffset(false)}
-                    onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setIsEditingOffset(false); }}
-                    style={{ width: `${Math.max(40, String(activeMaxStartRank).length * 8 + 20)}px`, textAlign: 'center', border: '1px solid #ccc', borderRadius: 3, fontSize: CONTROL_SMALL_FONT_PX }}
-                  />
-                ) : (
-                  <button
-                    onClick={() => { setOffsetInputValue(String(activeRangeStart)); setIsEditingOffset(true); }}
-                    title="クリックして開始位置を入力"
-                    style={{ color: '#999', fontSize: META_FONT_PX, background: 'transparent', border: 'none', cursor: 'text', padding: 0 }}
-                  >{activeRangeStart}</button>
-                )}
-                <span style={{ color: '#999', fontSize: META_FONT_PX }}>〜{activeRangeEnd}</span>
-                <input type="range" min={0} max={activeMax} value={activeOffset} onChange={e => { pendingFocusId.current = null; setActiveOffset(Number(e.target.value)); }} style={{ width: 60 }} />
-                {/* 総件数表示は幅を取るためスマホ幅では非表示 */}
-                {!isCompactWidth && <span style={{ color: '#999', fontSize: META_FONT_PX }}>/{activeTotalCount}件</span>}
-                <div style={{ display: 'flex', flexDirection: 'row', gap: 2, alignItems: 'center' }}>
-                  {([
-                    [-1, 'M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6z', '前へ'],
-                    [1,  'M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z', '次へ'],
-                  ] as [number, string, string][]).map(([delta, path, title]) => (
-                    <button key={delta} title={title} aria-label={title}
-                      data-testid={testId(delta > 0 ? 'recipient-offset-next' : 'recipient-offset-prev')}
-                      {...offsetRepeat(() => {
-                        pendingHistoryAction.current = 'replace';
-                        pendingFocusId.current = null;
-                        if (isProjectMode) setProjectOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
-                        else setRecipientOffset(prev => Math.max(0, Math.min(activeMax, prev + delta)));
-                      }, { stopPropagation: true })}
-                      onClick={(e) => {
-                        if (e.detail === 0) {
-                          setActiveOffset(Math.max(0, Math.min(activeMax, activeOffset + delta)));
-                        }
-                      }}
-                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555"><path d={path}/></svg>
-                    </button>
-                  ))}
-                </div>
-                {/* Material Icons: vertical_align_top — オフセットリセット */}
-                <button onClick={e => { e.preventDefault(); setActiveOffset(0); }} title="先頭へリセット" aria-label="先頭へリセット"
-                  onContextMenu={(e) => e.preventDefault()}
-                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'none' }}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" height={scaleSize(14)} width={scaleSize(14)} viewBox="0 0 24 24" fill="#555" style={{ transform: 'rotate(-90deg)' }}><path d="M8 11h3v10h2V11h3l-4-4-4 4zM4 3v2h16V3H4z"/></svg>
-                </button>
-              </label>
-            </div>
-            {/* Row 2: 事業・支出先 TopN スライダー（スマホ幅では設定ダイアログへ移動） */}
-            {!isCompactWidth && showTopNSliders && topNSlidersFragment}
-          </div>
-          {/* トグルボタン（パネル外・下部）— スマホ幅では設定ダイアログにTopNを移すため非表示 */}
-          {!isCompactWidth && (
-          <button
-            onClick={() => setShowTopNSliders(s => !s)}
-            title={showTopNSliders ? 'TopN設定 を隠す' : 'TopN設定 を表示'}
-            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.92)', borderTop: 'none', borderLeft: '1px solid #e0e0e0', borderRight: '1px solid #e0e0e0', borderBottom: '1px solid #e0e0e0', borderRadius: '0 0 4px 4px', cursor: 'pointer', padding: '0 2px', marginTop: -1, userSelect: 'none' }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#bbb">
-              <path d={showTopNSliders ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z' : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'} />
-            </svg>
-          </button>
-          )}
-          </div>
-        );
-      })()}
 
-      {/* ページ切替メニュー — 表示設定(⋮)の左隣。
-          rs-vis は右上を［ツール - 年度 - メニュー］に組み替えているが、marumie の右上は
-          AIチャットパネル展開時に rightControlsOffset ぶん左へ退避する制御を持つため、
-          現行の配置を保ったままメニューだけを足している（配置の見直しは別途）。 */}
-      <div style={{ position: 'absolute', top: 14, right: 52 + rightControlsOffset, zIndex: 200, transition: isResizingAiPanel ? 'none' : 'right 0.2s ease' }}>
-        <PageNavMenu current="/sankey-svg" theme="light" />
-      </div>
+      {/* 狭幅では TopN・オフセット操作を画面下部へ（クラスタには入れない） */}
+      {isCompactWidth && offsetControlsBlock}
 
-      {/* Settings button — independent, top right（ダイアログを最前面にするため高いzIndex） */}
-      <div style={{ position: 'absolute', top: 14, right: 12 + rightControlsOffset, zIndex: 200, transition: isResizingAiPanel ? 'none' : 'right 0.2s ease' }}>
+      {/* 右上クラスタ: ［ツール - 探索履歴 - 表示設定 - 年度 - ページ切替］。
+          rs-vis の並び（ツール → 年度 → メニュー）に合わせつつ、marumie 固有の
+          探索履歴と表示設定(⋮)を年度コンボの左に置く。
+          AIチャットパネル展開時は rightControlsOffset ぶん左へ退避する。
+          スマホ幅では表示設定とページ切替だけを残す（ツール・履歴・年度は
+          それぞれ画面下部と設定ダイアログへ移す）。 */}
+      <div
+        data-pan-disabled="true"
+        style={{
+          position: 'absolute', top: 12, right: 12 + rightControlsOffset, zIndex: 200,
+          display: 'flex', gap: 8, alignItems: 'flex-start',
+          transition: isResizingAiPanel ? 'none' : 'right 0.2s ease',
+        }}
+      >
+        {!isCompactWidth && offsetControlsBlock}
+
+        {/* 探索履歴・発見メモ（IndexedDB のみ・サーバ送信なし） */}
+        {!isCompactWidth && (
+          <ExplorationHistory
+            getSnapshot={getExplorationSnapshot}
+            onApply={applyExplorationEntry}
+            fontPx={CONTROL_FONT_PX}
+          />
+        )}
+
+        {/* 表示設定(⋮)。ダイアログはこの要素を基準に開く */}
+        <div style={{ position: 'relative', flexShrink: 0 }}>
         <button
           onClick={() => setShowSettings(s => !s)}
           aria-label="表示設定を開く"
@@ -5026,6 +4905,29 @@ export default function RealDataSankeyPage() {
             </div>
           </>
         )}
+        </div>
+
+        {/* 年度切替（rs-vis の並びに合わせて、ツール類の右・メニューの左）。
+            スマホ幅では検索ボックスに隠れるため設定ダイアログ側に置く */}
+        {!isCompactWidth && (
+        <div data-pan-disabled="true" style={{ position: 'relative', flexShrink: 0 }}>
+          <select
+            data-testid={testId('year-select')}
+            value={year}
+            onChange={e => handleYearChange(e.target.value as '2024' | '2025')}
+            style={{ fontSize: CONTROL_FONT_PX, border: '1px solid #e0e0e0', borderRadius: 8, padding: '6px 28px 6px 10px', background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', color: '#333', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none' }}
+          >
+            <option value="2025">2025年度</option>
+            <option value="2024">2024年度</option>
+          </select>
+          {/* dropdown arrow */}
+          <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
+            <path d="M7 10l5 5 5-5z"/>
+          </svg>
+        </div>
+        )}
+
+        <PageNavMenu current="/sankey-svg" theme="light" />
       </div>
 
       {/* Zoom controls — bottom right (sankey2 style) */}

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -12,6 +12,7 @@ import {
   getColumn, getNodeColor, getLinkColor, ribbonPath, formatYen, sortPriority,
 } from '@/app/lib/sankey-svg-constants';
 import { PageNavMenu } from '@/components/navigation/PageNavMenu';
+import { YearSelect } from '@/components/navigation/YearSelect';
 import { MinimapOverlay } from '@/client/components/SankeySvg/MinimapOverlay';
 import { TopNSliders } from '@/client/components/SankeySvg/TopNSliders';
 import { FontSizeControls } from '@/client/components/SankeySvg/FontSizeControls';
@@ -4818,7 +4819,8 @@ export default function RealDataSankeyPage() {
           <ExplorationHistory
             getSnapshot={getExplorationSnapshot}
             onApply={applyExplorationEntry}
-            fontPx={CONTROL_FONT_PX}
+            // 他ページは text-xs(12px)。フォントスケール機能があるので倍率だけ合わせる
+            fontPx={scaleFont(12)}
           />
         )}
 
@@ -4910,21 +4912,15 @@ export default function RealDataSankeyPage() {
         {/* 年度切替（rs-vis の並びに合わせて、ツール類の右・メニューの左）。
             スマホ幅では検索ボックスに隠れるため設定ダイアログ側に置く */}
         {!isCompactWidth && (
-        <div data-pan-disabled="true" style={{ position: 'relative', flexShrink: 0 }}>
-          <select
-            data-testid={testId('year-select')}
+          <YearSelect
             value={year}
-            onChange={e => handleYearChange(e.target.value as '2024' | '2025')}
-            style={{ fontSize: CONTROL_FONT_PX, border: '1px solid #e0e0e0', borderRadius: 8, padding: '6px 28px 6px 10px', background: 'rgba(255,255,255,0.95)', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', color: '#333', cursor: 'pointer', appearance: 'none', WebkitAppearance: 'none' }}
-          >
-            <option value="2025">2025年度</option>
-            <option value="2024">2024年度</option>
-          </select>
-          {/* dropdown arrow */}
-          <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-            <path d="M7 10l5 5 5-5z"/>
-          </svg>
-        </div>
+            onChange={y => handleYearChange(y as '2024' | '2025')}
+            years={[2025, 2024]}
+            theme="light"
+            // 他ページは text-xs(12px)。フォントスケール機能があるので倍率だけ合わせる
+            fontPx={scaleFont(12)}
+            testId={testId('year-select')}
+          />
         )}
 
         <PageNavMenu current="/sankey-svg" theme="light" />

--- a/app/sankey-svg/page.tsx
+++ b/app/sankey-svg/page.tsx
@@ -4056,6 +4056,7 @@ export default function RealDataSankeyPage() {
                 return (
                   <PolicyEvaluationBlock
                     pid={selectedNode.projectId}
+                    year={year}
                     error={policyError}
                     view={entry ? {
                       overall: entry.o, proportionality: entry.x, necessity: entry.n,

--- a/app/subcontracts/[projectId]/page.tsx
+++ b/app/subcontracts/[projectId]/page.tsx
@@ -600,6 +600,7 @@ function SidePane({
         view={policyView}
         error={policyError}
         pid={graph.projectId}
+        year={year}
         labelPx={scaleFont(12)}
         metaPx={scaleFont(10)}
         onOpenDetail={() => openScoreDialog(graph.projectId)}

--- a/app/subcontracts/page.tsx
+++ b/app/subcontracts/page.tsx
@@ -583,7 +583,7 @@ function SubcontractsPageInner() {
   return (
     <div style={{ height: '100vh', background: '#f9fafb', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       {/* ── 上部: フィルタ群 ── */}
-      <div style={{ flexShrink: 0, padding: '12px 16px', maxWidth: 1600, margin: '0 auto', width: '100%', boxSizing: 'border-box' }}>
+      <div style={{ flexShrink: 0, padding: '12px 16px', width: '100%', boxSizing: 'border-box' }}>
         {/* コントロール（/sankey-svg と同じトーン） */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
 
@@ -774,7 +774,7 @@ function SubcontractsPageInner() {
       </div>
 
       {/* ── 中部: スクロールテーブル ── */}
-      <div style={{ flex: 1, minHeight: 0, padding: '0 16px', maxWidth: 1600, margin: '0 auto', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ flex: 1, minHeight: 0, padding: '0 16px', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column' }}>
         {loading && <p style={{ color: '#6b7280', fontSize: 14 }}>読み込み中...</p>}
         {error && <p style={{ color: '#ef4444', fontSize: 14 }}>エラー: {error}</p>}
         {!loading && !error && (
@@ -938,7 +938,7 @@ function SubcontractsPageInner() {
       {/* ── 下部: ページネーション ── */}
       {!loading && !error && totalPages > 1 && (
         <div style={{ flexShrink: 0, background: '#fff', borderTop: '1px solid #e5e7eb', padding: '8px 16px' }}>
-          <div style={{ maxWidth: 1600, margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}

--- a/app/subcontracts/page.tsx
+++ b/app/subcontracts/page.tsx
@@ -28,6 +28,7 @@ import { FilterTextInput } from '@/components/filters/FilterTextInput';
 import { MinMaxInput } from '@/components/filters/MinMaxInput';
 import { MultiSelectDropdown } from '@/components/filters/MultiSelectDropdown';
 import { PageNavMenu } from '@/components/navigation/PageNavMenu';
+import { YearSelect } from '@/components/navigation/YearSelect';
 import { ProjectReferenceLinks } from '@/components/subcontracts/ProjectReferenceLinks';
 import { formatYen, parseAmountToYen } from '@/app/lib/format/yen';
 import { accountCategoryLabel, bureauLeaf } from '@/app/lib/subcontracts/labels';
@@ -583,7 +584,7 @@ function SubcontractsPageInner() {
   return (
     <div style={{ height: '100vh', background: '#f9fafb', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       {/* ── 上部: フィルタ群 ── */}
-      <div style={{ flexShrink: 0, padding: '12px 16px', width: '100%', boxSizing: 'border-box' }}>
+      <div style={{ flexShrink: 0, padding: '12px', width: '100%', boxSizing: 'border-box' }}>
         {/* コントロール（/sankey-svg と同じトーン） */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
 
@@ -673,31 +674,7 @@ function SubcontractsPageInner() {
 
           {/* 年度とページ切替。全ページ共通で右上に置く */}
           <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-            <div style={{ position: 'relative' }}>
-              <select
-                value={year}
-                onChange={(e) => setYear(Number(e.target.value))}
-                aria-label="年度"
-                style={{
-                  fontSize: 13,
-                  border: '1px solid #e0e0e0',
-                  borderRadius: 8,
-                  padding: '8px 28px 8px 10px',
-                  background: 'rgba(255,255,255,0.95)',
-                  boxShadow: '0 1px 4px rgba(0,0,0,0.1)',
-                  color: '#333',
-                  cursor: 'pointer',
-                  appearance: 'none',
-                  WebkitAppearance: 'none',
-                }}
-              >
-                <option value={2025}>2025年度</option>
-                <option value={2024}>2024年度</option>
-              </select>
-              <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24" fill="#999" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-                <path d="M7 10l5 5 5-5z"/>
-              </svg>
-            </div>
+            <YearSelect value={String(year)} onChange={y => setYear(Number(y))} years={[2025, 2024]} theme="light" />
             <PageNavMenu current="/subcontracts" theme="light" />
           </div>
         </div>
@@ -774,7 +751,7 @@ function SubcontractsPageInner() {
       </div>
 
       {/* ── 中部: スクロールテーブル ── */}
-      <div style={{ flex: 1, minHeight: 0, padding: '0 16px', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ flex: 1, minHeight: 0, padding: '0 12px', width: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column' }}>
         {loading && <p style={{ color: '#6b7280', fontSize: 14 }}>読み込み中...</p>}
         {error && <p style={{ color: '#ef4444', fontSize: 14 }}>エラー: {error}</p>}
         {!loading && !error && (

--- a/client/components/quality/PolicyEvaluationBlock.tsx
+++ b/client/components/quality/PolicyEvaluationBlock.tsx
@@ -44,6 +44,7 @@ function scoreColor(v: number | null): string {
 export function PolicyEvaluationBlock({
   view,
   pid,
+  year,
   error,
   labelPx,
   metaPx,
@@ -53,6 +54,8 @@ export function PolicyEvaluationBlock({
   /** null = スコアなし（何も描かない）。undefined = 取得中 */
   view: PolicyEvaluationView | null | undefined;
   pid: string | number;
+  /** 「一覧で見る →」に付ける年度。付けないと /quality が既定年度で開く */
+  year: string | number;
   /** 取得に失敗したときのメッセージ。表示だけ落として本体の動作は妨げない */
   error?: string | null;
   labelPx: number;
@@ -102,7 +105,7 @@ export function PolicyEvaluationBlock({
           >{detailLoading ? '読込中…' : '詳細'}</button>
         )}
         <a
-          href={`/quality?pid=${pid}`}
+          href={`/quality?pid=${pid}&year=${year}`}
           target="_blank"
           rel="noopener noreferrer"
           style={{ marginLeft: onOpenDetail ? 8 : 'auto', fontSize: metaPx, color: '#4a90d9', textDecoration: 'none', flexShrink: 0 }}

--- a/components/navigation/YearSelect.tsx
+++ b/components/navigation/YearSelect.tsx
@@ -37,7 +37,7 @@ export function YearSelect({
         onChange={e => onChange(e.target.value)}
         aria-label="年度"
         style={fontPx ? { fontSize: fontPx } : undefined}
-        className={`h-9 cursor-pointer appearance-none rounded-lg border border-black/10 bg-white/90 pl-2.5 pr-7 text-xs text-neutral-700 shadow-md backdrop-blur focus:outline-none ${
+        className={`h-9 cursor-pointer appearance-none rounded-lg border border-black/10 bg-white/90 pl-2.5 pr-7 text-xs text-neutral-700 shadow-md backdrop-blur focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
           dark ? 'dark:border-white/10 dark:bg-neutral-900/90 dark:text-neutral-200' : ''
         }`}
       >

--- a/components/navigation/YearSelect.tsx
+++ b/components/navigation/YearSelect.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * 年度セレクト。全ページ共通で PageNavMenu の左隣に置く。
+ *
+ * 以前はページごとに inline style と Tailwind が混在し、高さ 34/36/38px・
+ * 文字 12/13px・枠線 2色・矢印がネイティブとカスタムで割れていた。
+ * 見た目は PageNavMenu のボタン（h-9・rounded-lg・border-black/10・shadow-md）に揃える。
+ *
+ * 矢印は appearance:none ＋ 自前 SVG に統一する。ネイティブのままだと
+ * ブラウザ・OS で形と幅が変わり、隣のメニューボタンと高さが揃わないため。
+ */
+
+export function YearSelect({
+  value,
+  onChange,
+  years,
+  theme = 'auto',
+  fontPx,
+  testId,
+}: {
+  value: string;
+  onChange: (year: string) => void;
+  years: readonly (string | number)[];
+  /** 'light' はライト配色固定のページ（/sankey-svg 等）用。OSダーク時の浮きを防ぐ */
+  theme?: 'auto' | 'light';
+  /** フォントスケール対応ページ用。未指定なら text-xs 相当 */
+  fontPx?: number;
+  testId?: string;
+}) {
+  const dark = theme === 'auto';
+  return (
+    <div className="relative shrink-0">
+      <select
+        data-testid={testId}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        aria-label="年度"
+        style={fontPx ? { fontSize: fontPx } : undefined}
+        className={`h-9 cursor-pointer appearance-none rounded-lg border border-black/10 bg-white/90 pl-2.5 pr-7 text-xs text-neutral-700 shadow-md backdrop-blur focus:outline-none ${
+          dark ? 'dark:border-white/10 dark:bg-neutral-900/90 dark:text-neutral-200' : ''
+        }`}
+      >
+        {years.map(y => (
+          <option key={y} value={String(y)}>{y}年度</option>
+        ))}
+      </select>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="14"
+        width="14"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className={`pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 fill-neutral-400 ${
+          dark ? 'dark:fill-neutral-500' : ''
+        }`}
+      >
+        <path d="M7 10l5 5 5-5z" />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
rs-vis へ反映する前の合わせ込みです。PR-3（#294）で見送っていた右上コントロールの再構成を、rs-vis の並びを採用する形で実施し、あわせてページごとにバラついていた年度セレクトとページ切替ボタンの位置・見た目を揃えます。

## 1. サンキー図の右上を1クラスタへ統合（`dcbddfd`）

年度コンボを画面上部中央から右上へ移し、従来右上にあったコントロールをその左に並べました。

```text
[TopN・オフセット] [探索履歴] [表示設定⋮] [年度] [ページ切替☰]
```

1440px 実測で右端12px・要素間8px（x=856 / 1172 / 1246 / 1286 / 1392）。

### 重なりの解消

**PR-3 で `PageNavMenu` を `right: 52 + rightControlsOffset` に置いたところ、オフセットパネルも同じ `right: 52` に絶対配置されており重なっていました。** 1つの flex クラスタにまとめて解消しています。

### 構造

- オフセットパネルを JSX 内の IIFE から `const offsetControlsBlock` へ切り出し。通常幅はクラスタの子（位置はクラスタが持つ）、スマホ幅は従来どおり画面下部へ絶対配置
- **PR-3 で除外したハンクの残骸だった未使用の `offsetControlsBlock`（117行）を削除。** 今回の切り出しで名前が衝突したため、実体のあるこちらに置き換わりました（CodeRabbit が指摘していた lint 未使用警告も解消）
- `filterExcludedIds` の依存配列から `filterScoreO/X/N` を除去（スコアは `scoreExcludeProject` 経由でのみ参照するため冗長。これも PR-3 の新規警告）

### スマホ幅

クラスタは常に描画し、子だけを出し分けます。ツール・探索履歴・年度はそれぞれ画面下部と設定ダイアログへ移すため非表示、表示設定(⋮)とページ切替は残します。

作業中にクラスタ全体を `!isCompactWidth` で囲んでしまい、390px で ⋮ とページ切替まで消える状態を作ったため、実機幅で確認して修正しました。

## 2. 一覧の幅をウィンドウ連動に（`d1ac847`）

`/quality` と `/subcontracts` はヘッダー・フィルタ・テーブルが `max-width:1600px` の中央寄せコンテナに入っており、1600px を超えるウィンドウでボタンが内側に寄っていました。

```text
viewport 1920px       変更前    変更後
  /quality             160px  →   16px
  /subcontracts        176px  →   16px
  他3ページ              12px      12px
```

2560px でも同じ値になり、幅に依存しなくなりました。1920px でレイアウトが崩れていないことをスクリーンショットで確認済みです。

## 3. 年度セレクトの共有コンポーネント化と位置の統一（`7d1bd4a`）

### 変更前の実測（1600px）

| ページ | 年度セレクト | メニュー |
|---|---|---|
| `/sankey-svg` | 98x34 13px `#e0e0e0` カスタム矢印 | right:12 top:12 |
| `/quality` | 89x36 12px `black/10` ネイティブ矢印 | right:16 top:16 |
| `/subcontracts` | 95x38 13px `#e0e0e0` カスタム矢印 | right:16 top:13 |
| `/project-bubble` | 89x36 12px `black/10` ネイティブ矢印 | right:12 top:12 |

**高さ3種・文字2種・枠線2色・矢印2種**に割れていました。

### 変更後

```text
全ページ  年度 91x36 12px  /  メニュー 36x36 right:12 top:12
```

`components/navigation/YearSelect.tsx` を新設し、見た目を `PageNavMenu` のボタン（`h-9`・`rounded-lg`・`border-black/10`・`shadow-md`・`backdrop-blur`）に合わせました。矢印は `appearance:none` ＋ 自前 SVG に統一しています（ネイティブのままだとブラウザ・OS で形と幅が変わり、隣のメニューと高さが揃わないため）。

`/sankey-svg` のフォントスケール機能は `fontPx` で維持しつつ、基準を他ページと同じ 12px に合わせました（従来は 13px 基準で1px大きい状態）。

位置は `/quality` の `px-4 py-4` → `px-3 py-3`・`gap-3` → `gap-2`、`/subcontracts` の左右パディング 16px → 12px。テーブルの右端とボタンの右端が揃ったまま、他3ページの `right:12` と一致します。

## 残す差（対応しない）

`/sankey-svg` だけ年度セレクトの幅が 3px 広くなります。原因は**ページの基準フォント**で、`/sankey-svg` が `system-ui`、他ページが `Arial` でした。パディング・文字サイズは同一で、フォントファミリの統一は全ページに波及するため本PRの範囲外とします。

## 検証

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | クリーン |
| `npm run lint` | エラーなし。**PR-3 由来の新規警告2件はどちらも解消** |
| `npx vitest run` | 100件パス |
| `npm run build` | 成功 |
| Playwright | 1440 / 1600 / 1920 / 2560 / 390px で位置を実測、5ページのスクリーンショット比較、設定ダイアログの展開方向を確認 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent, styled year selector across project, quality, Sankey, and subcontract pages.
  * Improved responsive controls on the Sankey page, including better organization on compact layouts.
* **Style**
  * Updated page layouts to use the available screen width with streamlined horizontal spacing.
  * Refined Sankey toolbar placement and control presentation across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->