### PR TITLE
docs: S1の方針決定（CSV由来cnは補正しない）と支出先データ4系統の整理

### DIFF
--- a/docs/tasks/20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md
+++ b/docs/tasks/20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md
@@ -168,3 +168,70 @@ cnVerifiedCount / validRatio / axis1
 `axisIdentify`（重み28）は AI が `辞書判定: unknown` を見て付けた値のままである。cn を AI 判定へ反映するには再採点が必要で、それは S3（プロンプトへの辞書判定値の定義追加）とセットで行う。**本作業は機械計算項目の整合を回復しただけ**で、AI 軸は cn 未反映のまま。
 
 2024年度は marumie が独自版（cn あり）を保持しているため対象外。
+
+## 方針決定と現状整理（2026-07-31）
+
+### 方針: CSV 由来の cn には処理で手を加えない
+
+誤記載であっても補正しない。**元データに誤りがあること自体を可視化すべき観点**と位置づける。設計の「A/B」でいう **A（`recipient-resolution` の適用を全部やめる）** を採る。
+
+影響範囲は2つだけ。
+
+| 対象 | 変化 |
+|---|---|
+| `generate-sankey-svg-data.ts` | `corpAmounts`（名前集約ノードが内包する法人番号の内訳）から補正が消える。**ノード分割は元々名前ベースなのでグラフの形は変わらない** |
+| `generate-recipient-index.ts` | キーが変わる。2024で 1,639行・443名が法人番号キーを失い `name:` キーへ落ちる |
+
+派生して不要になるもの:
+
+- `recipient-resolution-{YEAR}.json.gz` — 消費者が消えるので廃止
+- `types/recipient-index.ts` の `rawCorporateNumber` / `redirects` — 補正の存在が前提の仕組み
+- `generate-recipient-resolution.py` — `mergeCn`/`supplement` の生成を落とし、**`verified` 専用スクリプトに作り替える**（houjin.db を読む唯一のスクリプトという位置づけは維持）
+
+**結果として S1 は単純になる。** houjin.db の用途が「名称の裏取り」だけに絞られ、成果物も `recipient-verified-{YEAR}.json.gz` 1本になる。
+
+実測した補正の規模（参考・これらが適用されなくなる）:
+
+```text
+2024: mergeCn で置換 178行（60名） / supplement で補完 1,639行（443名）
+2025: mergeCn で置換 150行（64名） / supplement で補完   647行（177名）
+```
+
+### 支出先データは4系統ある
+
+同じ 5-1 CSV を出発点にしながら、生成器・キー規則・補正の有無がすべて違う。
+
+| 画面 | データ | 生成 | 支出先のキー | 補正 |
+|---|---|---|---|---|
+| `/quality` 詳細 | `project-quality-recipients-{Y}.json.gz` | `score-project-quality.py` | なし（行単位・`cn` は生CSV値） | 無し |
+| `/subcontracts` | `subcontracts-{Y}.json.gz` | `generate-subcontracts.ts` | `支出先名\|法人番号`（ブロック配下） | 無し |
+| `/sankey-svg` | `sankey-svg-{Y}-graph.json.gz` | `generate-sankey-svg-data.ts` | **支出先名のみ**（正規化もしない） | 有り → **A で廃止** |
+| `/recipients` | `recipient-index-{Y}.json.gz` | `generate-recipient-index.ts` | `buildRecipientKey(name, cn)`（cn優先） | 有り → **A で廃止** |
+
+方針A の適用で「元データに手を加えているか」は全画面で統一される。**名寄せ規則が4通りある状態は残る**ので、それを1本化するのが S2 の主題になる。
+
+### 各画面の性質（確認済み）
+
+- **`/sankey-svg`** — 直接支出のみ。再委託ブロックの行は `indirectRows` として集計から除外され、再委託先は描かれない。支出先名キーのため**1ノードに複数の法人番号が混ざる**（2025で285名。最多は「株式会社秋山商会」等で各4個）。ノードは `representativeCorporateNumber`（最大金額の cn）と `corporateNumberCount` を持つ
+- **`/quality`** — 支出先の記載の正確さは**無くなったのではなく判定方法が変わった**。旧 `axis1`（辞書の名前完全一致）は総合点から外れ、代わりに `axisIdentify`（AI・重み28）と `axisPurpose`（AI・重み22）が `執行透明性` を構成する
+- **`/subcontracts`** — 5-1・5-2・5-3・2-1 の4CSVを使う唯一のパイプライン。同じ支出先でもブロック配下に置かれ、費目・使途（5-3）が別途ぶら下がる
+- **間接経費** — 支出先ブロックを持たない支出。サンキー図には乗らない（2025で1,045事業・約329億円）。#288 で再委託フロー図にグレーの終端ノードとして追加済み
+
+### 辞書は新スコアでも現役
+
+`public/data/dictionaries/` は22本あるが、**実際に読まれているのは4本**（残り18本は `recipient_dictionary.csv` を組み立てた素材の残骸と見られる）。
+
+```text
+recipient_dictionary.csv / government_agency_names.csv / supplementary_valid_names.csv
+  → score-project-quality.py が s (valid/gov/supp/cn/invalid/unknown) を決める
+opaque_recipient_keywords.csv
+  → score-project-quality.py と score-project-quality-ai.py の両方が読む
+```
+
+新スコアへの効き方は3経路。
+
+1. `o`（不透明キーワード）→ `gate_judgment()` が **AI を経ずに `identify=0` で確定**（2025で4,051行）。辞書が直接 `axisIdentify` を決めている
+2. `s` → AI プロンプトの「辞書判定: {s}」→ `axisIdentify` / `axisPurpose`
+3. `axis1` / `validRatio` → **総合点に不算入**（ここだけ退役）
+
+つまり辞書は退役しておらず、1 の経路では旧来より強く効いている。

--- a/docs/tasks/20260731_0533_S1_cn検証の成果物化_対応案.md
+++ b/docs/tasks/20260731_0533_S1_cn検証の成果物化_対応案.md
@@ -1,0 +1,146 @@
+# S1: cn 検証の成果物化（houjin.db 非依存化）対応案
+
+作成: 2026-07-31 05:33 JST / 設計: `20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md`
+
+## ゴール
+
+`scripts/score-project-quality.py` から `data/houjin.db`（1GB・`.gitignore`）への依存を外し、**houjin.db を持たない環境（rs-vis・CI）でもパイプラインを回せば同じ `s='cn'` が付く**状態にする。
+
+## 実測
+
+2025・2024 の 5-1 CSV 全行に対して houjin.db を引いて測った。
+
+| | 2025 | 2024 |
+|---|---|---|
+| 有効な法人番号を持つ (cn, 正規化名) の組 | 20,226 | 20,030 |
+| うち houjin 公式名と一致（= verified） | **18,423**（91.1%） | **18,312**（91.4%） |
+| verified の cn 数 | 18,423 | 18,312 |
+| JSON 生 / gzip | 981KB / **307KB** | 981KB / **307KB** |
+
+## 設計判断（設計書の案から2点変える）
+
+### 1. `verified` は `Record<cn, 正規化公式名>` — 配列は要らない
+
+設計書では「`cn → 正規化名の配列`」としていたが、**実測で verified の組数と cn 数が完全に一致した**（18,423 = 18,423）。houjin.db の公式名は cn ごとに1つなので、正規化して一致する名前も1つに定まる。配列にする理由がない。
+
+```json
+{
+  "generatedAt": "2026-07-31T05:33:00+09:00",
+  "houjinSnapshot": "2026-02-20",
+  "verified": { "3010001137944": "株式会社ウルフスタイル", "…": "…" }
+}
+```
+
+値は**正規化済みの公式名**を入れる。消費側は支出先名を同じ関数で正規化して等値比較するだけでよく、正規化規則の再実装が要らない。
+
+### 2. `recipient-resolution` に同居させず、別ファイルにする
+
+| | recipient-resolution | verified |
+|---|---|---|
+| サイズ（gzip） | 5KB（2025）/ 9KB（2024） | 307KB |
+| 消費者 | `generate-recipient-index.ts`・`generate-sankey-svg-data.ts` | `score-project-quality.py` |
+
+**サイズが60倍違い、消費者も重ならない。** 同居させると index・sankey の生成器が使わない 307KB を毎回読むことになる。`public/data/recipient-verified-{YEAR}.json.gz` として分ける。
+
+### 3. `score-project-quality.py` は houjin.db を一切見ない
+
+設計書は「houjin.db があれば従来どおり検証し、無ければ `verified` を参照」というフォールバックだったが、**これだと環境によって結果が変わる**（houjin.db のスナップショット差がそのまま出力差になる）。
+
+役割を分ける。
+
+```text
+generate-recipient-resolution.py  … houjin.db を読む唯一のスクリプト
+                                     → recipient-resolution + recipient-verified を出力
+score-project-quality.py          … recipient-verified だけを読む（houjin.db 非依存）
+```
+
+こうすると **どの環境で回しても出力が同じ**になり、cn の網羅率は「どの verified を使ったか」だけで決まる。`houjinSnapshot` を成果物に持たせて追えるようにする。
+
+## 変更点
+
+### `scripts/generate-recipient-resolution.py`
+
+- `verified` の構築を追加。既に 5-1 CSV を全行走査し houjin.db を引いているので、**同じループで (cn, 正規化名) の一致判定を溜める**だけ。追加の DB アクセスは実質ゼロ
+- 出力を2ファイルに: `recipient-resolution-{YEAR}.json`（従来どおり）と `recipient-verified-{YEAR}.json`（新規）
+- `houjinSnapshot` は houjin.db のファイル更新日時から自動で入れる（手入力にしない）
+
+### `scripts/score-project-quality.py`
+
+- `import sqlite3`・`HOUJIN_DB`・`_houjin_conn`/`_houjin_cur`・`houjin_name()` を削除（L30・52・107-128）
+- `is_cn_verified(cn, name)` を verified の辞書引きに置き換える
+
+```python
+# 変更後（イメージ）
+VERIFIED_JSON = REPO_ROOT / 'public' / 'data' / f'recipient-verified-{YEAR}.json'
+_verified = {}   # cn → 正規化公式名
+# 読み込みは .json → .json.gz の順（他ローダと同じ作法）
+
+def is_cn_verified(cn: str, recipient_name: str) -> bool:
+    cn = cn.strip()
+    if not is_valid_corporate_number(cn):
+        return False
+    official = _verified.get(cn)
+    return bool(official) and official == normalize_houjin_name(recipient_name)
+```
+
+- ファイルが無いときは cn 判定を全件 False にし、**警告を1回出す**（現状の「houjin.db 無し」と同じ扱い。黙って劣化させない）
+
+### `package.json` / `.claude/commands/data-update.md`
+
+`generate-recipient-resolution.py` は現在 **npm script にも data-update 手順にも載っていない**（手動実行）。S1 で `score-project-quality.py` の前提になるので、両方に追加する。
+
+```text
+6.  成果指標・点検所見        generate-project-outcomes.py
+6b. 支出先の法人番号解決      generate-recipient-resolution.py  ← 追加（houjin.db 必要）
+7.  /quality 用              score-quality / score-quality-2025
+8.  /project-bubble 用       generate-project-map-2025
+```
+
+`generate-recipient-index.ts`・`generate-sankey-svg-data.ts` も resolution を読むので、**6b はそれらより前**に置く必要がある。現行手順は 2（sankey）・3（subcontracts）が先にあるため、6b ではなく **前提確認の直後（手順1の次）へ置くのが正しい**。ここは実装時に手順全体の依存順を確認して確定する。
+
+### `.gitignore` / データ管理
+
+`recipient-verified-{YEAR}.json.gz` は Git 管理下に置く（307KB）。展開後の `.json`（981KB）は他と同様 `.gitignore` 対象。`scripts/decompress-data.sh` の扱いは、**サーバ API から読まないので `data/server` 同梱は不要**、展開もパイプライン実行時だけでよい（`decompress_if_needed` に optional で足すか、スクリプト側で `.gz` を直接読むかは実装時に決める。後者のほうが `public/data` を汚さない）。
+
+## 検証方法
+
+houjin.db を持つ環境で、**変更前後の出力がバイト一致すること**を確認する。
+
+1. 現行 `score-project-quality.py`（houjin.db 直参照）で 2025 を生成 → 退避
+2. `generate-recipient-resolution.py` で `recipient-verified-2025.json` を生成
+3. 改修版 `score-project-quality.py` で 2025 を生成
+4. `project-quality-scores-2025.json` と `project-quality-recipients-2025.json` を 1 と比較
+
+`s='cn'` が 10,277行、`cnVerifiedCount` 合計が 18,666 で一致すれば成功。2024 でも同じ手順で確認する（`s='cn'` 55行）。
+
+**注意**: 現在 main にある `project-quality-scores-2025.json.gz` は PR #295 で機械項目だけを移植したもので、AI 軸は rs-vis 生成のまま。**再生成すると AI 軸が消える**ので、検証は退避コピーとの比較に留め、`public/data` の成果物は差し替えない（差し替えるなら再採点が必要＝S3 とセット）。
+
+## 段取り
+
+| 手順 | 内容 |
+|---|---|
+| 1 | `generate-recipient-resolution.py` に verified 出力を追加（`recipient-verified-{YEAR}.json`） |
+| 2 | 2024・2025 で生成し、件数（18,312 / 18,423）とサイズ（各307KB）を確認 |
+| 3 | `score-project-quality.py` から houjin.db 依存を除去し verified 参照へ |
+| 4 | 上記「検証方法」で変更前後のバイト一致を確認 |
+| 5 | `package.json`・`data-update.md` に生成手順を追加 |
+| 6 | `docs/data-pipeline-guide.md` に「houjin.db は resolution 生成時のみ必要」を明記 |
+
+1〜2 と 3〜4 は分けてコミットできる。1〜2 だけ入れた時点では既存の挙動は変わらない（成果物が増えるだけ）ので、**先行してマージしても安全**。
+
+## 方針A 適用による更新（2026-07-31）
+
+「CSV 由来の cn には処理で手を加えない」方針が決まったため、本対応案の範囲が縮む。
+
+- `generate-recipient-resolution.py` は `mergeCn`/`supplement` の生成を落とし、**`verified` 専用スクリプトへ作り替える**（改名も検討）。出力は `recipient-verified-{YEAR}.json.gz` の1本のみ
+- `recipient-resolution-{YEAR}.json.gz` は廃止。`generate-recipient-index.ts`・`generate-sankey-svg-data.ts` から読み込みを外す
+- 「別ファイルに分ける」という設計判断2は、resolution 自体が無くなるので**議論の余地なく確定**
+- `types/recipient-index.ts` の `rawCorporateNumber` / `redirects` も不要になる（別コミットで整理）
+
+**`/quality` の支出先一覧・`/subcontracts` は元々 resolution を使っていないため無変更。** 方針A の影響はサンキー図の `corpAmounts` と recipient-index のキーに限られる。
+
+## 残る論点
+
+- **verified の鮮度管理**。houjin.db は 2026-02-20 のスナップショット。更新すると verified の件数が動き、cn 判定が変わる。`houjinSnapshot` を成果物に持たせるところまでは決めたが、**いつ誰が更新するかの運用**は未定
+- **未 verified の 1,803件（2025）の扱い**。有効な法人番号なのに公式名が一致しない＝支出先名が通称・旧名・部署名付きなど。現状は `invalid`/`unknown` に落ちる。ここを救うには部分一致や別名辞書が要るが、[[feedback_recipient_name_normalization]] の「部分一致名寄せ禁止」に触れるため、**S1 の範囲外**とする
+- **S2 との関係**。S2（支出先キーの1本化）は verified を「正規化名 → cn」方向でも引きたくなる可能性がある。その場合は逆引き辞書を消費側で作るか、成果物に両方向を持たせるかを S2 着手時に判断する

--- a/docs/tasks/INDEX.md
+++ b/docs/tasks/INDEX.md
@@ -2,6 +2,7 @@
 
 task doc を新規作成したら本索引に1行追記する（新しいものを上に）。過去の検討を探すときは本索引を先に読み、対象を特定してから本文を読むこと。
 
+- [20260731_0533_S1_cn検証の成果物化_対応案.md](20260731_0533_S1_cn検証の成果物化_対応案.md) — houjin.db依存を`generate-recipient-resolution.py`に閉じ込め、`recipient-verified-{YEAR}.json.gz`（gzip307KB・18,423件）を新設して`score-project-quality.py`から参照。設計書の案を2点変更（配列不要・別ファイル化）＋フォールバックをやめ環境差を排除（対応案）
 - [20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md](20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md) — cn は「検証」がhoujin.db直依存で成果物化されておらず rs-vis で再現不能（「解決」は.gz化済み）。検証結果を recipient-resolution へ追加して非依存化し、支出先キーを resolveRecipientKey に1本化してサンキー図の名寄せもcn対応にする（設計）
 - [20260730_0618_rs-vis76c6f09のファイルに対するmarumie側修正の有無.md](20260730_0618_rs-vis76c6f09のファイルに対するmarumie側修正の有無.md) — `76c6f09` の64ファイルを marumie↔rs-vis で照合。53件は完全一致、取り込み時に手を入れたのは4件（sankey-svg・quality-scores/route・quality/page・subcontracts/page）、残る6件は 76c6f09 と無関係な既存差分（比較）
 - [20260729_2027_marumieとrs-visの差分比較.md](20260729_2027_marumieとrs-visの差分比較.md) — 逆流は完了（rs-visのみのファイルは0件）。残るは片方向の未反映47コミット。marumie独自コード87件（AIチャット一式・探索履歴・再委託UI部品・層分離）と内容差41件を整理。反映手順は `.agents/skills/sync-rs-vis`、起点は `7411ff0`（比較）


### PR DESCRIPTION
## 概要

ドキュメントのみ。S1（法人番号の裏取りの成果物化）の方針決定と、支出先データ4系統の整理を記録する。

## 決定事項

**CSV 由来の cn（法人番号）は、誤記載であっても処理で補正しない。**

元データに誤りがあること自体が可視化の価値であり、パイプライン側で黙って直すと「正しく見える誤り」になる。検証結果（チェックディジット・houjin.db 突合）は別フィールドとして持ち、表示側で「裏取り済み／不一致／該当なし」を出し分ける。

チェックディジットの検証はリポジトリの `hasValidCheckDigit` を正典とし、houjin.db の実データ 500,000 件で 0 件の誤判定を確認済み。

## 支出先データ4系統

キーの取り方が異なる4つの系統を整理した（`/quality` 詳細＝行単位、`/subcontracts`＝`名前|番号`、`/sankey-svg`＝生の名前、`/recipients`＝`buildRecipientKey`）。サンキー図の支出先名寄せを cn ベースへ寄せる際の前提になる。

## 追加ファイル

- `docs/tasks/20260730_0816_cn検証のhoujin-db非依存化と支出先名寄せの設計.md`
- `docs/tasks/20260731_0533_S1_cn検証の成果物化_対応案.md`
- `docs/tasks/INDEX.md` に1行追記

コードの変更なし。

## 注意

#300 と `docs/tasks/INDEX.md` の同じ位置に追記しているため、**後にマージする側で INDEX.md がコンフリクトする**。片方をマージした後、もう片方を rebase すること。
